### PR TITLE
Require manual calls to graphql.rebuild_schema()

### DIFF
--- a/dockerfiles/db/setup.sql
+++ b/dockerfiles/db/setup.sql
@@ -78,3 +78,6 @@ values
 
 
 comment on schema public is '@graphql({"inflect_names": true})';
+
+-- Sync the GraphQL schema
+select graphql.rebuild_schema();

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,4 +1,31 @@
-The public facing API consists of a single SQL function that resolves GraphQL queries. All other entities in the `graphql` schema are private.
+The public facing API consists of a two SQL functions. One resolves GraphQL queries and the other rebuild the GraphQL schema. All other entities in the `graphql` schema are private.
+
+
+### graphql.rebuild_schema
+
+##### description
+Re-synchronizes the GraphQL schema cache with the SQL schema.
+
+##### signature
+```sql
+graphql.rebuild_schema()
+    returns void
+    language plpgsql
+```
+
+##### usage
+```sql
+-- Create the extension
+graphqldb= create extension pg_graphql cascade;
+CREATE EXTENSION
+
+-- Rebuild the GraphQL schema
+graphqldb= select graphql.rebuild_schema();
+
+ rebuild_schema
+----------------
+(1 row)
+```
 
 ### graphql.resolve
 
@@ -31,6 +58,13 @@ CREATE EXTENSION
 -- Create an example table
 graphqldb= create table book(id int primary key, title text);
 CREATE TABLE
+
+-- Rebuild the GraphQL schema
+graphqldb= select graphql.rebuild_schema();
+
+ rebuild_schema
+----------------
+(1 row)
 
 -- Insert a record
 graphqldb= insert into book(id, title) values (1, 'book 1');

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -36,6 +36,12 @@ CREATE TABLE
 
 graphqldb= insert into book(id, title) values (1, 'book 1');
 INSERT 0 1
+
+graphqldb= select graphql.rebuild_schema();
+
+ rebuild_schema
+----------------
+(1 row)
 ```
 
 Finally, execute some graphql queries against the table.

--- a/pg_graphql--0.1.2.sql
+++ b/pg_graphql--0.1.2.sql
@@ -4672,11 +4672,3 @@ end;
 $$;
 
 select graphql.rebuild_schema();
-
-create event trigger graphql_watch_ddl
-    on ddl_command_end
-    execute procedure graphql.rebuild_on_ddl();
-
-create event trigger graphql_watch_drop
-    on sql_drop
-    execute procedure graphql.rebuild_on_drop();

--- a/src/sql/reflection/rebuild_schema.sql
+++ b/src/sql/reflection/rebuild_schema.sql
@@ -83,11 +83,3 @@ end;
 $$;
 
 select graphql.rebuild_schema();
-
-create event trigger graphql_watch_ddl
-    on ddl_command_end
-    execute procedure graphql.rebuild_on_ddl();
-
-create event trigger graphql_watch_drop
-    on sql_drop
-    execute procedure graphql.rebuild_on_drop();

--- a/test/fixtures.sql
+++ b/test/fixtures.sql
@@ -1,3 +1,14 @@
 create extension pg_graphql cascade;
 
 comment on schema public is '@graphql({"inflect_names": true})';
+
+-- Event triggers to watch for DDL and rebuild the schem
+-- So we don't need to call `graphql.rebuild_schema()` manually
+-- in each test
+create event trigger graphql_watch_ddl
+    on ddl_command_end
+    execute procedure graphql.rebuild_on_ddl();
+
+create event trigger graphql_watch_drop
+    on sql_drop
+    execute procedure graphql.rebuild_on_drop();


### PR DESCRIPTION
## What kind of change does this PR introduce?
Removes the automatic rebuild of graphql schema on DDL event. It is too slow in cases where migration include many ddl steps (particularly on free tier projects)
