### PR TITLE
remove dependency on pgcrypto

### DIFF
--- a/bin/commands/build
+++ b/bin/commands/build
@@ -13,7 +13,6 @@ cli_log "Build starting"
 
 cat \
     src/sql/init.sql \
-    src/sql/hash/*.sql \
     src/sql/jsonb/*.sql \
     src/sql/random/*.sql \
     src/sql/pg/*.sql \

--- a/dockerfiles/db/setup.sql
+++ b/dockerfiles/db/setup.sql
@@ -1,6 +1,8 @@
+create schema if not exists extensions;
+
 create role anon;
 create extension if not exists "uuid-ossp";
-create extension if not exists pg_graphql cascade;
+create extension if not exists pg_graphql with schema extensions cascade;
 
 grant usage on schema public to anon;
 alter default privileges in schema public grant all on tables to anon;

--- a/pg_graphql--0.1.0.sql
+++ b/pg_graphql--0.1.0.sql
@@ -1,12 +1,4 @@
 create schema if not exists graphql;
-create or replace function graphql.sha1(text)
-    returns text
-    strict
-    immutable
-    language sql
-as $$
-    select encode(digest($1, 'sha1'), 'hex')
-$$;
 create or replace function graphql.jsonb_coalesce(val jsonb, default_ jsonb)
     returns jsonb
     strict
@@ -4228,7 +4220,7 @@ create or replace function graphql.cache_key(role regrole, ast jsonb, variables 
 as $$
     select
         -- Different roles may have different levels of access
-        graphql.sha1(
+        md5(
             $1::text
             -- Parsed query hash
             || ast::text
@@ -4357,7 +4349,7 @@ declare
         case
             when operation = 'Query' then graphql.cache_key(current_user::regrole, ast, variables)
             -- If not a query (mutation) don't attempt to cache
-            else graphql.sha1(format('%s%s%s',random(),random(),random()))
+            else md5(format('%s%s%s',random(),random(),random()))
         end
     );
 

--- a/pg_graphql.control
+++ b/pg_graphql.control
@@ -1,4 +1,3 @@
 comment = 'GraphQL support'
 default_version = '0.1.0'
 relocatable = false
-requires = pgcrypto

--- a/src/sql/hash/sha1.sql
+++ b/src/sql/hash/sha1.sql
@@ -1,8 +1,0 @@
-create or replace function graphql.sha1(text)
-    returns text
-    strict
-    immutable
-    language sql
-as $$
-    select encode(digest($1, 'sha1'), 'hex')
-$$;

--- a/src/sql/resolve/cache/cache_key.sql
+++ b/src/sql/resolve/cache/cache_key.sql
@@ -5,7 +5,7 @@ create or replace function graphql.cache_key(role regrole, ast jsonb, variables 
 as $$
     select
         -- Different roles may have different levels of access
-        graphql.sha1(
+        md5(
             $1::text
             -- Parsed query hash
             || ast::text

--- a/src/sql/resolve/resolve.sql
+++ b/src/sql/resolve/resolve.sql
@@ -24,7 +24,7 @@ declare
         case
             when operation = 'Query' then graphql.cache_key(current_user::regrole, ast, variables)
             -- If not a query (mutation) don't attempt to cache
-            else graphql.sha1(format('%s%s%s',random(),random(),random()))
+            else md5(format('%s%s%s',random(),random(),random()))
         end
     );
 

--- a/test/expected/resolve___schema.out
+++ b/test/expected/resolve___schema.out
@@ -16,7 +16,7 @@ begin;
     );
     create type blog_post_status as enum ('PENDING', 'RELEASED');
     create table blog_post(
-        id uuid not null default uuid_generate_v4() primary key,
+        id uuid not null default gen_random_uuid() primary key,
         blog_id integer not null references blog(id),
         title varchar(255) not null,
         body varchar(10000),

--- a/test/expected/resolve_graphiql_schema.out
+++ b/test/expected/resolve_graphiql_schema.out
@@ -17,7 +17,7 @@ begin;
     );
     create type blog_post_status as enum ('PENDING', 'RELEASED');
     create table blog_post(
-        id uuid not null default uuid_generate_v4() primary key,
+        id uuid not null default gen_random_uuid() primary key,
         blog_id integer not null references blog(id),
         title varchar(255) not null,
         body varchar(10000),

--- a/test/fixtures.sql
+++ b/test/fixtures.sql
@@ -1,5 +1,3 @@
 create extension pg_graphql cascade;
-create extension "uuid-ossp";
-
 
 comment on schema public is '@graphql({"inflect_names": true})';

--- a/test/sql/resolve___schema.sql
+++ b/test/sql/resolve___schema.sql
@@ -23,7 +23,7 @@ begin;
 
 
     create table blog_post(
-        id uuid not null default uuid_generate_v4() primary key,
+        id uuid not null default gen_random_uuid() primary key,
         blog_id integer not null references blog(id),
         title varchar(255) not null,
         body varchar(10000),

--- a/test/sql/resolve_graphiql_schema.sql
+++ b/test/sql/resolve_graphiql_schema.sql
@@ -24,7 +24,7 @@ begin;
 
 
     create table blog_post(
-        id uuid not null default uuid_generate_v4() primary key,
+        id uuid not null default gen_random_uuid() primary key,
         blog_id integer not null references blog(id),
         title varchar(255) not null,
         body varchar(10000),


### PR DESCRIPTION
enables selecting an install schema
```sql
create extension if not exists pg_graphql with schema extensions cascade;
```
without using the schema name placeholder throughout the codebase