### PR TITLE
Update PostgREST to use ARM image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
 
   rest:
     container_name: pg_graphql_postgrest
-    image: postgrest/postgrest:v8.0.0.20211102
+    image: postgrest/postgrest:v9.0.0
     restart: unless-stopped
     ports:
       - 3000:3000

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -19,8 +19,6 @@ Next, launch the demo with docker-compose.
 ```shell
 docker-compose up
 ```
-!!! important
-    On ARM devices, including M1 Macs, the PostgREST Docker image **requires** >= 4GB of memory **and** 4GB of swap. If you see PostgREST exit repeatedly, adjust your memory and swap space settings within Docker.
 
 Finally, access GraphiQL at `http://localhost:4000/`.
 


### PR DESCRIPTION
There's an ARM image now: https://hub.docker.com/layers/postgrest/postgrest/v9.0.0/images/sha256-564c94132abf861adfd46a9473b90e4cf06881814799490660022e1c780eaa02