### PR TITLE
Passing null value for cursor as variable treated as omitting cursor arg

### DIFF
--- a/src/sql/resolve/transpile/build_connection.sql
+++ b/src/sql/resolve/transpile/build_connection.sql
@@ -34,6 +34,21 @@ declare
     before_ text = graphql.arg_clause('before', arguments, variable_definitions, entity);
     after_ text = graphql.arg_clause('after',  arguments, variable_definitions, entity);
 
+    -- If before or after is provided as a variable, and the value of the variable
+    -- is explicitly null, we must treat it as though the value were not provided
+    cursor_arg_ast jsonb = coalesce(
+        graphql.get_arg_by_name('before', graphql.jsonb_coalesce(arguments, '[]')),
+        graphql.get_arg_by_name('after', graphql.jsonb_coalesce(arguments, '[]'))
+    );
+    cursor_var_name text = case graphql.is_variable(
+            coalesce(cursor_arg_ast,'{}'::jsonb) -> 'value'
+        )
+        when true then graphql.name_literal(cursor_arg_ast -> 'value')
+        else null
+    end;
+    cursor_var_ix int = graphql.arg_index(cursor_var_name, variable_definitions);
+
+
     order_by_arg jsonb = graphql.get_arg_by_name('orderBy',  arguments);
     filter_arg jsonb = graphql.get_arg_by_name('filter',  arguments);
 
@@ -268,7 +283,7 @@ begin
             where
                 true
                 --pagination_clause
-                and %s %s %s
+                and ((%s is null) or (%s %s %s))
                 -- join clause
                 and %s
                 -- where clause
@@ -343,6 +358,7 @@ begin
             entity,
             block_name,
             -- pagination
+            case when cursor_var_ix is null then '1' else format('$%s', cursor_var_ix) end,
             case when coalesce(after_, before_) is null then 'true' else graphql.cursor_row_clause(entity, block_name) end,
             case when after_ is not null then '>' when before_ is not null then '<' else '=' end,
             case when coalesce(after_, before_) is null then 'true' else coalesce(after_, before_) end,

--- a/test/expected/resolve_connection_pagination_args.out
+++ b/test/expected/resolve_connection_pagination_args.out
@@ -82,6 +82,83 @@ begin;
  }
 (1 row)
 
+    -- First with after = null same as omitting after
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              accountCollection(first: 2, after: null) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+        $$)
+    );
+          jsonb_pretty           
+---------------------------------
+ {                              +
+     "data": {                  +
+         "accountCollection": { +
+             "edges": [         +
+                 {              +
+                     "node": {  +
+                         "id": 1+
+                     }          +
+                 },             +
+                 {              +
+                     "node": {  +
+                         "id": 2+
+                     }          +
+                 }              +
+             ]                  +
+         }                      +
+     },                         +
+     "errors": [                +
+     ]                          +
+ }
+(1 row)
+
+    -- First with after = null as variable same as omitting after
+    select jsonb_pretty(
+        graphql.resolve($$
+            query ABC($afterCursor: Cursor){
+              accountCollection(first: 2, after: $afterCursor) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+        $$,
+        variables := '{"afterCursor": null}'
+    ));
+          jsonb_pretty           
+---------------------------------
+ {                              +
+     "data": {                  +
+         "accountCollection": { +
+             "edges": [         +
+                 {              +
+                     "node": {  +
+                         "id": 1+
+                     }          +
+                 },             +
+                 {              +
+                     "node": {  +
+                         "id": 2+
+                     }          +
+                 }              +
+             ]                  +
+         }                      +
+     },                         +
+     "errors": [                +
+     ]                          +
+ }
+(1 row)
+
     -- last before
     select jsonb_pretty(
         graphql.resolve($$

--- a/test/sql/resolve_connection_pagination_args.sql
+++ b/test/sql/resolve_connection_pagination_args.sql
@@ -39,6 +39,37 @@ begin;
         $$)
     );
 
+    -- First with after = null same as omitting after
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              accountCollection(first: 2, after: null) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+        $$)
+    );
+
+    -- First with after = null as variable same as omitting after
+    select jsonb_pretty(
+        graphql.resolve($$
+            query ABC($afterCursor: Cursor){
+              accountCollection(first: 2, after: $afterCursor) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+        $$,
+        variables := '{"afterCursor": null}'
+    ));
+
     -- last before
     select jsonb_pretty(
         graphql.resolve($$


### PR DESCRIPTION
## What kind of change does this PR introduce?
Passing null value for cursor as variable treated as omitting cursor arg
 
## What is the current behavior?
Passing null value for a cursor (before or after argument) as a variable filters out all results

Please link any relevant issues here.
#127 

## What is the new behavior?
Passing null value for cursor as variable treated as omitting cursor arg