### PR TITLE
Support multiple operations in single request

### DIFF
--- a/pg_graphql--0.1.2.sql
+++ b/pg_graphql--0.1.2.sql
@@ -4355,26 +4355,26 @@ declare
     ---------------------
     parsed graphql.parse_result = graphql.parse(stmt);
     ast jsonb = parsed.ast;
-    variable_definitions jsonb = coalesce(graphql.variable_definitions_sort(ast -> 'definitions' -> 0 -> 'variableDefinitions'), '[]');
+    n_statements int = jsonb_array_length(ast -> 'definitions' -> 0 -> 'selectionSet' -> 'selections');
+
+    -- AST for the operation part of the def, not e.g. fragments
+    ast_operation jsonb = jsonb_path_query_first(ast, '$.definitions[*] ? (@.kind == "OperationDefinition")');
+
+    variable_definitions jsonb = coalesce(graphql.variable_definitions_sort(ast_operation -> 'variableDefinitions'), '[]');
 
     -- Query or Mutation?
     operation graphql.meta_kind = (
-        case (ast -> 'definitions' -> 0 ->> 'operation')
+        case (ast_operation ->> 'operation')
             when 'mutation' then 'Mutation'
             when 'query' then 'Query'
         end
     );
 
-    prepared_statement_name text = (
-        case
-            when operation = 'Query' then graphql.cache_key(current_user::regrole, ast, variables)
-            -- If not a query (mutation) don't attempt to cache
-            else md5(format('%s%s%s',random(),random(),random()))
-        end
-    );
+    prepared_statement_name text;
 
     q text;
     data_ jsonb;
+    request_data jsonb;
     errors_ text[] = case when parsed.error is null then '{}' else array[parsed.error] end;
 
     ---------------------
@@ -4382,12 +4382,12 @@ declare
     ---------------------
 
     -- AST without location info ("loc" key)
+    ast_statement jsonb;
     ast_locless jsonb;
 
     -- ast with fragments inlined
     fragment_definitions jsonb;
     ast_inlined jsonb;
-    ast_operation jsonb;
 
     meta_kind graphql.meta_kind;
     field_meta_kind graphql.field_meta_kind;
@@ -4395,142 +4395,162 @@ declare
     -- Exception stack
     error_message text;
 begin
-    -- Build query if not in cache
-    if errors_ = '{}' and not graphql.prepared_statement_exists(prepared_statement_name) then
 
-        begin
+    begin
 
-            ast_locless = graphql.ast_pass_strip_loc(ast);
-            fragment_definitions = jsonb_path_query_array(ast_locless, '$.definitions[*] ? (@.kind == "FragmentDefinition")');
-            -- Skip fragment inline when no fragments are present
-            ast_inlined = case
-                when fragment_definitions = '[]'::jsonb then ast_locless
-                else graphql.ast_pass_fragments(ast_locless, fragment_definitions)
-            end;
+        -- Build query if not in cache
+        if errors_ = '{}' then
 
-            ast_operation = ast_inlined -> 'definitions' -> 0 -> 'selectionSet' -> 'selections' -> 0;
+            for statement_ix in 0..(n_statements - 1) loop
 
