### PR TITLE
support __typename everywhere

### DIFF
--- a/test/expected/resolve___typename.out
+++ b/test/expected/resolve___typename.out
@@ -1,0 +1,62 @@
+begin;
+    create table account(
+        id int primary key
+    );
+    insert into public.account(id)
+    values
+        (1);
+    select jsonb_pretty(
+        graphql.resolve($$
+    {
+      allAccounts {
+        __typename
+        pageInfo {
+          __typename
+        }
+        edges {
+          __typename
+          node {
+            __typename
+          }
+        }
+      }
+    }
+        $$)
+    );
+                  jsonb_pretty                   
+-------------------------------------------------
+ {                                              +
+     "data": {                                  +
+         "allAccounts": {                       +
+             "edges": [                         +
+                 {                              +
+                     "node": {                  +
+                         "__typename": "Account"+
+                     },                         +
+                     "__typename": "AccountEdge"+
+                 }                              +
+             ],                                 +
+             "pageInfo": {                      +
+                 "__typename": "PageInfo"       +
+             },                                 +
+             "__typename": "AccountConnection"  +
+         }                                      +
+     },                                         +
+     "errors": [                                +
+     ]                                          +
+ }
+(1 row)
+
+    select graphql.resolve($$
+    {
+      account(id: "WyJhY2NvdW50IiwgMV0=") {
+        __typename
+      }
+    }
+    $$);
+                            resolve                             
+----------------------------------------------------------------
+ {"data": {"account": {"__typename": "Account"}}, "errors": []}
+(1 row)
+
+rollback;

--- a/test/expected/resolve_error_connection_edge_no_field.out
+++ b/test/expected/resolve_error_connection_edge_no_field.out
@@ -12,9 +12,9 @@ begin;
       }
     }
     $$);
-                                resolve                                
------------------------------------------------------------------------
- {"data": null, "errors": ["Unknown field 'dneField' on type 'Edge'"]}
+                                   resolve                                    
+------------------------------------------------------------------------------
+ {"data": null, "errors": ["Unknown field 'dneField' on type 'AccountEdge'"]}
 (1 row)
 
 rollback;

--- a/test/sql/resolve___typename.sql
+++ b/test/sql/resolve___typename.sql
@@ -1,0 +1,41 @@
+begin;
+
+    create table account(
+        id int primary key
+    );
+
+
+    insert into public.account(id)
+    values
+        (1);
+
+
+    select jsonb_pretty(
+        graphql.resolve($$
+    {
+      allAccounts {
+        __typename
+        pageInfo {
+          __typename
+        }
+        edges {
+          __typename
+          node {
+            __typename
+          }
+        }
+      }
+    }
+        $$)
+    );
+
+
+    select graphql.resolve($$
+    {
+      account(id: "WyJhY2NvdW50IiwgMV0=") {
+        __typename
+      }
+    }
+    $$);
+
+rollback;


### PR DESCRIPTION
### Summary
Adds `__typename` resolvers for

- Connection.__typename
- Connection.pageInfo.__typename
- Connection.edges.__typename

### Refs
resolves #24

### Examples:
Connection Type
```sql
    select jsonb_pretty(
        graphql.resolve($$
    {
      allAccounts {
        __typename
        pageInfo {
          __typename
        }
        edges {
          __typename
          node {
            __typename
          }
        }
      }
    }
        $$)
    );
                  jsonb_pretty                   
-------------------------------------------------
 {                                              +
     "data": {                                  +
         "allAccounts": {                       +
             "edges": [                         +
                 {                              +
                     "node": {                  +
                         "__typename": "Account"+
                     },                         +
                     "__typename": "AccountEdge"+
                 }                              +
             ],                                 +
             "pageInfo": {                      +
                 "__typename": "PageInfo"       +
             },                                 +
             "__typename": "AccountConnection"  +
         }                                      +
     },                                         +
     "errors": [                                +
     ]                                          +
 }
(1 row)
```
Node Type
```sql
    select graphql.resolve($$
    {
      account(id: "WyJhY2NvdW50IiwgMV0=") {
        __typename
      }
    }
    $$);
                            resolve                             
----------------------------------------------------------------
 {"data": {"account": {"__typename": "Account"}}, "errors": []}
```