### PR TITLE
improve docker image size and `Dockerfile` format

### DIFF
--- a/dockerfiles/db/Dockerfile
+++ b/dockerfiles/db/Dockerfile
@@ -11,9 +11,9 @@ RUN apt-get update \
     && rm -rf "/var/lib/apt/lists/*"
 
 RUN export \
-      LIBGRAPHQLPARSER_VERSION="v0.7.0" \
-      LIBGRAPHQLPARSER_REPO="https://github.com/graphql/libgraphqlparser" \
-    && git clone -b "${LIBGRAPHQLPARSER_VERSION}" --depth 1 "${LIBGRAPHQLPARSER_REPO}" \
+      VERSION="v0.7.0" \
+      REPO_URL="https://github.com/graphql/libgraphqlparser" \
+    && git clone -b "${VERSION}" --depth 1 "${REPO_URL}" \
     && cd libgraphqlparser \
     && cmake . \
     && make install

--- a/dockerfiles/db/Dockerfile
+++ b/dockerfiles/db/Dockerfile
@@ -1,22 +1,20 @@
 FROM postgres:13 as build
 
-RUN \
-  apt-get update && \
-  apt-get install -y --no-install-recommends \
-    build-essential \
-    ca-certificates \
-    cmake \
-    git \
-    postgresql-server-dev-13 \
-    python2 \
-    && \
-  rm -rf "/var/lib/apt/lists/*"
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      build-essential \
+      ca-certificates \
+      cmake \
+      git \
+      postgresql-server-dev-13 \
+      python2 \
+    && rm -rf "/var/lib/apt/lists/*"
 
-RUN \
-  git clone https://github.com/graphql/libgraphqlparser.git && \
-  cd libgraphqlparser && \
-  cmake . && \
-  make install
+RUN LIBGRAPHQLPARSER_VERSION="v0.7.0" \
+    git clone -b ${LIBGRAPHQLPARSER_VERSION} https://github.com/graphql/libgraphqlparser \
+    && cd libgraphqlparser \
+    && cmake . \
+    && make install
 
 COPY . pg_graphql
 WORKDIR /pg_graphql

--- a/dockerfiles/db/Dockerfile
+++ b/dockerfiles/db/Dockerfile
@@ -29,8 +29,5 @@ ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
 COPY --from=build ["/usr/local/lib/libgraphqlparser.so", "/usr/local/lib/libgraphqlparser.so"]
 
 # pg_graphql
-COPY --from=build ["/usr/lib/postgresql/13/lib/bitcode/pg_graphql/", "/usr/lib/postgresql/13/lib/bitcode/pg_graphql/"]
-COPY --from=build ["/usr/lib/postgresql/13/lib/bitcode/pg_graphql.index.bc", "/usr/lib/postgresql/13/lib/bitcode/pg_graphql.index.bc"]
-COPY --from=build ["/usr/lib/postgresql/13/lib/pg_graphql.so", "/usr/lib/postgresql/13/lib/pg_graphql.so"]
-COPY --from=build ["/usr/share/postgresql/13/extension/pg_graphql--0.1.sql", "/usr/share/postgresql/13/extension/pg_graphql--0.1.sql"]
-COPY --from=build ["/usr/share/postgresql/13/extension/pg_graphql.control", "/usr/share/postgresql/13/extension/pg_graphql.control"]
+COPY --from=build ["/usr/lib/postgresql", "/usr/lib/postgresql"]
+COPY --from=build ["/usr/share/postgresql", "/usr/share/postgresql"]

--- a/dockerfiles/db/Dockerfile
+++ b/dockerfiles/db/Dockerfile
@@ -27,7 +27,7 @@ ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
 COPY --from=build ["/usr/local/lib/libgraphqlparser.so", "/usr/local/lib/libgraphqlparser.so"]
 
 # pg_graphql
-COPY --from=build ["/usr/lib/postgresql/13/lib/bitcode/pg_graphql/src/lib.bc", "/usr/lib/postgresql/13/lib/bitcode/pg_graphql/src/lib.bc"]
+COPY --from=build ["/usr/lib/postgresql/13/lib/bitcode/pg_graphql/", "/usr/lib/postgresql/13/lib/bitcode/pg_graphql/"]
 COPY --from=build ["/usr/lib/postgresql/13/lib/bitcode/pg_graphql.index.bc", "/usr/lib/postgresql/13/lib/bitcode/pg_graphql.index.bc"]
 COPY --from=build ["/usr/lib/postgresql/13/lib/pg_graphql.so", "/usr/lib/postgresql/13/lib/pg_graphql.so"]
 COPY --from=build ["/usr/share/postgresql/13/extension/pg_graphql--0.1.sql", "/usr/share/postgresql/13/extension/pg_graphql--0.1.sql"]