-            field_meta_kind = f.meta_kind
-                from
-                    graphql.field f
-                where
-                    f.parent_type = operation::text
-                    and f.name = graphql.name_literal(ast_operation);
-
-            if field_meta_kind is null then
-                perform graphql.exception_unknown_field(
-                    graphql.name_literal(ast_operation),
-                    operation::text
+                ast_statement = (
+                     ast_operation -> 'selectionSet' -> 'selections' -> statement_ix
                 );
-            end if;
 
-            q = case field_meta_kind
-                when 'Mutation.insert' then
-                    graphql.build_insert(
-                        ast := ast_operation,
-                        variable_definitions := variable_definitions,
-                        variables := variables
-                    )
-                when 'Mutation.delete' then
-                    graphql.build_delete(
-                        ast := ast_operation,
-                        variable_definitions := variable_definitions,
-                        variables := variables
-                    )
-                when 'Mutation.update' then
-                    graphql.build_update(
-                        ast := ast_operation,
-                        variable_definitions := variable_definitions,
-                        variables := variables
-                    )
-                when 'Query.collection' then
-                        graphql.build_connection_query(
-                            ast := ast_operation,
-                            variable_definitions := variable_definitions,
-                            variables := variables,
-                            parent_type :=  'Query',
-                            parent_block_name := null
-                        )
-                when 'Query.heartbeat' then graphql.build_heartbeat_query(ast_operation)
-            end;
+                prepared_statement_name = (
+                    case
+                        when operation = 'Query' then graphql.cache_key(current_user::regrole, ast_statement, variables)
+                        -- If not a query (mutation) don't attempt to cache
+                        else md5(format('%s%s%s',random(),random(),random()))
+                    end
+                );
 
-            if q is null and operation = 'Query' then
+                if errors_ = '{}' and not graphql.prepared_statement_exists(prepared_statement_name) then
 
-                meta_kind = type_.meta_kind
-                    from
-                        graphql.field
-                        join graphql.type type_
-                            on field.type_ = type_.name
-                    where
-                        field.parent_type = 'Query'
-                        and field.name = graphql.name_literal(ast_operation);
+                        ast_locless = graphql.ast_pass_strip_loc(ast_statement);
+                        fragment_definitions = graphql.ast_pass_strip_loc(
+                            jsonb_path_query_array(ast, '$.definitions[*] ? (@.kind == "FragmentDefinition")')
+                        );
+                        -- Skip fragment inline when no fragments are present
+                        ast_inlined = case
+                            when fragment_definitions = '[]'::jsonb then ast_locless
+                            else graphql.ast_pass_fragments(ast_locless, fragment_definitions)
+                        end;
 
-                if meta_kind is null then
-                    perform graphql.exception_unknown_field(
-                        graphql.name_literal(ast_operation),
-                        'Query'
+                        field_meta_kind = f.meta_kind
+                            from
+                                graphql.field f
+                            where
+                                f.parent_type = operation::text
+                                and f.name = graphql.name_literal(ast_inlined);
+
+                        if field_meta_kind is null then
+                            perform graphql.exception_unknown_field(
+                                graphql.name_literal(ast_inlined),
+                                operation::text
+                            );
+                        end if;
+
+                        q = case field_meta_kind
+                            when 'Mutation.insert' then
+                                graphql.build_insert(
+                                    ast := ast_inlined,
+                                    variable_definitions := variable_definitions,
+                                    variables := variables
+                                )
+                            when 'Mutation.delete' then
+                                graphql.build_delete(
+                                    ast := ast_inlined,
+                                    variable_definitions := variable_definitions,
+                                    variables := variables
+                                )
+                            when 'Mutation.update' then
+                                graphql.build_update(
+                                    ast := ast_inlined,
+                                    variable_definitions := variable_definitions,
+                                    variables := variables
+                                )
+                            when 'Query.collection' then
+                                    graphql.build_connection_query(
+                                        ast := ast_inlined,
+                                        variable_definitions := variable_definitions,
+                                        variables := variables,
+                                        parent_type :=  'Query',
+                                        parent_block_name := null
+                                    )
+                            when 'Query.heartbeat' then graphql.build_heartbeat_query(ast_inlined)
+                        end;
+
+                        if q is null and operation = 'Query' then
+
+                            meta_kind = type_.meta_kind
+                                from
+                                    graphql.field
+                                    join graphql.type type_
+                                        on field.type_ = type_.name
+                                where
+                                    field.parent_type = 'Query'
+                                    and field.name = graphql.name_literal(ast_inlined);
+
+                            if meta_kind is null then
+                                perform graphql.exception_unknown_field(
+                                    graphql.name_literal(ast_inlined),
+                                    'Query'
+                                );
+                            end if;
+
+                            data_ = case meta_kind
+                                when '__Schema' then
+                                    graphql."resolve___Schema"(
+                                        ast := ast_inlined,
+                                        variable_definitions := variable_definitions
+                                    )
+                                when '__Type' then
+                                    jsonb_build_object(
+                                        graphql.name_literal(ast_inlined),
+                                        graphql."resolve___Type"(
+                                            (
+                                                select
+                                                    name
+                                                from
+                                                    graphql.type type_
+                                                where
+                                                    name = graphql.argument_value_by_name('name', ast_inlined)
+                                            ),
+                                            ast_inlined
+                                        )
+                                    )
+                                else null::jsonb
+                            end;
+                        end if;
+                end if;
+
+                if errors_ = '{}' and q is not null then
+                    execute graphql.prepared_statement_create_clause(prepared_statement_name, variable_definitions, q);
+                end if;
+
+                if errors_ = '{}' and data_ is null then
+                    -- Call prepared statement respecting passed values and variable definition defaults
+                    execute graphql.prepared_statement_execute_clause(prepared_statement_name, variable_definitions, variables) into data_;
+                    data_ = jsonb_build_object(
+                        graphql.alias_or_name_literal(ast_statement),
+                        data_
                     );
                 end if;
 
-                data_ = case meta_kind
-                    when '__Schema' then
-                        graphql."resolve___Schema"(
-                            ast := ast_operation,
-                            variable_definitions := variable_definitions
-                        )
-                    when '__Type' then
-                        jsonb_build_object(
-                            graphql.name_literal(ast_operation),
-                            graphql."resolve___Type"(
-                                (
-                                    select
-                                        name
-                                    from
-                                        graphql.type type_
-                                    where
-                                        name = graphql.argument_value_by_name('name', ast_operation)
-                                ),
-                                ast_operation
-                            )
-                        )
-                    else null::jsonb
+                -- Add data to final state
+                request_data = case
+                    when request_data is null then data_
+                    else request_data || data_
                 end;
-            end if;
 
-        exception when others then
-            -- https://stackoverflow.com/questions/56595217/get-error-message-from-error-code-postgresql
-            get stacked diagnostics error_message = MESSAGE_TEXT;
-            errors_ = errors_ || error_message;
-        end;
+                -- reset loop vars
+                q = null;
+                data_ = null;
 
-    end if;
+            end loop;
+        end if;
 
-    if errors_ = '{}' and q is not null then
-        begin
-            execute graphql.prepared_statement_create_clause(prepared_statement_name, variable_definitions, q);
-        exception when others then
-            get stacked diagnostics error_message = MESSAGE_TEXT;
-            errors_ = errors_ || error_message;
-        end;
-    end if;
+    exception when others then
+        get stacked diagnostics error_message = MESSAGE_TEXT;
+        errors_ = errors_ || error_message;
+        -- Do no show partial or rolled back results
+        request_data = null;
+    end;
 
-    if errors_ = '{}' and data_ is null then
-        begin
-            -- Call prepared statement respecting passed values and variable definition defaults
-            execute graphql.prepared_statement_execute_clause(prepared_statement_name, variable_definitions, variables) into data_;
-            data_ = jsonb_build_object(
-                graphql.alias_or_name_literal(ast -> 'definitions' -> 0 -> 'selectionSet' -> 'selections' -> 0),
-                data_
-            );
-        exception when others then
-            -- https://stackoverflow.com/questions/56595217/get-error-message-from-error-code-postgresql
-            get stacked diagnostics error_message = MESSAGE_TEXT;
-            errors_ = errors_ || error_message;
-        end;
-    end if;
 
     return jsonb_build_object(
-        'data', data_,
+        'data', request_data,
         'errors', to_jsonb(errors_)
     );
 end

--- a/src/sql/resolve/resolve.sql
+++ b/src/sql/resolve/resolve.sql
@@ -10,26 +10,26 @@ declare
     ---------------------
     parsed graphql.parse_result = graphql.parse(stmt);
     ast jsonb = parsed.ast;
-    variable_definitions jsonb = coalesce(graphql.variable_definitions_sort(ast -> 'definitions' -> 0 -> 'variableDefinitions'), '[]');
+    n_statements int = jsonb_array_length(ast -> 'definitions' -> 0 -> 'selectionSet' -> 'selections');
+
+    -- AST for the operation part of the def, not e.g. fragments
+    ast_operation jsonb = jsonb_path_query_first(ast, '$.definitions[*] ? (@.kind == "OperationDefinition")');
+
+    variable_definitions jsonb = coalesce(graphql.variable_definitions_sort(ast_operation -> 'variableDefinitions'), '[]');
 
     -- Query or Mutation?
     operation graphql.meta_kind = (
-        case (ast -> 'definitions' -> 0 ->> 'operation')
+        case (ast_operation ->> 'operation')
             when 'mutation' then 'Mutation'
             when 'query' then 'Query'
         end
     );
 
-    prepared_statement_name text = (
-        case
-            when operation = 'Query' then graphql.cache_key(current_user::regrole, ast, variables)
-            -- If not a query (mutation) don't attempt to cache
-            else md5(format('%s%s%s',random(),random(),random()))
-        end
-    );
+    prepared_statement_name text;
 
     q text;
     data_ jsonb;
+    request_data jsonb;
     errors_ text[] = case when parsed.error is null then '{}' else array[parsed.error] end;
 
     ---------------------
@@ -37,12 +37,12 @@ declare
     ---------------------
 
     -- AST without location info ("loc" key)
+    ast_statement jsonb;
     ast_locless jsonb;
 
     -- ast with fragments inlined
     fragment_definitions jsonb;
     ast_inlined jsonb;
-    ast_operation jsonb;
 
     meta_kind graphql.meta_kind;
     field_meta_kind graphql.field_meta_kind;
@@ -50,142 +50,162 @@ declare
     -- Exception stack
     error_message text;
 begin
-    -- Build query if not in cache
-    if errors_ = '{}' and not graphql.prepared_statement_exists(prepared_statement_name) then
 
-        begin
+    begin
 
-            ast_locless = graphql.ast_pass_strip_loc(ast);
-            fragment_definitions = jsonb_path_query_array(ast_locless, '$.definitions[*] ? (@.kind == "FragmentDefinition")');
-            -- Skip fragment inline when no fragments are present
-            ast_inlined = case
-                when fragment_definitions = '[]'::jsonb then ast_locless
-                else graphql.ast_pass_fragments(ast_locless, fragment_definitions)
-            end;
+        -- Build query if not in cache
+        if errors_ = '{}' then
 
-            ast_operation = ast_inlined -> 'definitions' -> 0 -> 'selectionSet' -> 'selections' -> 0;
+            for statement_ix in 0..(n_statements - 1) loop
 
-            field_meta_kind = f.meta_kind
-                from
-                    graphql.field f
-                where
-                    f.parent_type = operation::text
-                    and f.name = graphql.name_literal(ast_operation);
-
-            if field_meta_kind is null then
-                perform graphql.exception_unknown_field(
-                    graphql.name_literal(ast_operation),
-                    operation::text
+                ast_statement = (
+                     ast_operation -> 'selectionSet' -> 'selections' -> statement_ix
                 );
-            end if;
 
-            q = case field_meta_kind
-                when 'Mutation.insert' then
-                    graphql.build_insert(
-                        ast := ast_operation,
-                        variable_definitions := variable_definitions,
-                        variables := variables
-                    )
-                when 'Mutation.delete' then
-                    graphql.build_delete(
-                        ast := ast_operation,
-                        variable_definitions := variable_definitions,
-                        variables := variables
-                    )
-                when 'Mutation.update' then
-                    graphql.build_update(
-                        ast := ast_operation,
-                        variable_definitions := variable_definitions,
-                        variables := variables
-                    )
-                when 'Query.collection' then
-                        graphql.build_connection_query(
-                            ast := ast_operation,
-                            variable_definitions := variable_definitions,
-                            variables := variables,
-                            parent_type :=  'Query',
-                            parent_block_name := null
-                        )
-                when 'Query.heartbeat' then graphql.build_heartbeat_query(ast_operation)
-            end;
+                prepared_statement_name = (
+                    case
+                        when operation = 'Query' then graphql.cache_key(current_user::regrole, ast_statement, variables)
+                        -- If not a query (mutation) don't attempt to cache
+                        else md5(format('%s%s%s',random(),random(),random()))
+                    end
+                );
 
-            if q is null and operation = 'Query' then
+                if errors_ = '{}' and not graphql.prepared_statement_exists(prepared_statement_name) then
 
-                meta_kind = type_.meta_kind
-                    from
-                        graphql.field
-                        join graphql.type type_
-                            on field.type_ = type_.name
-                    where
-                        field.parent_type = 'Query'
-                        and field.name = graphql.name_literal(ast_operation);
+                        ast_locless = graphql.ast_pass_strip_loc(ast_statement);
+                        fragment_definitions = graphql.ast_pass_strip_loc(
+                            jsonb_path_query_array(ast, '$.definitions[*] ? (@.kind == "FragmentDefinition")')
+                        );
+                        -- Skip fragment inline when no fragments are present
+                        ast_inlined = case
+                            when fragment_definitions = '[]'::jsonb then ast_locless
+                            else graphql.ast_pass_fragments(ast_locless, fragment_definitions)
+                        end;
 
-                if meta_kind is null then
-                    perform graphql.exception_unknown_field(
-                        graphql.name_literal(ast_operation),
-                        'Query'
+                        field_meta_kind = f.meta_kind
+                            from
+                                graphql.field f
+                            where
+                                f.parent_type = operation::text
+                                and f.name = graphql.name_literal(ast_inlined);
+
+                        if field_meta_kind is null then
+                            perform graphql.exception_unknown_field(
+                                graphql.name_literal(ast_inlined),
+                                operation::text
+                            );
+                        end if;
+
+                        q = case field_meta_kind
+                            when 'Mutation.insert' then
+                                graphql.build_insert(
+                                    ast := ast_inlined,
+                                    variable_definitions := variable_definitions,
+                                    variables := variables
+                                )
+                            when 'Mutation.delete' then
+                                graphql.build_delete(
+                                    ast := ast_inlined,
+                                    variable_definitions := variable_definitions,
+                                    variables := variables
+                                )
+                            when 'Mutation.update' then
+                                graphql.build_update(
+                                    ast := ast_inlined,
+                                    variable_definitions := variable_definitions,
+                                    variables := variables
+                                )
+                            when 'Query.collection' then
+                                    graphql.build_connection_query(
+                                        ast := ast_inlined,
+                                        variable_definitions := variable_definitions,
+                                        variables := variables,
+                                        parent_type :=  'Query',
+                                        parent_block_name := null
+                                    )
+                            when 'Query.heartbeat' then graphql.build_heartbeat_query(ast_inlined)
+                        end;
+
+                        if q is null and operation = 'Query' then
+
+                            meta_kind = type_.meta_kind
+                                from
+                                    graphql.field
+                                    join graphql.type type_
+                                        on field.type_ = type_.name
+                                where
+                                    field.parent_type = 'Query'
+                                    and field.name = graphql.name_literal(ast_inlined);
+
+                            if meta_kind is null then
+                                perform graphql.exception_unknown_field(
+                                    graphql.name_literal(ast_inlined),
+                                    'Query'
+                                );
+                            end if;
+
+                            data_ = case meta_kind
+                                when '__Schema' then
+                                    graphql."resolve___Schema"(
+                                        ast := ast_inlined,
+                                        variable_definitions := variable_definitions
+                                    )
+                                when '__Type' then
+                                    jsonb_build_object(
+                                        graphql.name_literal(ast_inlined),
+                                        graphql."resolve___Type"(
+                                            (
+                                                select
+                                                    name
+                                                from
+                                                    graphql.type type_
+                                                where
+                                                    name = graphql.argument_value_by_name('name', ast_inlined)
+                                            ),
+                                            ast_inlined
+                                        )
+                                    )
+                                else null::jsonb
+                            end;
+                        end if;
+                end if;
+
+                if errors_ = '{}' and q is not null then
+                    execute graphql.prepared_statement_create_clause(prepared_statement_name, variable_definitions, q);
+                end if;
+
+                if errors_ = '{}' and data_ is null then
+                    -- Call prepared statement respecting passed values and variable definition defaults
+                    execute graphql.prepared_statement_execute_clause(prepared_statement_name, variable_definitions, variables) into data_;
+                    data_ = jsonb_build_object(
+                        graphql.alias_or_name_literal(ast_statement),
+                        data_
                     );
                 end if;
 
-                data_ = case meta_kind
-                    when '__Schema' then
-                        graphql."resolve___Schema"(
-                            ast := ast_operation,
-                            variable_definitions := variable_definitions
-                        )
-                    when '__Type' then
-                        jsonb_build_object(
-                            graphql.name_literal(ast_operation),
-                            graphql."resolve___Type"(
-                                (
-                                    select
-                                        name
-                                    from
-                                        graphql.type type_
-                                    where
-                                        name = graphql.argument_value_by_name('name', ast_operation)
-                                ),
-                                ast_operation
-                            )
-                        )
-                    else null::jsonb
+                -- Add data to final state
+                request_data = case
+                    when request_data is null then data_
+                    else request_data || data_
                 end;
-            end if;
 
-        exception when others then
-            -- https://stackoverflow.com/questions/56595217/get-error-message-from-error-code-postgresql
-            get stacked diagnostics error_message = MESSAGE_TEXT;
-            errors_ = errors_ || error_message;
-        end;
+                -- reset loop vars
+                q = null;
+                data_ = null;
 
-    end if;
+            end loop;
+        end if;
 
-    if errors_ = '{}' and q is not null then
-        begin
-            execute graphql.prepared_statement_create_clause(prepared_statement_name, variable_definitions, q);
-        exception when others then
-            get stacked diagnostics error_message = MESSAGE_TEXT;
-            errors_ = errors_ || error_message;
-        end;
-    end if;
+    exception when others then
+        get stacked diagnostics error_message = MESSAGE_TEXT;
+        errors_ = errors_ || error_message;
+        -- Do no show partial or rolled back results
+        request_data = null;
+    end;
 
-    if errors_ = '{}' and data_ is null then
-        begin
-            -- Call prepared statement respecting passed values and variable definition defaults
-            execute graphql.prepared_statement_execute_clause(prepared_statement_name, variable_definitions, variables) into data_;
-            data_ = jsonb_build_object(
-                graphql.alias_or_name_literal(ast -> 'definitions' -> 0 -> 'selectionSet' -> 'selections' -> 0),
-                data_
-            );
-        exception when others then
-            -- https://stackoverflow.com/questions/56595217/get-error-message-from-error-code-postgresql
-            get stacked diagnostics error_message = MESSAGE_TEXT;
-            errors_ = errors_ || error_message;
-        end;
-    end if;
 
     return jsonb_build_object(
-        'data', data_,
+        'data', request_data,
         'errors', to_jsonb(errors_)
     );
 end

--- a/test/expected/multiple_mutations.out
+++ b/test/expected/multiple_mutations.out
@@ -1,0 +1,144 @@
+begin;
+    create table account(
+        id serial primary key,
+        email varchar(255) not null,
+        priority int
+    );
+    savepoint a;
+    -- Scenario: Two Mutations, both are vaild
+    select jsonb_pretty(graphql.resolve($$
+    mutation {
+      firstInsert: insertIntoAccountCollection(objects: [
+        { email: "foo@barsley.com", priority: 1 }
+      ]) {
+        affectedCount
+        records {
+          id
+          email
+        }
+      }
+
+      secondInsert: insertIntoAccountCollection(objects: [
+        { email: "bar@foosworth.com" }
+      ]) {
+        affectedCount
+        records {
+          id
+          email
+        }
+      }
+    }
+    $$));
+                   jsonb_pretty                   
+--------------------------------------------------
+ {                                               +
+     "data": {                                   +
+         "firstInsert": {                        +
+             "records": [                        +
+                 {                               +
+                     "id": 1,                    +
+                     "email": "foo@barsley.com"  +
+                 }                               +
+             ],                                  +
+             "affectedCount": 1                  +
+         },                                      +
+         "secondInsert": {                       +
+             "records": [                        +
+                 {                               +
+                     "id": 2,                    +
+                     "email": "bar@foosworth.com"+
+                 }                               +
+             ],                                  +
+             "affectedCount": 1                  +
+         }                                       +
+     },                                          +
+     "errors": [                                 +
+     ]                                           +
+ }
+(1 row)
+
+    select * from account;
+ id |       email       | priority 
+----+-------------------+----------
+  1 | foo@barsley.com   |        1
+  2 | bar@foosworth.com |         
+(2 rows)
+
+    rollback to savepoint a;
+    -- Scenario: Two Mutations, first one fails. Expect total rollback
+    select jsonb_pretty(graphql.resolve($$
+    mutation {
+      firstInsert: insertIntoAccountCollection(objects: [
+        { email: "foo@barsley.com", invalidKey: 1 }
+      ]) {
+        records {
+          id
+          email
+        }
+      }
+
+      secondInsert: insertIntoAccountCollection(objects: [
+        { email: "bar@foosworth.com" }
+      ]) {
+        records {
+          id
+          email
+        }
+      }
+    }
+    $$));
+             jsonb_pretty             
+--------------------------------------
+ {                                   +
+     "data": null,                   +
+     "errors": [                     +
+         "Unknown field 'invalidKey'"+
+     ]                               +
+ }
+(1 row)
+
+    select * from account;
+ id | email | priority 
+----+-------+----------
+(0 rows)
+
+    rollback to savepoint a;
+    -- Scenario: Two Mutations, second one fails. Expect total rollback
+    select jsonb_pretty(graphql.resolve($$
+    mutation {
+      secondInsert: insertIntoAccountCollection(objects: [
+        { email: "bar@foosworth.com" }
+      ]) {
+        records {
+          id
+          email
+        }
+      }
+
+    firstInsert: insertIntoAccountCollection(objects: [
+        { email: "foo@barsley.com", invalidKey: 1 }
+      ]) {
+        records {
+          id
+          email
+        }
+      }
+    }
+    $$));
+             jsonb_pretty             
+--------------------------------------
+ {                                   +
+     "data": null,                   +
+     "errors": [                     +
+         "Unknown field 'invalidKey'"+
+     ]                               +
+ }
+(1 row)
+
+    select * from account;
+ id | email | priority 
+----+-------+----------
+(0 rows)
+
+    rollback to savepoint a;
+rollback

--- a/test/expected/multiple_queries.out
+++ b/test/expected/multiple_queries.out
@@ -1,0 +1,68 @@
+begin;
+    create table account(
+        id serial primary key,
+        email varchar(255) not null,
+        priority int
+    );
+    insert into account(email)
+    values ('email_1'), ('email_2');
+    -- Scenario: Two queries
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              forward: accountCollection(orderBy: [{id: AscNullsFirst}]) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+              backward: accountCollection(orderBy: [{id: DescNullsFirst}]) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+        $$)
+    );
+          jsonb_pretty           
+---------------------------------
+ {                              +
+     "data": {                  +
+         "forward": {           +
+             "edges": [         +
+                 {              +
+                     "node": {  +
+                         "id": 1+
+                     }          +
+                 },             +
+                 {              +
+                     "node": {  +
+                         "id": 2+
+                     }          +
+                 }              +
+             ]                  +
+         },                     +
+         "backward": {          +
+             "edges": [         +
+                 {              +
+                     "node": {  +
+                         "id": 2+
+                     }          +
+                 },             +
+                 {              +
+                     "node": {  +
+                         "id": 1+
+                     }          +
+                 }              +
+             ]                  +
+         }                      +
+     },                         +
+     "errors": [                +
+     ]                          +
+ }
+(1 row)
+
+rollback

--- a/test/sql/multiple_mutations.sql
+++ b/test/sql/multiple_mutations.sql
@@ -1,0 +1,94 @@
+begin;
+
+    create table account(
+        id serial primary key,
+        email varchar(255) not null,
+        priority int
+    );
+
+    savepoint a;
+
+    -- Scenario: Two Mutations, both are vaild
+    select jsonb_pretty(graphql.resolve($$
+    mutation {
+      firstInsert: insertIntoAccountCollection(objects: [
+        { email: "foo@barsley.com", priority: 1 }
+      ]) {
+        affectedCount
+        records {
+          id
+          email
+        }
+      }
+
+      secondInsert: insertIntoAccountCollection(objects: [
+        { email: "bar@foosworth.com" }
+      ]) {
+        affectedCount
+        records {
+          id
+          email
+        }
+      }
+    }
+    $$));
+
+    select * from account;
+
+    rollback to savepoint a;
+
+    -- Scenario: Two Mutations, first one fails. Expect total rollback
+    select jsonb_pretty(graphql.resolve($$
+    mutation {
+      firstInsert: insertIntoAccountCollection(objects: [
+        { email: "foo@barsley.com", invalidKey: 1 }
+      ]) {
+        records {
+          id
+          email
+        }
+      }
+
+      secondInsert: insertIntoAccountCollection(objects: [
+        { email: "bar@foosworth.com" }
+      ]) {
+        records {
+          id
+          email
+        }
+      }
+    }
+    $$));
+
+    select * from account;
+
+    rollback to savepoint a;
+
+    -- Scenario: Two Mutations, second one fails. Expect total rollback
+    select jsonb_pretty(graphql.resolve($$
+    mutation {
+      secondInsert: insertIntoAccountCollection(objects: [
+        { email: "bar@foosworth.com" }
+      ]) {
+        records {
+          id
+          email
+        }
+      }
+
+    firstInsert: insertIntoAccountCollection(objects: [
+        { email: "foo@barsley.com", invalidKey: 1 }
+      ]) {
+        records {
+          id
+          email
+        }
+      }
+    }
+    $$));
+
+    select * from account;
+
+    rollback to savepoint a;
+
+rollback

--- a/test/sql/multiple_queries.sql
+++ b/test/sql/multiple_queries.sql
@@ -1,0 +1,34 @@
+begin;
+
+    create table account(
+        id serial primary key,
+        email varchar(255) not null,
+        priority int
+    );
+
+    insert into account(email)
+    values ('email_1'), ('email_2');
+
+    -- Scenario: Two queries
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              forward: accountCollection(orderBy: [{id: AscNullsFirst}]) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+              backward: accountCollection(orderBy: [{id: DescNullsFirst}]) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+        $$)
+    );
+
+rollback


### PR DESCRIPTION
## What kind of change does this PR introduce?
resolves #126 

Example:
```graphql
{
  forward: accountCollection(orderBy: [{id: AscNullsFirst}]) {
    edges {
      node {
        id
      }
    }
  }
  backward: accountCollection(orderBy: [{id: DescNullsFirst}]) {
    edges {
      node {
        id
      }
    }
  }
}
```