### PR TITLE
Updates Type/Field Naming Convention

### DIFF
--- a/sql/pg_graphql--0.1.sql
+++ b/sql/pg_graphql--0.1.sql
@@ -105,6 +105,35 @@ from
     unnest(string_to_array($1, '_')) with ordinality x(part, part_ix)
 $$;
 
+create function gql.to_type_name(regclass)
+    returns text
+    language sql
+    immutable
+as
+$$
+    /*
+    - Removes non-[A-z09_] characters
+    - Trims leading and trailing literal quotes
+    - Replaces '.' separator between schema and table name with '_'
+
+    Reference: http://spec.graphql.org/October2021/#sec-Names
+    */
+    select
+        regexp_replace(
+            concat_ws(
+                '_',
+                case
+                    when nullif(split_part($1::text, '.', 2), '') is null then null
+                    else trim('"' from split_part($1::text, '.', 1))
+                end,
+                trim('"' from coalesce(nullif(split_part($1::text, '.', 2), ''), $1::text))
+            ),
+            '[^0-9A-z_]+',
+            '_',
+            'g'
+        )
+$$;
+
 
 
 -------------------

--- a/test/expected/table_name_reflection.out
+++ b/test/expected/table_name_reflection.out
@@ -1,0 +1,23 @@
+begin;
+    create table public.account_holder(id int);
+    select gql.to_type_name('public.account_holder');
+  to_type_name  
+----------------
+ account_holder
+(1 row)
+
+    set search_path = '';
+    select gql.to_type_name('public.account_holder');
+     to_type_name      
+-----------------------
+ public_account_holder
+(1 row)
+
+    create table public."5ac!C h&"(id int);
+    select gql.to_type_name('public."5ac!C h&"');
+  to_type_name   
+-----------------
+ public_5ac_C_h_
+(1 row)
+
+rollback;

--- a/test/sql/table_name_reflection.sql
+++ b/test/sql/table_name_reflection.sql
@@ -1,0 +1,15 @@
+begin;
+
+    create table public.account_holder(id int);
+
+    select gql.to_type_name('public.account_holder');
+
+    set search_path = '';
+
+    select gql.to_type_name('public.account_holder');
+
+    create table public."5ac!C h&"(id int);
+
+    select gql.to_type_name('public."5ac!C h&"');
+
+rollback;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updates SQL to GraphQL conversion naming conventions according to RFC
#18

## What is the current behavior?

Attempts to inflect assuming a javascript client

## What is the new behavior?

Does not inflect or pluralize type or field names in favor of prefixes/suffixes