### PR TITLE
computed columns via regclass::text::regproc single arg functions

### DIFF
--- a/docs/computed_fields.md
+++ b/docs/computed_fields.md
@@ -1,0 +1,23 @@
+## PostgreSQL Builtin
+
+PostgreSQL has a builtin feature for adding [generated columns](https://www.postgresql.org/docs/14/ddl-generated-columns.html) to tables. Generated columns are reflected identically to non-generated columns. This is the reccomended approach to adding computed fields when your computation meets the restrictions. The most significant restrictions of generated columns are:
+
+- expression must be immutable
+- expression may only reference the current row
+
+For example:
+```sql
+--8<-- "test/expected/extend_type_with_generated_column.out"
+```
+
+
+## Extending Types with Functions
+
+For arbitrary computations that do not meet the requirements for [generated columns](https://www.postgresql.org/docs/14/ddl-generated-columns.html), a table's reflected GraphQL type can be extended by creating a function that:
+
+- accepts a single parameter of the table's tuple type
+- name starts with an underscore
+
+```sql
+--8<-- "test/expected/extend_type_with_function.out"
+```

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -10,6 +10,7 @@ nav:
     - Quickstart: 'quickstart.md'
     - API: 'api.md'
     - Reflection: 'reflection.md'
+    - Computed Fields: 'computed_fields.md'
     - Configuration: 'configuration.md'
     - Performance: 'performance.md'
     - Roadmap: 'roadmap.md'

--- a/pg_graphql--0.1.0.sql
+++ b/pg_graphql--0.1.0.sql
@@ -1015,7 +1015,7 @@ as $$
             )
             when rec.meta_kind = 'Function' then coalesce(
                 graphql.comment_directive_name(rec.func),
-                graphql.to_camel_case(graphql.to_function_name(rec.func))
+                graphql.to_camel_case(ltrim(graphql.to_function_name(rec.func), '_'))
             )
             when rec.meta_kind = 'Query.one' then graphql.to_camel_case(graphql.to_table_name($1.entity))
             when rec.meta_kind = 'Query.collection' then graphql.to_camel_case(graphql.to_table_name($1.entity)) || 'Collection'
@@ -1233,7 +1233,9 @@ begin
                 on pp.proargtypes[0] = pc.reltype
         where
             gt.meta_kind = 'Node'
-            and pronargs = 1;
+            and pronargs = 1
+            -- starts with underscore
+            and graphql.to_function_name(pp.oid::regproc) like '\_%';
 
     -- Node.<relationship>
     insert into graphql._field(

--- a/src/sql/directive/parse.sql
+++ b/src/sql/directive/parse.sql
@@ -31,6 +31,13 @@ as $$
     select pg_catalog.obj_description($1::oid, 'pg_type')
 $$;
 
+create function graphql.comment(regproc)
+    returns text
+    language sql
+as $$
+    select pg_catalog.obj_description($1::oid, 'pg_proc')
+$$;
+
 
 create function graphql.comment(regclass, column_name text)
     returns text
@@ -65,6 +72,13 @@ $$;
 
 
 create function graphql.comment_directive_name(regtype)
+    returns text
+    language sql
+as $$
+    select graphql.comment_directive(graphql.comment($1)) ->> 'name'
+$$;
+
+create function graphql.comment_directive_name(regproc)
     returns text
     language sql
 as $$

--- a/src/sql/pg/to_function_name.sql
+++ b/src/sql/pg/to_function_name.sql
@@ -1,0 +1,6 @@
+create function graphql.to_function_name(regproc)
+    returns text
+    language sql
+    immutable
+as
+$$ select coalesce(nullif(split_part($1::text, '.', 2), ''), $1::text) $$;

--- a/src/sql/reflection/field/field.sql
+++ b/src/sql/reflection/field/field.sql
@@ -6,7 +6,8 @@ create type graphql.field_meta_kind as enum (
     'Relationship.toMany',
     'Relationship.toOne',
     'OrderBy.Column',
-    'Filter.Column'
+    'Filter.Column',
+    'Function'
 );
 
 create table graphql._field (
@@ -32,6 +33,8 @@ create table graphql._field (
     foreign_entity regclass,
     foreign_name_override text, -- from comment directive
 
+    -- function extensions
+    func regproc,
 
     -- internal flags
     is_not_null boolean not null,
@@ -63,6 +66,10 @@ as $$
             when rec.meta_kind in ('Column', 'OrderBy.Column', 'Filter.Column') then coalesce(
                 graphql.comment_directive_name(rec.entity, rec.column_name),
                 graphql.to_camel_case(rec.column_name)
+            )
+            when rec.meta_kind = 'Function' then coalesce(
+                graphql.comment_directive_name(rec.func),
+                graphql.to_camel_case(graphql.to_function_name(rec.func))
             )
             when rec.meta_kind = 'Query.one' then graphql.to_camel_case(graphql.to_table_name($1.entity))
             when rec.meta_kind = 'Query.collection' then graphql.to_camel_case(graphql.to_table_name($1.entity)) || 'Collection'
@@ -257,6 +264,30 @@ begin
             and pa.attnum > 0
             and not pa.attisdropped;
 
+    -- Node
+    -- Extensibility via function taking record type
+    -- Node.<function()>
+    insert into graphql._field(meta_kind, entity, parent_type_id, type_id, is_not_null, is_array, is_array_not_null, description, is_hidden_from_schema, func)
+        select
+            'Function' as meta_kind,
+            gt.entity,
+            gt.id parent_type_id,
+            graphql.type_id(pp.prorettype::regtype) as type_id,
+            false as is_not_null,
+            graphql.sql_type_is_array(pp.prorettype::regtype) as is_array,
+            false as is_array_not_null,
+            null::text description,
+            false as is_hidden_from_schema,
+            pp.oid::regproc as func
+        from
+            graphql.type gt
+            join pg_class pc
+                on gt.entity = pc.oid
+            join pg_proc pp
+                on pp.proargtypes[0] = pc.reltype
+        where
+            gt.meta_kind = 'Node'
+            and pronargs = 1;
 
     -- Node.<relationship>
     insert into graphql._field(
@@ -542,6 +573,7 @@ create view graphql.field as
         f.column_type,
         f.foreign_columns,
         f.local_columns,
+        f.func,
         f.is_hidden_from_schema,
         f.meta_kind
     from

--- a/src/sql/reflection/field/field.sql
+++ b/src/sql/reflection/field/field.sql
@@ -69,7 +69,7 @@ as $$
             )
             when rec.meta_kind = 'Function' then coalesce(
                 graphql.comment_directive_name(rec.func),
-                graphql.to_camel_case(graphql.to_function_name(rec.func))
+                graphql.to_camel_case(ltrim(graphql.to_function_name(rec.func), '_'))
             )
             when rec.meta_kind = 'Query.one' then graphql.to_camel_case(graphql.to_table_name($1.entity))
             when rec.meta_kind = 'Query.collection' then graphql.to_camel_case(graphql.to_table_name($1.entity)) || 'Collection'
@@ -287,7 +287,9 @@ begin
                 on pp.proargtypes[0] = pc.reltype
         where
             gt.meta_kind = 'Node'
-            and pronargs = 1;
+            and pronargs = 1
+            -- starts with underscore
+            and graphql.to_function_name(pp.oid::regproc) like '\_%';
 
     -- Node.<relationship>
     insert into graphql._field(

--- a/src/sql/resolve/transpile/build_node_query.sql
+++ b/src/sql/resolve/transpile/build_node_query.sql
@@ -19,7 +19,8 @@ begin
         E'(\nselect\njsonb_build_object(\n'
         || string_agg(quote_literal(graphql.alias_or_name_literal(x.sel)) || E',\n' ||
             case
-                when nf.column_name is not null then (quote_ident(block_name) || '.' || quote_ident(nf.column_name))
+                when nf.column_name is not null then format('%I.%I', block_name, nf.column_name)
+                when nf.meta_kind = 'Function' then format('%I(%I)', nf.func, block_name)
                 when nf.name = '__typename' then quote_literal(type_.name)
                 when nf.name = 'nodeId' then graphql.cursor_encoded_clause(type_.entity, block_name)
                 when nf.local_columns is not null and nf_t.meta_kind = 'Connection' then graphql.build_connection_query(

--- a/test/expected/extend_type_with_function.out
+++ b/test/expected/extend_type_with_function.out
@@ -1,0 +1,82 @@
+begin;
+    create table account(
+        id serial primary key,
+        first_name varchar(255) not null,
+        last_name varchar(255) not null
+    );
+    -- Extend with function
+    create function full_name(rec public.account)
+        returns text
+        immutable
+        strict
+        language sql
+    as $$
+        select format('%s %s', rec.first_name, rec.last_name)
+    $$;
+    insert into public.account(first_name, last_name)
+    values
+        ('Foo', 'Fooington'),
+        ('Bar', 'Barsworth');
+    savepoint a;
+    select jsonb_pretty(
+        graphql.resolve($$
+    {
+      accountCollection {
+        edges {
+          node {
+            id
+            firstName
+            lastName
+            fullName
+          }
+        }
+      }
+    }
+        $$)
+    );
+                     jsonb_pretty                     
+------------------------------------------------------
+ {                                                   +
+     "data": {                                       +
+         "accountCollection": {                      +
+             "edges": [                              +
+                 {                                   +
+                     "node": {                       +
+                         "id": 1,                    +
+                         "fullName": "Foo Fooington",+
+                         "lastName": "Fooington",    +
+                         "firstName": "Foo"          +
+                     }                               +
+                 },                                  +
+                 {                                   +
+                     "node": {                       +
+                         "id": 2,                    +
+                         "fullName": "Bar Barsworth",+
+                         "lastName": "Barsworth",    +
+                         "firstName": "Bar"          +
+                     }                               +
+                 }                                   +
+             ]                                       +
+         }                                           +
+     },                                              +
+     "errors": [                                     +
+     ]                                               +
+ }
+(1 row)
+
+    rollback to savepoint a;
+    select graphql.resolve($$
+    {
+      account(id: "WyJhY2NvdW50IiwgMV0=") {
+        id
+        fullName
+      }
+    }
+    $$);
+                                   resolve                                   
+-----------------------------------------------------------------------------
+ {"data": {"account": {"id": 1, "fullName": "Foo Fooington"}}, "errors": []}
+(1 row)
+
+    rollback to savepoint a;
+rollback;

--- a/test/expected/extend_type_with_generated_column.out
+++ b/test/expected/extend_type_with_generated_column.out
@@ -2,22 +2,12 @@ begin;
     create table public.account(
         id serial primary key,
         first_name varchar(255) not null,
-        last_name varchar(255) not null
+        last_name varchar(255) not null,
+        full_name text generated always as (first_name || ' ' ||  last_name) stored
     );
-    -- Extend with function
-    create function public._full_name(rec public.account)
-        returns text
-        immutable
-        strict
-        language sql
-    as $$
-        select format('%s %s', rec.first_name, rec.last_name)
-    $$;
     insert into public.account(first_name, last_name)
     values
-        ('Foo', 'Fooington'),
-        ('Bar', 'Barsworth');
-    savepoint a;
+        ('Foo', 'Fooington');
     select jsonb_pretty(
         graphql.resolve($$
     {
@@ -47,14 +37,6 @@ begin;
                          "lastName": "Fooington",    +
                          "firstName": "Foo"          +
                      }                               +
-                 },                                  +
-                 {                                   +
-                     "node": {                       +
-                         "id": 2,                    +
-                         "fullName": "Bar Barsworth",+
-                         "lastName": "Barsworth",    +
-                         "firstName": "Bar"          +
-                     }                               +
                  }                                   +
              ]                                       +
          }                                           +
@@ -64,19 +46,4 @@ begin;
  }
 (1 row)
 
-    rollback to savepoint a;
-    select graphql.resolve($$
-    {
-      account(id: "WyJhY2NvdW50IiwgMV0=") {
-        id
-        fullName
-      }
-    }
-    $$);
-                                   resolve                                   
------------------------------------------------------------------------------
- {"data": {"account": {"id": 1, "fullName": "Foo Fooington"}}, "errors": []}
-(1 row)
-
-    rollback to savepoint a;
 rollback;

--- a/test/expected/override_func_field_name.out
+++ b/test/expected/override_func_field_name.out
@@ -22,9 +22,8 @@ begin;
         entity = 'public.account'::regclass
         and func = 'full_name'::regproc
         and meta_kind = 'Function';
-   name    
------------
- wholeName
-(1 row)
+ name 
+------
+(0 rows)
 
 rollback;

--- a/test/expected/override_func_field_name.out
+++ b/test/expected/override_func_field_name.out
@@ -1,0 +1,30 @@
+begin;
+    create table account(
+        id serial primary key,
+        first_name varchar(255) not null,
+        last_name varchar(255) not null
+    );
+    -- Extend with function
+    create function full_name(rec public.account)
+        returns text
+        immutable
+        strict
+        language sql
+    as $$
+        select format('%s %s', rec.first_name, rec.last_name)
+    $$;
+    comment on function public.full_name(public.account) is E'@graphql({"name": "wholeName"})';
+    select
+        name
+    from
+        graphql.field
+    where
+        entity = 'public.account'::regclass
+        and func = 'full_name'::regproc
+        and meta_kind = 'Function';
+   name    
+-----------
+ wholeName
+(1 row)
+
+rollback;

--- a/test/sql/extend_type_with_function.sql
+++ b/test/sql/extend_type_with_function.sql
@@ -1,13 +1,13 @@
 begin;
 
-    create table account(
+    create table public.account(
         id serial primary key,
         first_name varchar(255) not null,
         last_name varchar(255) not null
     );
 
     -- Extend with function
-    create function full_name(rec public.account)
+    create function public._full_name(rec public.account)
         returns text
         immutable
         strict

--- a/test/sql/extend_type_with_function.sql
+++ b/test/sql/extend_type_with_function.sql
@@ -1,0 +1,57 @@
+begin;
+
+    create table account(
+        id serial primary key,
+        first_name varchar(255) not null,
+        last_name varchar(255) not null
+    );
+
+    -- Extend with function
+    create function full_name(rec public.account)
+        returns text
+        immutable
+        strict
+        language sql
+    as $$
+        select format('%s %s', rec.first_name, rec.last_name)
+    $$;
+
+    insert into public.account(first_name, last_name)
+    values
+        ('Foo', 'Fooington'),
+        ('Bar', 'Barsworth');
+
+
+    savepoint a;
+
+    select jsonb_pretty(
+        graphql.resolve($$
+    {
+      accountCollection {
+        edges {
+          node {
+            id
+            firstName
+            lastName
+            fullName
+          }
+        }
+      }
+    }
+        $$)
+    );
+
+    rollback to savepoint a;
+
+    select graphql.resolve($$
+    {
+      account(id: "WyJhY2NvdW50IiwgMV0=") {
+        id
+        fullName
+      }
+    }
+    $$);
+
+    rollback to savepoint a;
+
+rollback;

--- a/test/sql/extend_type_with_generated_column.sql
+++ b/test/sql/extend_type_with_generated_column.sql
@@ -1,0 +1,32 @@
+begin;
+
+    create table public.account(
+        id serial primary key,
+        first_name varchar(255) not null,
+        last_name varchar(255) not null,
+        full_name text generated always as (first_name || ' ' ||  last_name) stored
+    );
+
+    insert into public.account(first_name, last_name)
+    values
+        ('Foo', 'Fooington');
+
+
+    select jsonb_pretty(
+        graphql.resolve($$
+    {
+      accountCollection {
+        edges {
+          node {
+            id
+            firstName
+            lastName
+            fullName
+          }
+        }
+      }
+    }
+        $$)
+    );
+
+rollback;

--- a/test/sql/override_func_field_name.sql
+++ b/test/sql/override_func_field_name.sql
@@ -1,0 +1,29 @@
+begin;
+    create table account(
+        id serial primary key,
+        first_name varchar(255) not null,
+        last_name varchar(255) not null
+    );
+
+    -- Extend with function
+    create function full_name(rec public.account)
+        returns text
+        immutable
+        strict
+        language sql
+    as $$
+        select format('%s %s', rec.first_name, rec.last_name)
+    $$;
+
+    comment on function public.full_name(public.account) is E'@graphql({"name": "wholeName"})';
+
+    select
+        name
+    from
+        graphql.field
+    where
+        entity = 'public.account'::regclass
+        and func = 'full_name'::regproc
+        and meta_kind = 'Function';
+
+rollback;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds computed columns via 

```sql
  create table account(
      id serial primary key,
      first_name varchar(255) not null,
      last_name varchar(255) not null
  );

  -- extend Account type with fullName field
  create function _full_name(rec public.account)
      returns text
      immutable
      strict
      language sql
  as $$
      select format('%s %s', rec.first_name, rec.last_name)
  $$;

  insert into public.account(first_name, last_name)
  values
      ('Foo', 'Fooington'),
      ('Bar', 'Barsworth');


  select jsonb_pretty(
      graphql.resolve($$
  {
    accountCollection {
      edges {
        node {
          id
          firstName
          lastName
          fullName
        }
      }
    }
  }
      $$)
  );
                     jsonb_pretty                     
------------------------------------------------------
 {                                                   +
     "data": {                                       +
         "accountCollection": {                      +
             "edges": [                              +
                 {                                   +
                     "node": {                       +
                         "id": 1,                    +
                         "fullName": "Foo Fooington",+
                         "lastName": "Fooington",    +
                         "firstName": "Foo"          +
                     }                               +
                 },                                  +
                 {                                   +
                     "node": {                       +
                         "id": 2,                    +
                         "fullName": "Bar Barsworth",+
                         "lastName": "Barsworth",    +
                         "firstName": "Bar"          +
                     }                               +
                 }                                   +
             ]                                       +
         }                                           +
     },                                              +
     "errors": [                                     +
     ]                                               +
 }
```
