### PR TITLE
By default, do not inflect names

### DIFF
--- a/dockerfiles/db/setup.sql
+++ b/dockerfiles/db/setup.sql
@@ -73,3 +73,6 @@ values
     ((select id from account where email ilike 'a%'), 'A: Blog 2', 'a desc2', now(), now()),
     ((select id from account where email ilike 'a%'), 'A: Blog 3', 'a desc3', now(), now()),
     ((select id from account where email ilike 'b%'), 'B: Blog 3', 'b desc1', now(), now());
+
+
+comment on schema public is '@graphql({"inflect_names": true})';

--- a/pg_graphql--0.1.0.sql
+++ b/pg_graphql--0.1.0.sql
@@ -1205,10 +1205,7 @@ as $$
             format(
                 '%sCollection',
                 graphql.lowercase_first_letter(
-                    coalesce(
-                        foreign_name_override,
-                        graphql.type_name(foreign_entity, 'Node')
-                    )
+                    graphql.type_name(foreign_entity, 'Node')
                 )
             )
         );
@@ -1247,21 +1244,23 @@ declare
     is_single_col_ending_id bool = array_length(foreign_columns, 1) = 1 and foreign_columns[1] like '%\_id';
 
     base_single_col_name text = left(foreign_columns[1], -3);
-    base_name text = graphql.lowercase_first_letter(graphql.type_name(foreign_entity, 'Node'));
+    base_name text = graphql.type_name(foreign_entity, 'Node');
 begin
     return
         coalesce(
             -- comment directive override
             foreign_name_override,
-            case is_single_col_ending_id
-                when true then (
-                    case
-                        when is_inflection_on then graphql.to_camel_case(base_single_col_name)
-                        else base_single_col_name
-                    end
-                )
-                else base_name
-            end
+            graphql.lowercase_first_letter(
+                case is_single_col_ending_id
+                    when true then (
+                        case
+                            when is_inflection_on then graphql.to_camel_case(base_single_col_name)
+                            else base_single_col_name
+                        end
+                    )
+                    else base_name
+                end
+            )
         );
 end;
 $$;

--- a/pg_graphql--0.1.0.sql
+++ b/pg_graphql--0.1.0.sql
@@ -498,6 +498,12 @@ as $$
     select pg_catalog.obj_description($1::oid, 'pg_proc')
 $$;
 
+create function graphql.comment(regnamespace)
+    returns text
+    language sql
+as $$
+    select pg_catalog.obj_description($1::oid, 'pg_namespace')
+$$;
 
 create function graphql.comment(regclass, column_name text)
     returns text
@@ -543,6 +549,17 @@ create function graphql.comment_directive_name(regproc)
     language sql
 as $$
     select graphql.comment_directive(graphql.comment($1)) ->> 'name'
