### PR TITLE
Improve docker-compose healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,10 @@ services:
   db:
     container_name: pg_graphql_db
     build:
-        context: .
-        dockerfile: ./dockerfiles/db/Dockerfile
+      context: .
+      dockerfile: ./dockerfiles/db/Dockerfile
     volumes:
-        - ./dockerfiles/db/setup.sql:/docker-entrypoint-initdb.d/setup.sql
+      - ./dockerfiles/db/setup.sql:/docker-entrypoint-initdb.d/setup.sql
     ports:
       - 5404:5432
     command:
@@ -16,7 +16,7 @@ services:
       - -c
       - shared_preload_libraries=pg_stat_statements
     healthcheck:
-      test: ["CMD-SHELL", "PGUSER=postgres", "pg_isready"]
+      test: [ "CMD-SHELL", "PGUSER=postgres", "pg_isready" ]
       interval: 1s
       timeout: 10s
       retries: 5
@@ -41,8 +41,8 @@ services:
   graphiql:
     container_name: graphiql
     build:
-        context: ./dockerfiles/graphiql
+      context: ./dockerfiles/graphiql
     ports:
-        - 4000:8000
+      - 4000:8000
     depends_on:
       - rest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,8 @@ services:
     ports:
       - 3000:3000
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       PGRST_DB_URI: postgres://postgres:password@db:5432/gqldb
       PGRST_DB_SCHEMA: public, gql
@@ -45,4 +46,5 @@ services:
     ports:
       - 4000:8000
     depends_on:
-      - rest
+      rest:
+        condition: service_started

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   db:
     container_name: pg_graphql_db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,10 @@ services:
   db:
     container_name: pg_graphql_db
     build:
-      context: .
-      dockerfile: ./dockerfiles/db/Dockerfile
+        context: .
+        dockerfile: ./dockerfiles/db/Dockerfile
     volumes:
-      - ./dockerfiles/db/setup.sql:/docker-entrypoint-initdb.d/setup.sql
+        - ./dockerfiles/db/setup.sql:/docker-entrypoint-initdb.d/setup.sql
     ports:
       - 5404:5432
     command:
@@ -15,7 +15,7 @@ services:
       - -c
       - shared_preload_libraries=pg_stat_statements
     healthcheck:
-      test: [ "CMD-SHELL", "PGUSER=postgres", "pg_isready" ]
+      test: ["CMD-SHELL", "PGUSER=postgres", "pg_isready"]
       interval: 1s
       timeout: 10s
       retries: 5
@@ -41,9 +41,9 @@ services:
   graphiql:
     container_name: graphiql
     build:
-      context: ./dockerfiles/graphiql
+        context: ./dockerfiles/graphiql
     ports:
-      - 4000:8000
+        - 4000:8000
     depends_on:
       rest:
         condition: service_started


### PR DESCRIPTION
## What kind of change does this PR introduce?

Modest improvements to docker-compose

## What is the current behavior?

`docker-compose.yaml`'s `depends_on` does not depend on the success of the health check.

https://github.com/peter-evans/docker-compose-healthcheck
https://github.com/compose-spec/compose-spec/blob/e8db8022c0b2e3d5eb007d629ff684cbe49a17a4/spec.md#long-syntax-1

## What is the new behavior?

We can make it dependent on the success of the health check by writing the following

```yml
    depends_on:
      db:
        condition: service_healthy
```

## Additional context

`condition: service_healthy` waits for the container to start. This is the same as if we had not written any condition.

In the compose spec, the version field is not required