--- a/dockerfiles/db/Dockerfile
+++ b/dockerfiles/db/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update \
       python2 \
     && rm -rf "/var/lib/apt/lists/*"
 
-RUN LIBGRAPHQLPARSER_VERSION="v0.7.0" \
-    git clone -b ${LIBGRAPHQLPARSER_VERSION} https://github.com/graphql/libgraphqlparser \
+RUN export LIBGRAPHQLPARSER_VERSION="v0.7.0" \
+    && git clone -b "${LIBGRAPHQLPARSER_VERSION}" https://github.com/graphql/libgraphqlparser \
     && cd libgraphqlparser \
     && cmake . \
     && make install

--- a/dockerfiles/db/Dockerfile
+++ b/dockerfiles/db/Dockerfile
@@ -10,8 +10,9 @@ RUN apt-get update \
       python2 \
     && rm -rf "/var/lib/apt/lists/*"
 
-RUN export LIBGRAPHQLPARSER_VERSION="v0.7.0" \
-    export LIBGRAPHQLPARSER_REPO="git@github.com:graphql/libgraphqlparser.git" \
+RUN export \
+      LIBGRAPHQLPARSER_VERSION="v0.7.0" \
+      LIBGRAPHQLPARSER_REPO="https://github.com/graphql/libgraphqlparser" \
     && git clone -b "${LIBGRAPHQLPARSER_VERSION}" --depth 1 "${LIBGRAPHQLPARSER_REPO}" \
     && cd libgraphqlparser \
     && cmake . \

--- a/dockerfiles/db/Dockerfile
+++ b/dockerfiles/db/Dockerfile
@@ -1,25 +1,36 @@
 FROM postgres:13 as build
 
-RUN apt-get update
-RUN apt-get install build-essential git cmake curl -y
-RUN apt-get install postgresql-server-dev-13 -y
-RUN apt-get install python2 -y
+RUN \
+  apt-get update && \
+  apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    cmake \
+    git \
+    postgresql-server-dev-13 \
+    python2 \
+    && \
+  rm -rf "/var/lib/apt/lists/*"
 
-RUN git clone https://github.com/graphql/libgraphqlparser.git \
-    && cd libgraphqlparser \
-    && cmake . \
-    && make install
+RUN \
+  git clone https://github.com/graphql/libgraphqlparser.git && \
+  cd libgraphqlparser && \
+  cmake . && \
+  make install
 
 COPY . pg_graphql
-WORKDIR pg_graphql
+WORKDIR /pg_graphql
 RUN make install
 
 FROM postgres:13 as main
 
+# libgraphqlparser
 ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
-
-COPY --from=build ["/usr/local/include/graphqlparser", "/usr/local/include/graphqlparser"]
 COPY --from=build ["/usr/local/lib/libgraphqlparser.so", "/usr/local/lib/libgraphqlparser.so"]
-COPY --from=build ["/usr/lib/postgresql", "/usr/lib/postgresql"]
-COPY --from=build ["/usr/share/postgresql", "/usr/share/postgresql"]
-COPY --from=build ["/pg_graphql/pg_graphql.control", "/usr/share/postgresql/13/extension/pg_graphql.control"]
+
+# pg_graphql
+COPY --from=build ["/usr/lib/postgresql/13/lib/bitcode/pg_graphql/src/lib.bc", "/usr/lib/postgresql/13/lib/bitcode/pg_graphql/src/lib.bc"]
+COPY --from=build ["/usr/lib/postgresql/13/lib/bitcode/pg_graphql.index.bc", "/usr/lib/postgresql/13/lib/bitcode/pg_graphql.index.bc"]
+COPY --from=build ["/usr/lib/postgresql/13/lib/pg_graphql.so", "/usr/lib/postgresql/13/lib/pg_graphql.so"]
+COPY --from=build ["/usr/share/postgresql/13/extension/pg_graphql--0.1.sql", "/usr/share/postgresql/13/extension/pg_graphql--0.1.sql"]
+COPY --from=build ["/usr/share/postgresql/13/extension/pg_graphql.control", "/usr/share/postgresql/13/extension/pg_graphql.control"]

--- a/dockerfiles/db/Dockerfile
+++ b/dockerfiles/db/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update \
     && rm -rf "/var/lib/apt/lists/*"
 
 RUN export LIBGRAPHQLPARSER_VERSION="v0.7.0" \