+$$;
+
+create function graphql.comment_directive_inflect_names(regnamespace)
+    returns bool
+    language sql
+as $$
+    select
+        case
+            when (graphql.comment_directive(graphql.comment($1)) -> 'inflect_names') = to_jsonb(true) then true
+            else false
+        end
 $$;
 create type graphql.cardinality as enum ('ONE', 'MANY');
 create type graphql.meta_kind as enum (
@@ -648,11 +665,12 @@ as $$
         select
             case
                 when rec.entity is not null then coalesce(
+                    -- Explicit name has firts priority
                     graphql.comment_directive_name(rec.entity),
-                    case
-                        -- when the name contains a capital do not attempt inflection
-                        when graphql.to_table_name(rec.entity) <> lower(graphql.to_table_name(rec.entity)) then graphql.to_table_name(rec.entity)
-                        else graphql.inflect_type_default(graphql.to_table_name(rec.entity))
+                    -- When the schema has "inflect_names: true then inflect. otherwise, use table name
+                    case graphql.comment_directive_inflect_names(current_schema::regnamespace)
+                        when true then graphql.inflect_type_default(graphql.to_table_name(rec.entity))
+                        else graphql.to_table_name(rec.entity)
                     end
                 )
                 else null
@@ -1155,13 +1173,78 @@ as $$
     select
         coalesce(
             graphql.comment_directive_name($1, $2),
-            case
-                -- If contains a capital letter, do not inflect
-                when $2 <> lower($2) then $2
-                else graphql.to_camel_case($2)
+            case graphql.comment_directive_inflect_names(current_schema::regnamespace)
+                when true then graphql.to_camel_case($2)
+                else $2
             end
         )
 $$;
+
+create or replace function graphql.field_name_for_to_many(foreign_entity regclass, foreign_name_override text)
+    returns text
+    immutable
+    language sql
+as $$
+    select
+        coalesce(
+            foreign_name_override,
+            format(
+                '%sCollection',
+                case graphql.comment_directive_inflect_names(current_schema::regnamespace)
+                    when true then graphql.to_camel_case(graphql.type_name(foreign_entity, 'Node'))
+                    else graphql.type_name(foreign_entity, 'Node')
+                end
+            )
+        )
+$$;
+
+create or replace function graphql.field_name_for_to_one(foreign_entity regclass, foreign_name_override text, foreign_columns text[])
+    returns text
+    immutable
+    language plpgsql
+as $$
+declare
+    is_inflection_on bool = graphql.comment_directive_inflect_names(current_schema::regnamespace);
+    -- owner_id -> owner
+    is_single_col_ending_id bool = array_length(foreign_columns, 1) = 1 and foreign_columns[1] like '%\_id';
+begin
+    return
+        coalesce(
+            -- comment directive override
+            foreign_name_override,
+            case is_inflection_on
+                when true then (
+                    case is_single_col_ending_id
+                        when true then graphql.to_camel_case(left(foreign_columns[1], -3))
+                        else graphql.to_camel_case(graphql.type_name(foreign_entity, 'Node'))
+                    end
+                )
+                else (
+                    case is_single_col_ending_id
+                        when true then left(foreign_columns[1], -3)
+                        else graphql.type_name(foreign_entity, 'Node')
+                    end
+                )
+            end
+        );
+end;
+$$;
+
+create or replace function graphql.field_name_for_function(func regproc)
+    returns text
+    immutable
+    language sql
+as $$
+    select
+        coalesce(
+            graphql.comment_directive_name(func),
+            case graphql.comment_directive_inflect_names(current_schema::regnamespace)
+                when true then graphql.to_camel_case(ltrim(graphql.to_function_name(func), '_'))
+                else ltrim(graphql.to_function_name(func), '_')
+            end
+        )
+$$;
+
 
 
 create or replace function graphql.field_name(rec graphql._field)
@@ -1169,40 +1252,32 @@ create or replace function graphql.field_name(rec graphql._field)
     immutable
     language sql
 as $$
-
+    with base(name) as (
+        select graphql.type_name(rec.entity, 'Node')
+    )
     select
         case
             when rec.meta_kind = 'Constant' then rec.constant_name
-            when rec.meta_kind in ('Column', 'OrderBy.Column', 'Filter.Column') then graphql.field_name_for_column(
-                rec.entity,
-                rec.column_name
+            when rec.meta_kind in ('Column', 'OrderBy.Column', 'Filter.Column') then graphql.field_name_for_column(rec.entity, rec.column_name)
+            when rec.meta_kind = 'Function' then graphql.field_name_for_function(rec.func)
+            when rec.meta_kind = 'Query.collection' then format(
+                '%sCollection',
+                case graphql.comment_directive_inflect_names(current_schema::regnamespace)
+                    -- re-camel case because we're at the start of a field name, not the middle
+                    when true then graphql.to_camel_case(base.name)
+                    else base.name
+                end
             )
-            when rec.meta_kind = 'Function' then coalesce(
-                graphql.comment_directive_name(rec.func),
-                graphql.to_camel_case(ltrim(graphql.to_function_name(rec.func), '_'))
-            )
-            when rec.meta_kind = 'Query.collection' then format('%sCollection', graphql.to_camel_case(graphql.type_name(rec.entity, 'Node')))
-            when rec.meta_kind = 'Mutation.insert' then format('insertInto%sCollection', graphql.type_name(rec.entity, 'Node'))
-            when rec.meta_kind = 'Mutation.update' then format('update%sCollection', graphql.type_name(rec.entity, 'Node'))
-            when rec.meta_kind = 'Mutation.delete' then format('deleteFrom%sCollection', graphql.type_name(rec.entity, 'Node'))
-            when rec.meta_kind = 'Relationship.toMany' then coalesce(
-                rec.foreign_name_override,
-                graphql.to_camel_case(graphql.type_name(rec.foreign_entity, 'Node')) || 'Collection'
-            )
-            when rec.meta_kind = 'Relationship.toOne' then coalesce(
-                -- comment directive override
-                rec.foreign_name_override,
-                -- owner_id -> owner
-                case array_length(rec.foreign_columns, 1) = 1 and rec.foreign_columns[1] like '%\_id'
-                    when true then graphql.to_camel_case(left(rec.foreign_columns[1], -3))
-                    else null
-                end,
-                -- default
-                graphql.to_camel_case(graphql.type_name(rec.foreign_entity, 'Node'))
-            )
+            when rec.meta_kind = 'Mutation.insert' then format('insertInto%sCollection', base.name)
+            when rec.meta_kind = 'Mutation.update' then format('update%sCollection', base.name)
+            when rec.meta_kind = 'Mutation.delete' then format('deleteFrom%sCollection', base.name)
+            when rec.meta_kind = 'Relationship.toMany' then graphql.field_name_for_to_many(rec.foreign_entity, rec.foreign_name_override)
+            when rec.meta_kind = 'Relationship.toOne' then graphql.field_name_for_to_one(rec.foreign_entity, rec.foreign_name_override, rec.foreign_columns)
             when rec.constant_name is not null then rec.constant_name
             else graphql.exception(format('could not determine field name, %s', $1))
         end
+    from
+        base
 $$;
 
 

--- a/pg_graphql--0.1.0.sql
+++ b/pg_graphql--0.1.0.sql
@@ -1167,7 +1167,7 @@ create index ix_graphql_field_entity on graphql._field(entity);
 
 create or replace function graphql.field_name_for_column(entity regclass, column_name text)
     returns text
-    immutable
+    stable
     language sql
 as $$
     select
@@ -1180,9 +1180,23 @@ as $$
         )
 $$;
 
-create or replace function graphql.field_name_for_to_many(foreign_entity regclass, foreign_name_override text)
+create or replace function graphql.lowercase_first_letter(text)
     returns text
     immutable
+    strict
+    language sql
+as $$
+    select format(
+        '%s%s',
+        substring(lower($1), 1, 1),
+        substring($1, 2, 999)
+    );
+$$;
+
+
+create or replace function graphql.field_name_for_to_many(foreign_entity regclass, foreign_name_override text)
+    returns text
+    stable
     language sql
 as $$
     select
@@ -1190,49 +1204,74 @@ as $$
             foreign_name_override,
             format(
                 '%sCollection',
-                case graphql.comment_directive_inflect_names(current_schema::regnamespace)
-                    when true then graphql.to_camel_case(graphql.type_name(foreign_entity, 'Node'))
-                    else graphql.type_name(foreign_entity, 'Node')
-                end
+                graphql.lowercase_first_letter(
+                    coalesce(
+                        foreign_name_override,
+                        graphql.type_name(foreign_entity, 'Node')
+                    )
+                )
             )
-        )
+        );
 $$;
