### PR TITLE
Explicitly typecast Update Mutation `set` argument

### DIFF
--- a/pg_graphql--0.2.0.sql
+++ b/pg_graphql--0.2.0.sql
@@ -3866,7 +3866,7 @@ begin
         select
             string_agg(
                 format(
-                    '%I = $%s::jsonb -> %L',
+                    '%I = ($%s::jsonb -> %L)::%s',
                     case
                         when ac.column_name is not null then ac.column_name
                         else graphql.exception_unknown_field(x.key_, f.type_)
@@ -3875,7 +3875,8 @@ begin
                         graphql.name_literal(set_arg -> 'value'),
                         variable_definitions
                     ),
-                    x.key_
+                    x.key_,
+                    ac.column_type
                 ),
                 ', '
             )
@@ -3892,7 +3893,7 @@ begin
             string_agg(
                 case
                     when graphql.is_variable(val -> 'value') then format(
-                        '%I = $%s',
+                        '%I = ($%s)::%s',
                         case
                             when ac.meta_kind = 'Column' then ac.column_name
                             else graphql.exception_unknown_field(graphql.name_literal(val), field_rec.type_)
@@ -3900,15 +3901,18 @@ begin
                         graphql.arg_index(
                             (val -> 'value' -> 'name' ->> 'value'),
                             variable_definitions
-                        )
+                        ),
+                        ac.column_type
+
                     )
                     else format(
-                        '%I = %L',
+                        '%I = (%L)::%s',
                         case
                             when ac.meta_kind = 'Column' then ac.column_name
                             else graphql.exception_unknown_field(graphql.name_literal(val), field_rec.type_)
                         end,
-                        graphql.value_literal(val)
+                        graphql.value_literal(val),
+                        ac.column_type
                     )
                 end,
                 ', '

--- a/test/expected/mutation_update.out
+++ b/test/expected/mutation_update.out
@@ -199,4 +199,25 @@ begin;
  {"data": {"updateAccountCollection": {"records": [{"id": 2}]}}}
 (1 row)
 
+    -- pass integer as a variable to `set`
+    -- https://twitter.com/aiji42_dev/status/1512305435017023489
+    select graphql.resolve($$
+        mutation SetVar($ownerId: Int) {
+          updateBlogCollection(
+            set: {
+              ownerId: $ownerId
+            }
+            atMost: 10
+          ) {
+            records { ownerId }
+          }
+        }
+    $$,
+    '{"ownerId": 1}'
+);
+                                                      resolve                                                      
+-------------------------------------------------------------------------------------------------------------------
+ {"data": {"updateBlogCollection": {"records": [{"ownerId": 1}, {"ownerId": 1}, {"ownerId": 1}, {"ownerId": 1}]}}}
+(1 row)
+
 rollback;

--- a/test/sql/mutation_update.sql
+++ b/test/sql/mutation_update.sql
@@ -150,4 +150,22 @@ begin;
         }
     $$);
 
+    -- pass integer as a variable to `set`
+    -- https://twitter.com/aiji42_dev/status/1512305435017023489
+    select graphql.resolve($$
+        mutation SetVar($ownerId: Int) {
+          updateBlogCollection(
+            set: {
+              ownerId: $ownerId
+            }
+            atMost: 10
+          ) {
+            records { ownerId }
+          }
+        }
+    $$,
+    '{"ownerId": 1}'
+);
+
+
 rollback;


### PR DESCRIPTION
## What kind of change does this PR introduce?
Adds explicit column type casting to the `set` argument of update mutations.

I verified this issue is not present in the `filter` and `objects` args for other mutation types.


Bug fix, feature, docs update, ...
https://twitter.com/aiji42_dev/status/1512305435017023489

## What is the current behavior?
Passing a value as a variable to a column that is not represented as text (int, bigint) returns an error
```
column \"some_id\" is of type integer but expression is of type text
```