### PR TITLE
docs: Adds Docker PostgREST quickstart configuration note for Apple M1 platforms

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,8 @@ services:
 
   rest:
     container_name: pg_graphql_postgrest
-    image: postgrest/postgrest:latest
-    restart: always
+    image: postgrest/postgrest:v8.0.0.20211102
+    restart: unless-stopped
     ports:
       - 3000:3000
     depends_on:
@@ -45,5 +45,4 @@ services:
     ports:
         - 4000:8000
     depends_on:
-      - db
       - rest

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,8 +1,5 @@
 If you are new to the project, start here.
 
-!!! Important:
-The latest PostgREST docker image is not currently compatible with ARM devices, including M1 Macs. That issue is being tracked [here](https://github.com/PostgREST/postgrest/issues/1117). If you are on one of those platforms, see you **must** configure Docket to used 4GB of Memory **_and_** 4GB of Swap so that PostgREST can run properly. If you see that PostgREST starts up, exits, then restarts repeatedly, please adjust your Memory and Swap space settings.
-
 The easiest way to try `pg_graphql` is to run the interactive [GraphiQL IDE](https://github.com/graphql/graphiql) demo. The demo environment launches a database, webserver and the GraphiQL IDE/API explorer with a small pre-populated schema.
 
 Requires:
@@ -22,6 +19,8 @@ Next, launch the demo with docker-compose.
 ```shell
 docker-compose up
 ```
+!!! important
+    On ARM devices, including M1 Macs, the PostgREST Docker image **requires** >= 4GB of memory **and** 4GB of swap. If you see that PostgREST exit repeatedly, please adjust your memory and swap space settings within Docker.
 
 Finally, access GraphiQL at `http://localhost:4000/`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -20,7 +20,7 @@ Next, launch the demo with docker-compose.
 docker-compose up
 ```
 !!! important
-    On ARM devices, including M1 Macs, the PostgREST Docker image **requires** >= 4GB of memory **and** 4GB of swap. If you see that PostgREST exit repeatedly, please adjust your memory and swap space settings within Docker.
+    On ARM devices, including M1 Macs, the PostgREST Docker image **requires** >= 4GB of memory **and** 4GB of swap. If you see PostgREST exit repeatedly, adjust your memory and swap space settings within Docker.
 
 Finally, access GraphiQL at `http://localhost:4000/`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,11 +1,9 @@
 If you are new to the project, start here.
 
-!!! note
-    The PostgREST docker image is not currently compatible with ARM devices, including M1 Macs. That issue is being tracked [here](https://github.com/PostgREST/postgrest/issues/1117). If you are on one of those platforms see the `examples` directory for other ways you can launch a webserver that exposes pg_graphql's `gql.resolve` function.
+!!! Important:
+The latest PostgREST docker image is not currently compatible with ARM devices, including M1 Macs. That issue is being tracked [here](https://github.com/PostgREST/postgrest/issues/1117). If you are on one of those platforms, see you **must** configure Docket to used 4GB of Memory **_and_** 4GB of Swap so that PostgREST can run properly. If you see that PostgREST starts up, exits, then restarts repeatedly, please adjust your Memory and Swap space settings.
 
 The easiest way to try `pg_graphql` is to run the interactive [GraphiQL IDE](https://github.com/graphql/graphiql) demo. The demo environment launches a database, webserver and the GraphiQL IDE/API explorer with a small pre-populated schema.
-
-
 
 Requires:
 
@@ -13,6 +11,7 @@ Requires:
 - docker-compose
 
 First, clone the repo
+
 ```shell
 git clone https://github.com/supabase/pg_graphql.git
 cd pg_graphql


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updates Quickstart to describe how to get PostgREST running on ARM devices, such as M1-based Apple machines.

## What is the current behavior?

Currently, the docs for Quickstart state that the PostgREST Docker image is not compatible with Apple M1 platforms.

<img width="434" alt="image" src="https://user-images.githubusercontent.com/1051633/144078432-39928799-bc62-417a-83c7-98feea10883c.png">


PostgREST will start, exit and then restart several times.

The key to get it running is that Docker needs 4GB Memory allocated and also 4GB of Swap -- the swap being key.

<img width="814" alt="image" src="https://user-images.githubusercontent.com/1051633/144078327-db1d55c8-5657-4a79-8681-0b4e55adf30e.png">


With these settings, one can use pg_graphql and the GraphQL playground as documented.