### PR TITLE
Name override support for table type, enum type, field name. todo: relationships

### DIFF
--- a/bin/commands/build
+++ b/bin/commands/build
@@ -22,6 +22,7 @@ cat \
     src/sql/ast/*.sql \
     src/sql/exception/*.sql \
     src/sql/cursor/*.sql \
+    src/sql/directive/*.sql \
     src/sql/reflection/type/types/*.sql \
     src/sql/reflection/type/tables/*.sql \
     src/sql/reflection/type/views/*.sql \

--- a/dockerfiles/db/setup.sql
+++ b/dockerfiles/db/setup.sql
@@ -33,6 +33,8 @@ create table account(
     updated_at timestamp not null
 );
 
+comment on column public.account.encrypted_password is E'@graphql({"name": "passwordHash"})';
+
 
 create table blog(
     id serial primary key,

--- a/pg_graphql--0.1.0.sql
+++ b/pg_graphql--0.1.0.sql
@@ -889,8 +889,6 @@ create view graphql.relationship as
     )
     select
         constraint_name,
-        constraint_oid,
-        false as is_reversed,
         local_entity,
         local_columns,
         local_cardinality,
@@ -903,8 +901,6 @@ create view graphql.relationship as
     union all
     select
         constraint_name,
-        constraint_oid,
-        true as is_reversed,
         foreign_entity,
         foreign_columns,
         foreign_cardinality,

--- a/pg_graphql--0.1.0.sql
+++ b/pg_graphql--0.1.0.sql
@@ -553,6 +553,9 @@ create table graphql._type (
 );
 
 create index ix_graphql_type_name on graphql._type(name);
+create index ix_graphql_type_type_kind on graphql._type(type_kind);
+create index ix_graphql_type_meta_kind on graphql._type(meta_kind);
+create index ix_graphql_type_graphql_type_id on graphql._type(graphql_type_id);
 
 
 create or replace function graphql.inflect_type_default(text)
@@ -968,6 +971,10 @@ create table graphql._field (
 );
 
 create index ix_graphql_field_name on graphql._field(name);
+create index ix_graphql_field_parent_type_id on graphql._field(parent_type_id);
+create index ix_graphql_field_type_id on graphql._field(type_id);
+create index ix_graphql_field_parent_arg_field_id on graphql._field(parent_arg_field_id);
+create index ix_graphql_field_meta_kind on graphql._field(meta_kind);
 
 
 create or replace function graphql.field_name(rec graphql._field)

--- a/src/sql/directive/parse.sql
+++ b/src/sql/directive/parse.sql
@@ -1,0 +1,72 @@
+create function graphql.comment_directive(comment_ text)
+    returns jsonb
+    language sql
+as $$
+    /*
+    comment on column public.account.name is '@graphql.name: myField'
+    */
+    select
+        (
+            regexp_matches(
+                comment_,
+                '@graphql\((.+?)\)',
+                'g'
+            )
+        )[1]::jsonb
+$$;
+
+
+create function graphql.comment(regclass)
+    returns text
+    language sql
+as $$
+    select pg_catalog.obj_description($1::oid, 'pg_class')
+$$;
+
+
+create function graphql.comment(regtype)
+    returns text
+    language sql
+as $$
+    select pg_catalog.obj_description($1::oid, 'pg_type')
+$$;
+
+
+create function graphql.comment(regclass, column_name text)
+    returns text
+    language sql
+as $$
+    select
+        pg_catalog.col_description($1::oid, attnum)
+    from
+        pg_attribute
+    where
+        attrelid = $1::oid
+        and attname = column_name::name
+        and attnum > 0
+        and not attisdropped
+$$;
+
+
+create function graphql.comment_directive_name(regclass, column_name text)
+    returns text
+    language sql
+as $$
+    select graphql.comment_directive(graphql.comment($1, column_name)) ->> 'name'
+$$;
+
+
+create function graphql.comment_directive_name(regclass)
+    returns text
+    language sql
+as $$
+    select graphql.comment_directive(graphql.comment($1)) ->> 'name'
+$$;
+
+
+create function graphql.comment_directive_name(regtype)
+    returns text
+    language sql
+as $$
+    select graphql.comment_directive(graphql.comment($1)) ->> 'name'
+$$;

--- a/src/sql/reflection/field/field.sql
+++ b/src/sql/reflection/field/field.sql
@@ -45,6 +45,10 @@ create table graphql._field (
 );
 
 create index ix_graphql_field_name on graphql._field(name);