+
+
+create or replace function graphql.field_name_for_query_collection(entity regclass)
+    returns text
+    stable
+    language sql
+as $$
+    select
+        format(
+            '%sCollection',
+            format(
+                '%s',
+                graphql.lowercase_first_letter(
+                    coalesce(
+                        graphql.comment_directive_name(entity),
+                        graphql.type_name(entity, 'Node')
+                    )
+                )
+            )
+        );
+$$;
+
 
 create or replace function graphql.field_name_for_to_one(foreign_entity regclass, foreign_name_override text, foreign_columns text[])
     returns text
-    immutable
+    stable
     language plpgsql
 as $$
 declare
     is_inflection_on bool = graphql.comment_directive_inflect_names(current_schema::regnamespace);
     -- owner_id -> owner
     is_single_col_ending_id bool = array_length(foreign_columns, 1) = 1 and foreign_columns[1] like '%\_id';
+
+    base_single_col_name text = left(foreign_columns[1], -3);
+    base_name text = graphql.lowercase_first_letter(graphql.type_name(foreign_entity, 'Node'));
 begin
     return
         coalesce(
             -- comment directive override
             foreign_name_override,
-            case is_inflection_on
+            case is_single_col_ending_id
                 when true then (
-                    case is_single_col_ending_id
-                        when true then graphql.to_camel_case(left(foreign_columns[1], -3))
-                        else graphql.to_camel_case(graphql.type_name(foreign_entity, 'Node'))
+                    case
+                        when is_inflection_on then graphql.to_camel_case(base_single_col_name)
+                        else base_single_col_name
                     end
                 )
-                else (
-                    case is_single_col_ending_id
-                        when true then left(foreign_columns[1], -3)
-                        else graphql.type_name(foreign_entity, 'Node')
-                    end
-                )
+                else base_name
             end
         );
 end;
 $$;
 
+
+
+
 create or replace function graphql.field_name_for_function(func regproc)
     returns text
-    immutable
+    stable
     language sql
 as $$
     select
@@ -1244,7 +1283,6 @@ as $$
             end
         )
 $$;
-
 
 
 create or replace function graphql.field_name(rec graphql._field)