-    && git clone -b "${LIBGRAPHQLPARSER_VERSION}" https://github.com/graphql/libgraphqlparser \
+    export LIBGRAPHQLPARSER_REPO="git@github.com:graphql/libgraphqlparser.git" \
+    && git clone -b "${LIBGRAPHQLPARSER_VERSION}" --depth 1 "${LIBGRAPHQLPARSER_REPO}" \
     && cd libgraphqlparser \
     && cmake . \
     && make install


### PR DESCRIPTION
ref: #21 and followup on https://github.com/supabase/pg_graphql/commit/305dd23ea2e46eab49f4e2bc723f0d20db655e93.

I fine-tuned the `Dockerfile` and squeezed out all the unnecessary bits.

I used [dive](https://github.com/wagoodman/dive) to explore the layers and figure out exactly what file were being generated with the two `make install` calls:

<img width="669" alt="Screen Shot 2021-12-20 at 7 22 22 PM" src="https://user-images.githubusercontent.com/385716/146867994-cacc6589-7655-46e2-aafc-10ede93b8a66.png">
<img width="635" alt="Screen Shot 2021-12-20 at 7 22 32 PM" src="https://user-images.githubusercontent.com/385716/146868015-da38e711-22a2-4f0b-aba5-3c3eadd34874.png">

This is the list of the only files needed at runtime:

<img width="861" alt="Screen Shot 2021-12-20 at 7 31 03 PM" src="https://user-images.githubusercontent.com/385716/146868110-f4411727-5f72-496a-b48a-eecce9b894df.png">

Text version:
```
 1.6 MB  COPY /usr/local/lib/libgraphqlparser.so /usr/local/lib/libgraphqlparser.so # buildkit...
 5.6 kB  COPY /usr/lib/postgresql/13/lib/bitcode/pg_graphql/src/lib.bc /usr/lib/postgresql/13/lib/bitcode/pg_graphql/sr...
  356 B  COPY /usr/lib/postgresql/13/lib/bitcode/pg_graphql.index.bc /usr/lib/postgresql/13/lib/bitcode/pg_graphql.inde...
  28 kB  COPY /usr/lib/postgresql/13/lib/pg_graphql.so /usr/lib/postgresql/13/lib/pg_graphql.so # buildkit...
  84 kB  COPY /usr/share/postgresql/13/extension/pg_graphql--0.1.sql /usr/share/postgresql/13/extension/pg_graphql--0.1...
   92 B  COPY /usr/share/postgresql/13/extension/pg_graphql.control /usr/share/postgresql/13/extension/pg_graphql.contr...
```

This is my working `Dockerfile` for reference, the only difference from the one in the PR, is that I git clone instead of a local `COPY`.

```docker
FROM postgres:13 as build

RUN \
  apt-get update && \
  apt-get install -y --no-install-recommends \
    build-essential \
    ca-certificates \
    cmake \
    git \
    postgresql-server-dev-13 \
    python2 \
    && \
  rm -rf "/var/lib/apt/lists/*"

RUN \
  git clone https://github.com/graphql/libgraphqlparser.git && \
  cd libgraphqlparser && \
  cmake . && \
  make install

RUN \
  git clone https://github.com/supabase/pg_graphql.git && \
  cd pg_graphql && \
  make install

FROM postgres:13 as main

# libgraphqlparser
ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
COPY --from=build ["/usr/local/lib/libgraphqlparser.so", "/usr/local/lib/libgraphqlparser.so"]

# pg_graphql
COPY --from=build ["/usr/lib/postgresql/13/lib/bitcode/pg_graphql/src/lib.bc", "/usr/lib/postgresql/13/lib/bitcode/pg_graphql/src/lib.bc"]
COPY --from=build ["/usr/lib/postgresql/13/lib/bitcode/pg_graphql.index.bc", "/usr/lib/postgresql/13/lib/bitcode/pg_graphql.index.bc"]
COPY --from=build ["/usr/lib/postgresql/13/lib/pg_graphql.so", "/usr/lib/postgresql/13/lib/pg_graphql.so"]
COPY --from=build ["/usr/share/postgresql/13/extension/pg_graphql--0.1.sql", "/usr/share/postgresql/13/extension/pg_graphql--0.1.sql"]
COPY --from=build ["/usr/share/postgresql/13/extension/pg_graphql.control", "/usr/share/postgresql/13/extension/pg_graphql.control"]
```

I also fixed:

- missing `ca-certificates` preventing git clones, over TLS, and others.
- it's good practice to use absolute paths for `WORKDIR` so I changed it to `WORKDIR /pg_graphql`
- removed curl as it is not needed

I am now working on running on `postgres:13-alpine3.15` and will open another PR soon. This will cut the size from ~350 to ~150. Which is 1/10 of the original image size <3.