+create index ix_graphql_field_parent_type_id on graphql._field(parent_type_id);
+create index ix_graphql_field_type_id on graphql._field(type_id);
+create index ix_graphql_field_parent_arg_field_id on graphql._field(parent_arg_field_id);
+create index ix_graphql_field_meta_kind on graphql._field(meta_kind);
 
 
 create or replace function graphql.field_name(rec graphql._field)

--- a/src/sql/reflection/field/relationship.sql
+++ b/src/sql/reflection/field/relationship.sql
@@ -39,8 +39,6 @@ create view graphql.relationship as
     )
     select
         constraint_name,
-        constraint_oid,
-        false as is_reversed,
         local_entity,
         local_columns,
         local_cardinality,
@@ -53,8 +51,6 @@ create view graphql.relationship as
     union all
     select
         constraint_name,
-        constraint_oid,
-        true as is_reversed,
         foreign_entity,
         foreign_columns,
         foreign_cardinality,

--- a/src/sql/reflection/type/tables/_type.sql
+++ b/src/sql/reflection/type/tables/_type.sql
@@ -4,7 +4,6 @@ create table graphql._type (
     meta_kind graphql.meta_kind not null,
     is_builtin bool not null default false,
     constant_name text,
-    override_name text,
     name text not null,
     entity regclass,
     graphql_type_id int references graphql._type(id),
@@ -86,7 +85,6 @@ as $$
 begin
     new.name = coalesce(
         new.constant_name,
-        new.override_name,
         graphql.type_name(new)
     );
     return new;

--- a/src/sql/reflection/type/tables/_type.sql
+++ b/src/sql/reflection/type/tables/_type.sql
@@ -14,6 +14,9 @@ create table graphql._type (
 );
 
 create index ix_graphql_type_name on graphql._type(name);
+create index ix_graphql_type_type_kind on graphql._type(type_kind);
+create index ix_graphql_type_meta_kind on graphql._type(meta_kind);
+create index ix_graphql_type_graphql_type_id on graphql._type(graphql_type_id);
 
 
 create or replace function graphql.inflect_type_default(text)

--- a/src/sql/reflection/type/tables/_type.sql
+++ b/src/sql/reflection/type/tables/_type.sql
@@ -3,6 +3,9 @@ create table graphql._type (
     type_kind graphql.type_kind not null,
     meta_kind graphql.meta_kind not null,
     is_builtin bool not null default false,
+    constant_name text,
+    override_name text,
+    name text not null,
     entity regclass,
     graphql_type_id int references graphql._type(id),
     enum regtype,
@@ -10,6 +13,8 @@ create table graphql._type (
     unique (meta_kind, entity),
     check (entity is null or graphql_type_id is null)
 );
+
+create index ix_graphql_type_name on graphql._type(name);
 
 
 create or replace function graphql.inflect_type_default(text)
@@ -21,41 +26,52 @@ as $$
 $$;
 
 
-create function graphql.type_name(rec graphql._type, dialect text = 'default')
+create function graphql.type_name(rec graphql._type)
     returns text
     immutable
     language sql
 as $$
+    with name_override as (
+        select
+            case
+                when rec.entity is not null then coalesce(
+                    graphql.comment_directive_name(rec.entity),
+                    graphql.inflect_type_default(graphql.to_table_name(rec.entity))
+                )
+                else null
+            end as base_type_name
+    )
     select
         case
             when (rec).is_builtin then rec.meta_kind::text
-            when dialect = 'default' then
-                case rec.meta_kind
-                    when 'Node'         then graphql.inflect_type_default(graphql.to_table_name(rec.entity))
-                    when 'Edge'         then format('%sEdge',       graphql.inflect_type_default(graphql.to_table_name(rec.entity)))
-                    when 'Connection'   then format('%sConnection', graphql.inflect_type_default(graphql.to_table_name(rec.entity)))
-                    when 'OrderBy'      then format('%sOrderBy',    graphql.inflect_type_default(graphql.to_table_name(rec.entity)))
-                    when 'FilterEntity' then format('%sFilter',     graphql.inflect_type_default(graphql.to_table_name(rec.entity)))
-                    when 'FilterType'   then format('%sFilter',     graphql.type_name(rec.graphql_type_id))
-                    when 'OrderByDirection' then rec.meta_kind::text
-                    when 'PageInfo'     then rec.meta_kind::text
-                    when 'Cursor'       then rec.meta_kind::text
-                    when 'Query'        then rec.meta_kind::text
-                    when 'Mutation'     then rec.meta_kind::text
-                    when 'Enum'         then graphql.inflect_type_default(graphql.to_type_name(rec.enum))
-                    else                graphql.exception('could not determine type name')
-                end
-            else graphql.exception('unknown dialect')
+            when rec.meta_kind='Node'         then base_type_name
+            when rec.meta_kind='Edge'         then format('%sEdge',       base_type_name)
+            when rec.meta_kind='Connection'   then format('%sConnection', base_type_name)
+            when rec.meta_kind='OrderBy'      then format('%sOrderBy',    base_type_name)
+            when rec.meta_kind='FilterEntity' then format('%sFilter',     base_type_name)
+            when rec.meta_kind='FilterType'   then format('%sFilter',     graphql.type_name(rec.graphql_type_id))
+            when rec.meta_kind='OrderByDirection' then rec.meta_kind::text
+            when rec.meta_kind='PageInfo'     then rec.meta_kind::text
+            when rec.meta_kind='Cursor'       then rec.meta_kind::text
+            when rec.meta_kind='Query'        then rec.meta_kind::text
+            when rec.meta_kind='Mutation'     then rec.meta_kind::text
+            when rec.meta_kind='Enum'         then coalesce(
+                graphql.comment_directive_name(rec.enum),
+                graphql.inflect_type_default(graphql.to_type_name(rec.enum))
+            )
+            else graphql.exception('could not determine type name')
         end
+    from
+        name_override
 $$;
 
-create function graphql.type_name(type_id int, dialect text = 'default')
+create function graphql.type_name(type_id int)
     returns text
     immutable
     language sql
 as $$
     select
-        graphql.type_name(rec, $2)
+        graphql.type_name(rec)
     from
         graphql._type rec
     where
@@ -63,7 +79,20 @@ as $$
 $$;
 
 
+create function graphql.set_type_name()
+    returns trigger
+    language plpgsql
+as $$
+begin
+    new.name = coalesce(
+        new.constant_name,
+        new.override_name,
+        graphql.type_name(new)
+    );
+    return new;
+end;
+$$;
 
-create index ix_graphql_type_name_dialect_default on graphql._type(
-    graphql.type_name(rec := _type, dialect := 'default'::text)
-);
+create trigger on_insert_set_name
+    before insert on graphql._type
+    for each row execute procedure graphql.set_type_name();

--- a/src/sql/reflection/type/views/type.sql
+++ b/src/sql/reflection/type/views/type.sql
@@ -1,8 +1,21 @@
 create view graphql.type as
     select
-       t.*
+        id,
+        type_kind,
+        meta_kind,
+        is_builtin,
+        constant_name,
+        name,
+        entity,
+        graphql_type_id,
+        enum,
+        description
     from
         graphql._type t
     where
         t.entity is null
-        or pg_catalog.has_any_column_privilege(current_user, t.entity, 'SELECT');
+        or pg_catalog.has_any_column_privilege(
+            current_user,
+            t.entity,
+            'SELECT'
+        );

--- a/src/sql/reflection/type/views/type.sql
+++ b/src/sql/reflection/type/views/type.sql
@@ -1,19 +1,8 @@
 create view graphql.type as
-    with d(dialect) as (
-        select
-            -- do not inline this call as it has a significant performance impact
-            --coalesce(current_setting('graphql.dialect', true), 'default')
-            'default'
-    )
     select
-       graphql.type_name(
-            rec := t,
-            dialect := d.dialect
-       ) as name,
        t.*
     from
-        graphql._type t,
-        d
+        graphql._type t
     where
         t.entity is null
         or pg_catalog.has_any_column_privilege(current_user, t.entity, 'SELECT');

--- a/test/expected/comment_directive.out
+++ b/test/expected/comment_directive.out
@@ -1,0 +1,9 @@
+select
+    graphql.comment_directive(
+        comment_ := '@graphql({"name": "myField"})'
+    )
+  comment_directive  
+---------------------
+ {"name": "myField"}
+(1 row)
+

--- a/test/expected/override_enum_name.out
+++ b/test/expected/override_enum_name.out
@@ -1,0 +1,10 @@
+begin;
+    create type account_priority as enum ('high', 'standard');
+    comment on type public.account_priority is E'@graphql({"name": "CustomerValue"})';
+    select name from graphql.type where enum = 'public.account_priority'::regtype;
+     name      
+---------------
+ CustomerValue
+(1 row)
+
+rollback;

--- a/test/expected/override_field_name.out
+++ b/test/expected/override_field_name.out
@@ -1,0 +1,20 @@
+begin;
+    create table account(
+        id serial primary key,
+        email varchar(255) not null
+    );
+    comment on column public.account.email is E'@graphql({"name": "emailAddress"})';
+    select
+        name
+    from
+        graphql.field
+    where
+        entity = 'public.account'::regclass
+        and column_name = 'email'
+        and meta_kind = 'Column';
+     name     
+--------------
+ emailAddress
+(1 row)
+
+rollback;

--- a/test/expected/override_relationship_field_name.out
+++ b/test/expected/override_relationship_field_name.out
@@ -1,0 +1,38 @@
+begin;
+    create table account(
+        id serial primary key
+    );
+    create table blog(
+        id serial primary key,
+        owner_id integer not null references account(id)
+    );
+    comment on constraint blog_owner_id_fkey
+    on blog
+    is E'@graphql({"foreign_name": "author", "local_name": "blogz"})';
+    -- expect: 'author'
+    select
+        name
+    from
+        graphql.field
+    where
+        parent_type = 'Blog'
+        and foreign_columns is not null;
+  name  
+--------
+ author
+(1 row)
+
+    -- expect: 'blogz'
+    select
+        name
+    from
+        graphql.field
+    where
+        parent_type = 'Account'
+        and foreign_columns is not null;
+ name  
+-------
+ blogz
+(1 row)
+
+rollback;

--- a/test/expected/override_type_name.out
+++ b/test/expected/override_type_name.out
@@ -1,0 +1,17 @@
+begin;
+    create table account(
+        id serial primary key,
+        email varchar(255) not null
+    );
+    comment on table public.account is E'@graphql({"name": "UserAccount"})';
+    select name from graphql.type where entity = 'public.account'::regclass order by name;
+         name          
+-----------------------
+ UserAccount
+ UserAccountConnection
+ UserAccountEdge
+ UserAccountFilter
+ UserAccountOrderBy
+(5 rows)
+
+rollback;

--- a/test/expected/resolve_connection_to_node.out
+++ b/test/expected/resolve_connection_to_node.out
@@ -27,7 +27,7 @@ begin;
             edges {
               node {
                 ownerId
-                account {
+                owner {
                   id
                 }
               }
@@ -44,7 +44,7 @@ begin;
              "edges": [              +
                  {                   +
                      "node": {       +
-                         "account": {+
+                         "owner": {  +
                              "id": 1 +
                          },          +
                          "ownerId": 1+
@@ -52,7 +52,7 @@ begin;
                  },                  +
                  {                   +
                      "node": {       +
-                         "account": {+
+                         "owner": {  +
                              "id": 1 +
                          },          +
                          "ownerId": 1+
@@ -60,7 +60,7 @@ begin;
                  },                  +
                  {                   +
                      "node": {       +
-                         "account": {+
+                         "owner": {  +
                              "id": 1 +
                          },          +
                          "ownerId": 1+
@@ -68,7 +68,7 @@ begin;
                  },                  +
                  {                   +
                      "node": {       +
-                         "account": {+
+                         "owner": {  +
                              "id": 2 +
                          },          +
                          "ownerId": 2+

--- a/test/expected/resolve_graphiql_schema.out
+++ b/test/expected/resolve_graphiql_schema.out
@@ -602,33 +602,6 @@ begin;
                          {                                                                                                                  +
                              "args": [                                                                                                      +
                                  {                                                                                                          +
-                                     "name": "nodeId",                                                                                      +
-                                     "type": {                                                                                              +
-                                         "kind": "NON_NULL",                                                                                +
-                                         "name": null,                                                                                      +
-                                         "ofType": {                                                                                        +
-                                             "kind": "SCALAR",                                                                              +
-                                             "name": "ID",                                                                                  +
-                                             "ofType": null                                                                                 +
-                                         }                                                                                                  +
-                                     },                                                                                                     +
-                                     "description": null,                                                                                   +
-                                     "defaultValue": null                                                                                   +
-                                 }                                                                                                          +
-                             ],                                                                                                             +
-                             "name": "account",                                                                                             +
-                             "type": {                                                                                                      +
-                                 "kind": "OBJECT",                                                                                          +
-                                 "name": "Account",                                                                                         +
-                                 "ofType": null                                                                                             +
-                             },                                                                                                             +
-                             "description": null,                                                                                           +
-                             "isDeprecated": false,                                                                                         +
-                             "deprecationReason": null                                                                                      +
-                         },                                                                                                                 +
-                         {                                                                                                                  +
-                             "args": [                                                                                                      +
-                                 {                                                                                                          +
                                      "name": "after",                                                                                       +
                                      "type": {                                                                                              +
                                          "kind": "SCALAR",                                                                                  +
@@ -783,6 +756,19 @@ begin;
                                      "name": "ID",                                                                                          +
                                      "ofType": null                                                                                         +
                                  }                                                                                                          +
+                             },                                                                                                             +
+                             "description": null,                                                                                           +
+                             "isDeprecated": false,                                                                                         +
+                             "deprecationReason": null                                                                                      +
+                         },                                                                                                                 +
+                         {                                                                                                                  +
+                             "args": [                                                                                                      +
+                             ],                                                                                                             +
+                             "name": "owner",                                                                                               +
+                             "type": {                                                                                                      +
+                                 "kind": "OBJECT",                                                                                          +
+                                 "name": "Account",                                                                                         +
+                                 "ofType": null                                                                                             +
                              },                                                                                                             +
                              "description": null,                                                                                           +
                              "isDeprecated": false,                                                                                         +

--- a/test/sql/comment_directive.sql
+++ b/test/sql/comment_directive.sql
@@ -1,0 +1,4 @@
+select
+    graphql.comment_directive(
+        comment_ := '@graphql({"name": "myField"})'
+    )

--- a/test/sql/override_enum_name.sql
+++ b/test/sql/override_enum_name.sql
@@ -1,0 +1,7 @@
+begin;
+    create type account_priority as enum ('high', 'standard');
+    comment on type public.account_priority is E'@graphql({"name": "CustomerValue"})';
+
+    select name from graphql.type where enum = 'public.account_priority'::regtype;
+
+rollback;

--- a/test/sql/override_field_name.sql
+++ b/test/sql/override_field_name.sql
@@ -1,0 +1,18 @@
+begin;
+    create table account(
+        id serial primary key,
+        email varchar(255) not null
+    );
+
+    comment on column public.account.email is E'@graphql({"name": "emailAddress"})';
+
+    select
+        name
+    from
+        graphql.field
+    where
+        entity = 'public.account'::regclass
+        and column_name = 'email'
+        and meta_kind = 'Column';
+
+rollback;

--- a/test/sql/override_relationship_field_name.sql
+++ b/test/sql/override_relationship_field_name.sql
@@ -1,0 +1,34 @@
+begin;
+
+    create table account(
+        id serial primary key
+    );
+
+    create table blog(
+        id serial primary key,
+        owner_id integer not null references account(id)
+    );
+
+    comment on constraint blog_owner_id_fkey
+    on blog
+    is E'@graphql({"foreign_name": "author", "local_name": "blogz"})';
+
+    -- expect: 'author'
+    select
+        name
+    from
+        graphql.field
+    where
+        parent_type = 'Blog'
+        and foreign_columns is not null;
+
+    -- expect: 'blogz'
+    select
+        name
+    from
+        graphql.field
+    where
+        parent_type = 'Account'
+        and foreign_columns is not null;
+
+rollback;

--- a/test/sql/override_type_name.sql
+++ b/test/sql/override_type_name.sql
@@ -1,0 +1,11 @@
+begin;
+    create table account(
+        id serial primary key,
+        email varchar(255) not null
+    );
+
+    comment on table public.account is E'@graphql({"name": "UserAccount"})';
+
+    select name from graphql.type where entity = 'public.account'::regclass order by name;
+
+rollback;

--- a/test/sql/resolve_connection_to_node.sql
+++ b/test/sql/resolve_connection_to_node.sql
@@ -36,7 +36,7 @@ begin;
             edges {
               node {
                 ownerId
-                account {
+                owner {
                   id
                 }
               }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enables overriding table type names, enum type names, and field names using comment directives

```sql
-- override table type name
comment on table public.account is e'@graphql({"name": "AccountHolder"})';

-- override column field name
comment on column public.account.email is e'@graphql({"name": "emailAddress"})';

-- override enum type name
comment on type public.customer_priority is e'@graphql({"name": "CustomerStatus"})';

-- override relationship field name
comment on constraint blog_owner_id_fkey
    on blog
    is E'@graphql({"foreign_name": "author", "local_name": "blogz"})';
```