@@ -1260,14 +1298,7 @@ as $$
             when rec.meta_kind = 'Constant' then rec.constant_name
             when rec.meta_kind in ('Column', 'OrderBy.Column', 'Filter.Column') then graphql.field_name_for_column(rec.entity, rec.column_name)
             when rec.meta_kind = 'Function' then graphql.field_name_for_function(rec.func)
-            when rec.meta_kind = 'Query.collection' then format(
-                '%sCollection',
-                case graphql.comment_directive_inflect_names(current_schema::regnamespace)
-                    -- re-camel case because we're at the start of a field name, not the middle
-                    when true then graphql.to_camel_case(base.name)
-                    else base.name
-                end
-            )
+            when rec.meta_kind = 'Query.collection' then graphql.field_name_for_query_collection(rec.entity)
             when rec.meta_kind = 'Mutation.insert' then format('insertInto%sCollection', base.name)
             when rec.meta_kind = 'Mutation.update' then format('update%sCollection', base.name)
             when rec.meta_kind = 'Mutation.delete' then format('deleteFrom%sCollection', base.name)

--- a/src/sql/directive/parse.sql
+++ b/src/sql/directive/parse.sql
@@ -38,6 +38,12 @@ as $$
     select pg_catalog.obj_description($1::oid, 'pg_proc')
 $$;
 
+create function graphql.comment(regnamespace)
+    returns text
+    language sql
+as $$
+    select pg_catalog.obj_description($1::oid, 'pg_namespace')
+$$;
 
 create function graphql.comment(regclass, column_name text)
     returns text
@@ -83,4 +89,15 @@ create function graphql.comment_directive_name(regproc)
     language sql
 as $$
     select graphql.comment_directive(graphql.comment($1)) ->> 'name'
+$$;
+
+create function graphql.comment_directive_inflect_names(regnamespace)
+    returns bool
+    language sql
+as $$
+    select
+        case
+            when (graphql.comment_directive(graphql.comment($1)) -> 'inflect_names') = to_jsonb(true) then true
+            else false
+        end
 $$;

--- a/src/sql/reflection/field/field.sql
+++ b/src/sql/reflection/field/field.sql
@@ -101,10 +101,7 @@ as $$
             format(
                 '%sCollection',
                 graphql.lowercase_first_letter(
-                    coalesce(
-                        foreign_name_override,
-                        graphql.type_name(foreign_entity, 'Node')
-                    )
+                    graphql.type_name(foreign_entity, 'Node')
                 )
             )
         );
@@ -143,21 +140,23 @@ declare
     is_single_col_ending_id bool = array_length(foreign_columns, 1) = 1 and foreign_columns[1] like '%\_id';
 
     base_single_col_name text = left(foreign_columns[1], -3);
-    base_name text = graphql.lowercase_first_letter(graphql.type_name(foreign_entity, 'Node'));
+    base_name text = graphql.type_name(foreign_entity, 'Node');
 begin
     return
         coalesce(
             -- comment directive override
             foreign_name_override,
-            case is_single_col_ending_id
-                when true then (
-                    case
-                        when is_inflection_on then graphql.to_camel_case(base_single_col_name)
-                        else base_single_col_name
-                    end
-                )
-                else base_name
-            end
+            graphql.lowercase_first_letter(
+                case is_single_col_ending_id
+                    when true then (
+                        case
+                            when is_inflection_on then graphql.to_camel_case(base_single_col_name)
+                            else base_single_col_name
+                        end
+                    )
+                    else base_name
+                end
+            )
         );
 end;
 $$;

--- a/src/sql/reflection/type/tables/_type.sql
+++ b/src/sql/reflection/type/tables/_type.sql
@@ -37,11 +37,12 @@ as $$
         select
             case
                 when rec.entity is not null then coalesce(
+                    -- Explicit name has firts priority
                     graphql.comment_directive_name(rec.entity),
-                    case
-                        -- when the name contains a capital do not attempt inflection
-                        when graphql.to_table_name(rec.entity) <> lower(graphql.to_table_name(rec.entity)) then graphql.to_table_name(rec.entity)
-                        else graphql.inflect_type_default(graphql.to_table_name(rec.entity))
+                    -- When the schema has "inflect_names: true then inflect. otherwise, use table name
+                    case graphql.comment_directive_inflect_names(current_schema::regnamespace)
+                        when true then graphql.inflect_type_default(graphql.to_table_name(rec.entity))
+                        else graphql.to_table_name(rec.entity)
                     end
                 )
                 else null

--- a/test/expected/allow_camel_names.out
+++ b/test/expected/allow_camel_names.out
@@ -1,4 +1,5 @@
 begin;
+    comment on schema public is '@graphql({"inflect_names": false})';
     create table "AccountHolder"(
         "someId" int primary key,
         "accountHolderId" int references "AccountHolder"("someId")

--- a/test/expected/inflection_fields.out
+++ b/test/expected/inflection_fields.out
@@ -43,12 +43,12 @@ begin;
 (2 rows)
 
     -- Inflection on, Overrides: on
-    comment on column account.id is e'@graphql({"name": "iIIIDDDD"})';
+    comment on column account.id is e'@graphql({"name": "IddD"})';
     comment on column account.name_with_underscore is e'@graphql({"name": "nAMe"})';
     select * from f;
-   name   
-----------
- iIIIDDDD
+ name 
+------
+ IddD
  nAMe
 (2 rows)
 

--- a/test/expected/inflection_fields.out
+++ b/test/expected/inflection_fields.out
@@ -1,0 +1,55 @@
+begin;
+    create view f as
+        select
+            distinct name
+        from
+            graphql.field
+        where
+            column_name in ('id', 'name_with_underscore')
+        order by
+            name;
+    create table account (
+        id int primary key,
+        name_with_underscore text
+    );
+    -- Inflection off, Overrides: off
+    comment on schema public is e'@graphql({"inflect_names": false})';
+    select * from f;
+         name         
+----------------------
+ id
+ name_with_underscore
+(2 rows)
+
+    savepoint a;
+    -- Inflection off, Overrides: on
+    comment on column account.id is e'@graphql({"name": "IddD"})';
+    comment on column account.name_with_underscore is e'@graphql({"name": "nAMe"})';
+    select * from f;
+ name 
+------
+ IddD
+ nAMe
+(2 rows)
+
+    rollback to savepoint a;
+    -- Inflection on, Overrides: off
+    comment on schema public is e'@graphql({"inflect_names": true})';
+    select * from f;
+        name        
+--------------------
+ id
+ nameWithUnderscore
+(2 rows)
+
+    -- Inflection on, Overrides: on
+    comment on column account.id is e'@graphql({"name": "iIIIDDDD"})';
+    comment on column account.name_with_underscore is e'@graphql({"name": "nAMe"})';
+    select * from f;
+   name   
+----------
+ iIIIDDDD
+ nAMe
+(2 rows)
+
+rollback;

--- a/test/expected/inflection_function.out
+++ b/test/expected/inflection_function.out
@@ -5,35 +5,52 @@ begin;
         from
             graphql.field
         where
-            column_name in ('id', 'name_with_underscore')
+            func is not null
         order by
             name;
-
     create table account (
-        id int primary key,
-        name_with_underscore text
+        id int primary key
     );
-
+    create function _full_name(rec public.account)
+        returns text
+        immutable
+        strict
+        language sql
+    as $$
+        select 'Foo';
+    $$;
     -- Inflection off, Overrides: off
     comment on schema public is e'@graphql({"inflect_names": false})';
     select * from f;
+   name    
+-----------
+ full_name
+(1 row)
 
     savepoint a;
-
     -- Inflection off, Overrides: on
-    comment on column account.id is e'@graphql({"name": "IddD"})';
-    comment on column account.name_with_underscore is e'@graphql({"name": "nAMe"})';
+    comment on function public._full_name(public.account) is E'@graphql({"name": "wholeName"})';
     select * from f;
+   name    
+-----------
+ wholeName
+(1 row)
 
     rollback to savepoint a;
-
     -- Inflection on, Overrides: off
     comment on schema public is e'@graphql({"inflect_names": true})';
     select * from f;
+   name   
+----------
+ fullName
+(1 row)
 
     -- Inflection on, Overrides: on
-    comment on column account.id is e'@graphql({"name": "IddD"})';
-    comment on column account.name_with_underscore is e'@graphql({"name": "nAMe"})';
+    comment on function public._full_name(public.account) is E'@graphql({"name": "WholeName"})';
     select * from f;
+   name    
+-----------
+ WholeName
+(1 row)
 
 rollback;

--- a/test/expected/inflection_relationships.out
+++ b/test/expected/inflection_relationships.out
@@ -8,9 +8,9 @@ begin;
             local_columns is not null
         order by
             name;
+    savepoint o;
     create table account (
-        id int primary key,
-        name_with_underscore text
+        id int primary key
     );
     create table blog_post(
         id int primary key,
@@ -22,10 +22,12 @@ begin;
     savepoint a;
     -- Inflection off, Overrides: off
     comment on schema public is e'@graphql({"inflect_names": false})';
+    -- test that first letter of capital type name is lower cased when used as a field
+    alter table account rename to "AccOnunt";
     select * from r;
         name         
 ---------------------
- account
+ accOnunt
  author
  blog_postCollection
 (3 rows)
@@ -53,7 +55,7 @@ begin;
     select * from r;
         name        
 --------------------
- account
+ acconunt
  author
  blogPostCollection
 (3 rows)

--- a/test/expected/inflection_relationships.out
+++ b/test/expected/inflection_relationships.out
@@ -1,0 +1,77 @@
+begin;
+    create view r as
+        select
+            distinct name
+        from
+            graphql.field
+        where
+            local_columns is not null
+        order by
+            name;
+    create table account (
+        id int primary key,
+        name_with_underscore text
+    );
+    create table blog_post(
+        id int primary key,
+        author_id  int,
+        account_no  int,
+        constraint fkey_author_id foreign key (author_id) references account(id),
+        constraint fkey_author_no foreign key (account_no) references account(id)
+    );
+    savepoint a;
+    -- Inflection off, Overrides: off
+    comment on schema public is e'@graphql({"inflect_names": false})';
+    select * from r;
+        name         
+---------------------
+ account
+ author
+ blog_postCollection
+(3 rows)
+
+    savepoint a;
+    -- Inflection off, Overrides: on
+    comment on constraint fkey_author_id
+        on blog_post
+        is E'@graphql({"foreign_name": "ownerOO", "local_name": "Blogzzz"})';
+    comment on constraint fkey_author_no
+        on blog_post
+        is E'@graphql({"foreign_name": "accountNO", "local_name": "NOblogz"})';
+    select * from r;
+   name    
+-----------
+ Blogzzz
+ NOblogz
+ accountNO
+ ownerOO
+(4 rows)
+
+    rollback to savepoint a;
+    -- Inflection on, Overrides: off
+    comment on schema public is e'@graphql({"inflect_names": true})';
+    select * from r;
+        name        
+--------------------
+ account
+ author
+ blogPostCollection
+(3 rows)
+
+    -- Inflection on, Overrides: on
+    comment on constraint fkey_author_id
+        on blog_post
+        is E'@graphql({"foreign_name": "ownerOO", "local_name": "Blogzzz"})';
+    comment on constraint fkey_author_no
+        on blog_post
+        is E'@graphql({"foreign_name": "accountNO", "local_name": "NOblogz"})';
+    select * from r;
+   name    
+-----------
+ Blogzzz
+ NOblogz
+ accountNO
+ ownerOO
+(4 rows)
+
+rollback;

--- a/test/expected/inflection_types.out
+++ b/test/expected/inflection_types.out
@@ -1,0 +1,85 @@
+begin;
+    create view t as
+        select
+            distinct name
+        from
+            graphql.type
+        where
+            entity is not null
+        order by
+            name;
+    create table blog_post(
+        id int primary key,
+        author_id int
+    );
+    savepoint a;
+    -- Inflection off, Overrides: off
+    comment on schema public is e'@graphql({"inflect_names": false})';
+    select * from t;
+          name           
+-------------------------
+ blog_post
+ blog_postConnection
+ blog_postDeleteResponse
+ blog_postEdge
+ blog_postFilter
+ blog_postInsertInput
+ blog_postInsertResponse
+ blog_postOrderBy
+ blog_postUpdateInput
+ blog_postUpdateResponse
+(10 rows)
+
+    -- Inflection off, Overrides: on
+    comment on table blog_post is e'@graphql({"name": "BlogZZZ"})';
+    select * from t;
+         name          
+-----------------------
+ BlogZZZ
+ BlogZZZConnection
+ BlogZZZDeleteResponse
+ BlogZZZEdge
+ BlogZZZFilter
+ BlogZZZInsertInput
+ BlogZZZInsertResponse
+ BlogZZZOrderBy
+ BlogZZZUpdateInput
+ BlogZZZUpdateResponse
+(10 rows)
+
+    rollback to savepoint a;
+    -- Inflection on, Overrides: off
+    comment on schema public is e'@graphql({"inflect_names": true})';
+    select name from graphql.type where entity is not null order by entity, name;
+          name          
+------------------------
+ BlogPost
+ BlogPostConnection
+ BlogPostDeleteResponse
+ BlogPostEdge
+ BlogPostFilter
+ BlogPostInsertInput
+ BlogPostInsertResponse
+ BlogPostOrderBy
+ BlogPostUpdateInput
+ BlogPostUpdateResponse
+(10 rows)
+
+    -- Inflection on, Overrides: on
+    comment on table blog_post is e'@graphql({"name": "BlogZZZ"})';
+    select name from graphql.type where entity is not null order by entity, name;
+         name          
+-----------------------
+ BlogZZZ
+ BlogZZZConnection
+ BlogZZZDeleteResponse
+ BlogZZZEdge
+ BlogZZZFilter
+ BlogZZZInsertInput
+ BlogZZZInsertResponse
+ BlogZZZOrderBy
+ BlogZZZUpdateInput
+ BlogZZZUpdateResponse
+(10 rows)
+
+rollback;

--- a/test/expected/override_func_field_name.out
+++ b/test/expected/override_func_field_name.out
@@ -5,7 +5,7 @@ begin;
         last_name varchar(255) not null
     );
     -- Extend with function
-    create function full_name(rec public.account)
+    create function _full_name(rec public.account)
         returns text
         immutable
         strict
@@ -13,17 +13,16 @@ begin;
     as $$
         select format('%s %s', rec.first_name, rec.last_name)
     $$;
-    comment on function public.full_name(public.account) is E'@graphql({"name": "wholeName"})';
+    comment on function public._full_name(public.account) is E'@graphql({"name": "wholeName"})';
     select
         name
     from
         graphql.field
     where
-        entity = 'public.account'::regclass
-        and func = 'full_name'::regproc
-        and meta_kind = 'Function';
- name 
-------
-(0 rows)
+        func is not null;
+   name    
+-----------
+ wholeName
+(1 row)
 
 rollback;

--- a/test/fixtures.sql
+++ b/test/fixtures.sql
@@ -1,2 +1,5 @@
 create extension pg_graphql cascade;
 create extension "uuid-ossp";
+
+
+comment on schema public is '@graphql({"inflect_names": true})';

--- a/test/sql/allow_camel_names.sql
+++ b/test/sql/allow_camel_names.sql
@@ -1,5 +1,7 @@
 begin;
 
+    comment on schema public is '@graphql({"inflect_names": false})';
+
     create table "AccountHolder"(
         "someId" int primary key,
         "accountHolderId" int references "AccountHolder"("someId")

--- a/test/sql/inflection_fields.sql
+++ b/test/sql/inflection_fields.sql
@@ -1,0 +1,39 @@
+begin;
+    create view f as
+        select
+            distinct name
+        from
+            graphql.field
+        where
+            column_name in ('id', 'name_with_underscore')
+        order by
+            name;
+
+    create table account (
+        id int primary key,
+        name_with_underscore text
+    );
+
+    -- Inflection off, Overrides: off
+    comment on schema public is e'@graphql({"inflect_names": false})';
+    select * from f;
+
+    savepoint a;
+
+    -- Inflection off, Overrides: on
+    comment on column account.id is e'@graphql({"name": "IddD"})';
+    comment on column account.name_with_underscore is e'@graphql({"name": "nAMe"})';
+    select * from f;
+
+    rollback to savepoint a;
+
+    -- Inflection on, Overrides: off
+    comment on schema public is e'@graphql({"inflect_names": true})';
+    select * from f;
+
+    -- Inflection on, Overrides: on
+    comment on column account.id is e'@graphql({"name": "iIIIDDDD"})';
+    comment on column account.name_with_underscore is e'@graphql({"name": "nAMe"})';
+    select * from f;
+
+rollback;

--- a/test/sql/inflection_function.sql
+++ b/test/sql/inflection_function.sql
@@ -5,14 +5,22 @@ begin;
         from
             graphql.field
         where
-            column_name in ('id', 'name_with_underscore')
+            func is not null
         order by
             name;
 
     create table account (
-        id int primary key,
-        name_with_underscore text
+        id int primary key
     );
+
+    create function _full_name(rec public.account)
+        returns text
+        immutable
+        strict
+        language sql
+    as $$
+        select 'Foo';
+    $$;
 
     -- Inflection off, Overrides: off
     comment on schema public is e'@graphql({"inflect_names": false})';
@@ -21,8 +29,7 @@ begin;
     savepoint a;
 
     -- Inflection off, Overrides: on
-    comment on column account.id is e'@graphql({"name": "IddD"})';
-    comment on column account.name_with_underscore is e'@graphql({"name": "nAMe"})';
+    comment on function public._full_name(public.account) is E'@graphql({"name": "wholeName"})';
     select * from f;
 
     rollback to savepoint a;
@@ -32,8 +39,7 @@ begin;
     select * from f;
 
     -- Inflection on, Overrides: on
-    comment on column account.id is e'@graphql({"name": "IddD"})';
-    comment on column account.name_with_underscore is e'@graphql({"name": "nAMe"})';
+    comment on function public._full_name(public.account) is E'@graphql({"name": "WholeName"})';
     select * from f;
 
 rollback;

--- a/test/sql/inflection_relationships.sql
+++ b/test/sql/inflection_relationships.sql
@@ -1,0 +1,58 @@
+begin;
+    create view r as
+        select
+            distinct name
+        from
+            graphql.field
+        where
+            local_columns is not null
+        order by
+            name;
+
+    create table account (
+        id int primary key,
+        name_with_underscore text
+    );
+
+    create table blog_post(
+        id int primary key,
+        author_id  int,
+        account_no  int,
+
+        constraint fkey_author_id foreign key (author_id) references account(id),
+        constraint fkey_author_no foreign key (account_no) references account(id)
+    );
+
+    savepoint a;
+
+    -- Inflection off, Overrides: off
+    comment on schema public is e'@graphql({"inflect_names": false})';
+    select * from r;
+
+    savepoint a;
+
+    -- Inflection off, Overrides: on
+    comment on constraint fkey_author_id
+        on blog_post
+        is E'@graphql({"foreign_name": "ownerOO", "local_name": "Blogzzz"})';
+    comment on constraint fkey_author_no
+        on blog_post
+        is E'@graphql({"foreign_name": "accountNO", "local_name": "NOblogz"})';
+    select * from r;
+
+    rollback to savepoint a;
+
+    -- Inflection on, Overrides: off
+    comment on schema public is e'@graphql({"inflect_names": true})';
+    select * from r;
+
+    -- Inflection on, Overrides: on
+    comment on constraint fkey_author_id
+        on blog_post
+        is E'@graphql({"foreign_name": "ownerOO", "local_name": "Blogzzz"})';
+    comment on constraint fkey_author_no
+        on blog_post
+        is E'@graphql({"foreign_name": "accountNO", "local_name": "NOblogz"})';
+    select * from r;
+
+rollback;

--- a/test/sql/inflection_relationships.sql
+++ b/test/sql/inflection_relationships.sql
@@ -9,9 +9,10 @@ begin;
         order by
             name;
 
+    savepoint o;
+
     create table account (
-        id int primary key,
-        name_with_underscore text
+        id int primary key
     );
 
     create table blog_post(
@@ -27,6 +28,8 @@ begin;
 
     -- Inflection off, Overrides: off
     comment on schema public is e'@graphql({"inflect_names": false})';
+    -- test that first letter of capital type name is lower cased when used as a field
+    alter table account rename to "AccOnunt";
     select * from r;
 
     savepoint a;

--- a/test/sql/inflection_types.sql
+++ b/test/sql/inflection_types.sql
@@ -1,0 +1,37 @@
+begin;
+    create view t as
+        select
+            distinct name
+        from
+            graphql.type
+        where
+            entity is not null
+        order by
+            name;
+
+    create table blog_post(
+        id int primary key,
+        author_id int
+    );
+
+    savepoint a;
+
+    -- Inflection off, Overrides: off
+    comment on schema public is e'@graphql({"inflect_names": false})';
+    select * from t;
+
+    -- Inflection off, Overrides: on
+    comment on table blog_post is e'@graphql({"name": "BlogZZZ"})';
+    select * from t;
+
+    rollback to savepoint a;
+
+    -- Inflection on, Overrides: off
+    comment on schema public is e'@graphql({"inflect_names": true})';
+    select name from graphql.type where entity is not null order by entity, name;
+
+    -- Inflection on, Overrides: on
+    comment on table blog_post is e'@graphql({"name": "BlogZZZ"})';
+    select name from graphql.type where entity is not null order by entity, name;
+
+rollback;

--- a/test/sql/override_func_field_name.sql
+++ b/test/sql/override_func_field_name.sql
@@ -6,7 +6,7 @@ begin;
     );
 
     -- Extend with function
-    create function full_name(rec public.account)
+    create function _full_name(rec public.account)
         returns text
         immutable
         strict
@@ -15,15 +15,13 @@ begin;
         select format('%s %s', rec.first_name, rec.last_name)
     $$;
 
-    comment on function public.full_name(public.account) is E'@graphql({"name": "wholeName"})';
+    comment on function public._full_name(public.account) is E'@graphql({"name": "wholeName"})';
 
     select
         name
     from
         graphql.field
     where
-        entity = 'public.account'::regclass
-        and func = 'full_name'::regproc
-        and meta_kind = 'Function';
+        func is not null;
 
 rollback;


### PR DESCRIPTION
## What kind of change does this PR introduce?
* [x] remove auto-inflection
* [x] create schema level comment directive `@graphql({"inflect_names": true})` to enable inflection
* [x] get the existing test suite passing with no edits to `.out` files
* [x] add a test to check names and types of all combinations of
   - inflected
   - not inflected
   - overrides (everywhere applicable)

