### PR TITLE
Rebuild schema cache on first query after SQL schema change

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,32 +1,6 @@
 The public facing API consists of a two SQL functions. One resolves GraphQL queries and the other rebuild the GraphQL schema. All other entities in the `graphql` schema are private.
 
 
-### graphql.rebuild_schema
-
-##### description
-Re-synchronizes the GraphQL schema cache with the SQL schema.
-
-##### signature
-```sql
-graphql.rebuild_schema()
-    returns void
-    language plpgsql
-```
-
-##### usage
-```sql
--- Create the extension
-graphqldb= create extension pg_graphql cascade;
-CREATE EXTENSION
-
--- Rebuild the GraphQL schema
-graphqldb= select graphql.rebuild_schema();
-
- rebuild_schema
-----------------
-(1 row)
-```
-
 ### graphql.resolve
 
 ##### description
@@ -58,13 +32,6 @@ CREATE EXTENSION
 -- Create an example table
 graphqldb= create table book(id int primary key, title text);
 CREATE TABLE
-
--- Rebuild the GraphQL schema
-graphqldb= select graphql.rebuild_schema();
-
- rebuild_schema
-----------------
-(1 row)
 
 -- Insert a record
 graphqldb= insert into book(id, title) values (1, 'book 1');

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -36,12 +36,6 @@ CREATE TABLE
 
 graphqldb= insert into book(id, title) values (1, 'book 1');
 INSERT 0 1
-
-graphqldb= select graphql.rebuild_schema();
-
- rebuild_schema
-----------------
-(1 row)
 ```
 
 Finally, execute some graphql queries against the table.

--- a/src/sql/reflection/rebuild_schema.sql
+++ b/src/sql/reflection/rebuild_schema.sql
@@ -1,17 +1,40 @@
+-- Is updated every time the schema changes
+create sequence if not exists graphql.seq_schema_version as int cycle;
+
+-- Tracks the most recently built schema version
+-- Contains 1 row
+create table graphql.schema_version(ver int primary key);
+insert into graphql.schema_version(ver) values (nextval('graphql.seq_schema_version'));
+
 create or replace function graphql.rebuild_schema()
     returns void
     security definer
     language plpgsql
 as $$
+declare
+    cur_schema_version int = last_value from graphql.seq_schema_version;
+    built_schema_version int = ver from graphql.schema_version;
 begin
-    truncate table graphql._field;
-    delete from graphql._type;
-    refresh materialized view graphql.entity with data;
-    refresh materialized view graphql.entity_column with data;
-    refresh materialized view graphql.entity_unique_columns with data;
-    refresh materialized view graphql.relationship with data;
-    perform graphql.rebuild_types();
-    perform graphql.rebuild_fields();
+    if built_schema_version <> cur_schema_version then
+        -- Lock the row to avoid concurrent access
+        built_schema_version = ver from graphql.schema_version for update;
+
+        -- Recheck condition now that we have aquired a row lock to avoid racing & stacking requests
+        if built_schema_version <> cur_schema_version then
+            truncate table graphql._field;
+            delete from graphql._type;
+            refresh materialized view graphql.entity with data;
+            refresh materialized view graphql.entity_column with data;
+            refresh materialized view graphql.entity_unique_columns with data;
+            refresh materialized view graphql.relationship with data;
+            perform graphql.rebuild_types();
+            perform graphql.rebuild_fields();
+
+            -- Update the stored schema version value
+            update graphql.schema_version set ver = cur_schema_version;
+
+        end if;
+    end if;
 end;
 $$;
 
@@ -48,7 +71,7 @@ begin
         )
         and cmd.schema_name is distinct from 'pg_temp'
         then
-            perform graphql.rebuild_schema();
+            perform nextval('graphql.seq_schema_version');
         end if;
     end loop;
 end;
@@ -77,10 +100,20 @@ begin
             )
             and obj.is_temporary IS false
             then
-                perform graphql.rebuild_schema();
+                perform nextval('graphql.seq_schema_version');
             end if;
     end loop;
 end;
 $$;
 
 select graphql.rebuild_schema();
+
+
+-- On DDL event, increment the schema version number
+create event trigger graphql_watch_ddl
+    on ddl_command_end
+    execute procedure graphql.rebuild_on_ddl();
+
+create event trigger graphql_watch_drop
+    on sql_drop
+    execute procedure graphql.rebuild_on_drop();

--- a/src/sql/resolve/resolve.sql
+++ b/src/sql/resolve/resolve.sql
@@ -90,6 +90,9 @@ begin
        );
     end if;
 
+    -- Rebuild the schema cache if the SQL schema has changed
+    perform graphql.rebuild_schema();
+
     begin
 
         -- Build query if not in cache

--- a/test/expected/inflection_fields.out
+++ b/test/expected/inflection_fields.out
@@ -14,6 +14,12 @@ begin;
     );
     -- Inflection off, Overrides: off
     comment on schema public is e'@graphql({"inflect_names": false})';
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select * from f;
          name         
 ----------------------
@@ -25,6 +31,12 @@ begin;
     -- Inflection off, Overrides: on
     comment on column account.id is e'@graphql({"name": "IddD"})';
     comment on column account.name_with_underscore is e'@graphql({"name": "nAMe"})';
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select * from f;
  name 
 ------
@@ -35,6 +47,12 @@ begin;
     rollback to savepoint a;
     -- Inflection on, Overrides: off
     comment on schema public is e'@graphql({"inflect_names": true})';
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select * from f;
         name        
 --------------------
@@ -45,6 +63,12 @@ begin;
     -- Inflection on, Overrides: on
     comment on column account.id is e'@graphql({"name": "IddD"})';
     comment on column account.name_with_underscore is e'@graphql({"name": "nAMe"})';
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select * from f;
  name 
 ------

--- a/test/expected/inflection_function.out
+++ b/test/expected/inflection_function.out
@@ -21,6 +21,12 @@ begin;
     $$;
     -- Inflection off, Overrides: off
     comment on schema public is e'@graphql({"inflect_names": false})';
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select * from f;
    name    
 -----------
@@ -30,6 +36,12 @@ begin;
     savepoint a;
     -- Inflection off, Overrides: on
     comment on function public._full_name(public.account) is E'@graphql({"name": "wholeName"})';
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select * from f;
    name    
 -----------
@@ -39,6 +51,12 @@ begin;
     rollback to savepoint a;
     -- Inflection on, Overrides: off
     comment on schema public is e'@graphql({"inflect_names": true})';
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select * from f;
    name   
 ----------
@@ -47,6 +65,12 @@ begin;
 
     -- Inflection on, Overrides: on
     comment on function public._full_name(public.account) is E'@graphql({"name": "WholeName"})';
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select * from f;
    name    
 -----------

--- a/test/expected/inflection_relationships.out
+++ b/test/expected/inflection_relationships.out
@@ -16,6 +16,12 @@ begin;
         author_id int,
         constraint fkey_author_id foreign key (author_id) references account_holder(id)
     );
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select * from r;
           name           
 -------------------------
@@ -31,6 +37,12 @@ begin;
         author int,
         constraint fkey_author_id foreign key (author) references account_holder(id)
     );
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select * from r;
           name           
 -------------------------
@@ -49,6 +61,12 @@ begin;
     comment on constraint fkey_account_id
     on account_holder
     is E'@graphql({"foreign_name": "auTHor", "local_name": "children"})';
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select * from r;
    name   
 ----------
@@ -64,6 +82,12 @@ begin;
         "authorId" int,
         constraint fkey_author_id foreign key ("authorId") references "AccountHolder"(id)
     );
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select * from r;
           name           
 -------------------------
@@ -79,6 +103,12 @@ begin;
         author int,
         constraint fkey_author_id foreign key (author) references "AccountHolder"(id)
     );
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select * from r;
           name           
 -------------------------
@@ -97,6 +127,12 @@ begin;
     comment on constraint fkey_account_id
     on "AccountHolder"
     is E'@graphql({"foreign_name": "auTHor", "local_name": "children"})';
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select * from r;
    name   
 ----------

--- a/test/expected/inflection_types.out
+++ b/test/expected/inflection_types.out
@@ -15,6 +15,12 @@ begin;
     savepoint a;
     -- Inflection off, Overrides: off
     comment on schema public is e'@graphql({"inflect_names": false})';
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select * from t;
           name           
 -------------------------
@@ -32,6 +38,12 @@ begin;
 
     -- Inflection off, Overrides: on
     comment on table blog_post is e'@graphql({"name": "BlogZZZ"})';
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select * from t;
          name          
 -----------------------
@@ -50,6 +62,12 @@ begin;
     rollback to savepoint a;
     -- Inflection on, Overrides: off
     comment on schema public is e'@graphql({"inflect_names": true})';
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select name from graphql.type where entity is not null order by entity, name;
           name          
 ------------------------
@@ -67,6 +85,12 @@ begin;
 
     -- Inflection on, Overrides: on
     comment on table blog_post is e'@graphql({"name": "BlogZZZ"})';
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select name from graphql.type where entity is not null order by entity, name;
          name          
 -----------------------

--- a/test/expected/omit_exotic_types.out
+++ b/test/expected/omit_exotic_types.out
@@ -13,6 +13,12 @@ begin;
         js json,
         jsb jsonb
     );
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select
         name, parent_type, type_, is_not_null, is_array, is_arg
     from

--- a/test/expected/override_enum_name.out
+++ b/test/expected/override_enum_name.out
@@ -1,6 +1,12 @@
 begin;
     create type account_priority as enum ('high', 'standard');
     comment on type public.account_priority is E'@graphql({"name": "CustomerValue"})';
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select name from graphql.type where enum = 'public.account_priority'::regtype;
      name      
 ---------------

--- a/test/expected/override_field_name.out
+++ b/test/expected/override_field_name.out
@@ -4,6 +4,12 @@ begin;
         email varchar(255) not null
     );
     comment on column public.account.email is E'@graphql({"name": "emailAddress"})';
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select
         name
     from

--- a/test/expected/override_func_field_name.out
+++ b/test/expected/override_func_field_name.out
@@ -14,6 +14,12 @@ begin;
         select format('%s %s', rec.first_name, rec.last_name)
     $$;
     comment on function public._full_name(public.account) is E'@graphql({"name": "wholeName"})';
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select
         name
     from

--- a/test/expected/override_relationship_field_name.out
+++ b/test/expected/override_relationship_field_name.out
@@ -9,6 +9,12 @@ begin;
     comment on constraint blog_owner_id_fkey
     on blog
     is E'@graphql({"foreign_name": "author", "local_name": "blogz"})';
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     -- expect: 'author'
     select
         name

--- a/test/expected/override_type_name.out
+++ b/test/expected/override_type_name.out
@@ -4,6 +4,12 @@ begin;
         email varchar(255) not null
     );
     comment on table public.account is E'@graphql({"name": "UserAccount"})';
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select name from graphql.type where entity = 'public.account'::regclass order by name;
            name            
 ---------------------------

--- a/test/expected/permissions_table_level.out
+++ b/test/expected/permissions_table_level.out
@@ -11,6 +11,12 @@ begin;
     -- Allow access to public.account.id but nothing else
     grant usage on schema public to api;
     grant all on all tables in schema public to api;
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     savepoint a;
     -- Nothing is excluded
     set role api;

--- a/test/expected/permissions_types.out
+++ b/test/expected/permissions_types.out
@@ -9,7 +9,6 @@ begin;
  
 (1 row)
 
-    
     -- expect nothing b/c not in search_path
     select name from graphql.type t where t.enum is not null;
  name 

--- a/test/expected/permissions_types.out
+++ b/test/expected/permissions_types.out
@@ -3,6 +3,13 @@ begin;
     --set log_min_messages to panic;
     create schema xyz;
     create type xyz.light as enum ('red');
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
+    
     -- expect nothing b/c not in search_path
     select name from graphql.type t where t.enum is not null;
  name 

--- a/test/expected/primary_key_is_required.out
+++ b/test/expected/primary_key_is_required.out
@@ -3,6 +3,12 @@ begin;
     create table account(
         id serial primary key
     );
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     -- Should be visible because it has a primary ky
     select * from graphql.entity;
  entity  

--- a/test/expected/search_path_filters_visibility.out
+++ b/test/expected/search_path_filters_visibility.out
@@ -6,6 +6,12 @@ begin;
     create table other.bar(
         id serial primary key
     );
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     -- public.foo is visible, other.bar is not
     select
         name

--- a/test/expected/type_name.out
+++ b/test/expected/type_name.out
@@ -1,6 +1,12 @@
 begin;
     create table account(id int primary key);
     create type post_status as enum ('published', 'unpublished');
+    select graphql.rebuild_schema();
+ rebuild_schema 
+----------------
+ 
+(1 row)
+
     select
         (rec).type_kind,
         (rec).meta_kind,

--- a/test/fixtures.sql
+++ b/test/fixtures.sql
@@ -1,14 +1,3 @@
 create extension pg_graphql cascade;
 
 comment on schema public is '@graphql({"inflect_names": true})';
-
--- Event triggers to watch for DDL and rebuild the schem
--- So we don't need to call `graphql.rebuild_schema()` manually
--- in each test
-create event trigger graphql_watch_ddl
-    on ddl_command_end
-    execute procedure graphql.rebuild_on_ddl();
-
-create event trigger graphql_watch_drop
-    on sql_drop
-    execute procedure graphql.rebuild_on_drop();

--- a/test/sql/inflection_fields.sql
+++ b/test/sql/inflection_fields.sql
@@ -16,6 +16,7 @@ begin;
 
     -- Inflection off, Overrides: off
     comment on schema public is e'@graphql({"inflect_names": false})';
+    select graphql.rebuild_schema();
     select * from f;
 
     savepoint a;
@@ -23,17 +24,20 @@ begin;
     -- Inflection off, Overrides: on
     comment on column account.id is e'@graphql({"name": "IddD"})';
     comment on column account.name_with_underscore is e'@graphql({"name": "nAMe"})';
+    select graphql.rebuild_schema();
     select * from f;
 
     rollback to savepoint a;
 
     -- Inflection on, Overrides: off
     comment on schema public is e'@graphql({"inflect_names": true})';
+    select graphql.rebuild_schema();
     select * from f;
 
     -- Inflection on, Overrides: on
     comment on column account.id is e'@graphql({"name": "IddD"})';
     comment on column account.name_with_underscore is e'@graphql({"name": "nAMe"})';
+    select graphql.rebuild_schema();
     select * from f;
 
 rollback;

--- a/test/sql/inflection_function.sql
+++ b/test/sql/inflection_function.sql
@@ -24,22 +24,26 @@ begin;
 
     -- Inflection off, Overrides: off
     comment on schema public is e'@graphql({"inflect_names": false})';
+    select graphql.rebuild_schema();
     select * from f;
 
     savepoint a;
 
     -- Inflection off, Overrides: on
     comment on function public._full_name(public.account) is E'@graphql({"name": "wholeName"})';
+    select graphql.rebuild_schema();
     select * from f;
 
     rollback to savepoint a;
 
     -- Inflection on, Overrides: off
     comment on schema public is e'@graphql({"inflect_names": true})';
+    select graphql.rebuild_schema();
     select * from f;
 
     -- Inflection on, Overrides: on
     comment on function public._full_name(public.account) is E'@graphql({"name": "WholeName"})';
+    select graphql.rebuild_schema();
     select * from f;
 
 rollback;

--- a/test/sql/inflection_relationships.sql
+++ b/test/sql/inflection_relationships.sql
@@ -20,6 +20,7 @@ begin;
         constraint fkey_author_id foreign key (author_id) references account_holder(id)
     );
 
+    select graphql.rebuild_schema();
     select * from r;
 
     -- Inflection true, Overrides: off, does not end with '_id'
@@ -33,6 +34,7 @@ begin;
         constraint fkey_author_id foreign key (author) references account_holder(id)
     );
 
+    select graphql.rebuild_schema();
     select * from r;
 
     -- Inflection true, Overrides: true
@@ -50,6 +52,7 @@ begin;
     on account_holder
     is E'@graphql({"foreign_name": "auTHor", "local_name": "children"})';
 
+    select graphql.rebuild_schema();
     select * from r;
 
     -- Inflection false, Overrides: off, Ends with 'Id'
@@ -63,6 +66,7 @@ begin;
         constraint fkey_author_id foreign key ("authorId") references "AccountHolder"(id)
     );
 
+    select graphql.rebuild_schema();
     select * from r;
 
     -- Inflection false, Overrides: off, does not end with 'Id'
@@ -76,6 +80,7 @@ begin;
         constraint fkey_author_id foreign key (author) references "AccountHolder"(id)
     );
 
+    select graphql.rebuild_schema();
     select * from r;
 
     -- Inflection false, Overrides: true
@@ -93,6 +98,7 @@ begin;
     on "AccountHolder"
     is E'@graphql({"foreign_name": "auTHor", "local_name": "children"})';
 
+    select graphql.rebuild_schema();
     select * from r;
 
 rollback;

--- a/test/sql/inflection_types.sql
+++ b/test/sql/inflection_types.sql
@@ -18,20 +18,24 @@ begin;
 
     -- Inflection off, Overrides: off
     comment on schema public is e'@graphql({"inflect_names": false})';
+    select graphql.rebuild_schema();
     select * from t;
 
     -- Inflection off, Overrides: on
     comment on table blog_post is e'@graphql({"name": "BlogZZZ"})';
+    select graphql.rebuild_schema();
     select * from t;
 
     rollback to savepoint a;
 
     -- Inflection on, Overrides: off
     comment on schema public is e'@graphql({"inflect_names": true})';
+    select graphql.rebuild_schema();
     select name from graphql.type where entity is not null order by entity, name;
 
     -- Inflection on, Overrides: on
     comment on table blog_post is e'@graphql({"name": "BlogZZZ"})';
+    select graphql.rebuild_schema();
     select name from graphql.type where entity is not null order by entity, name;
 
 rollback;

--- a/test/sql/omit_exotic_types.sql
+++ b/test/sql/omit_exotic_types.sql
@@ -17,6 +17,7 @@ begin;
         jsb jsonb
     );
 
+    select graphql.rebuild_schema();
 
     select
         name, parent_type, type_, is_not_null, is_array, is_arg

--- a/test/sql/override_enum_name.sql
+++ b/test/sql/override_enum_name.sql
@@ -1,6 +1,7 @@
 begin;
     create type account_priority as enum ('high', 'standard');
     comment on type public.account_priority is E'@graphql({"name": "CustomerValue"})';
+    select graphql.rebuild_schema();
 
     select name from graphql.type where enum = 'public.account_priority'::regtype;
 

--- a/test/sql/override_field_name.sql
+++ b/test/sql/override_field_name.sql
@@ -6,6 +6,8 @@ begin;
 
     comment on column public.account.email is E'@graphql({"name": "emailAddress"})';
 
+    select graphql.rebuild_schema();
+
     select
         name
     from

--- a/test/sql/override_func_field_name.sql
+++ b/test/sql/override_func_field_name.sql
@@ -17,6 +17,8 @@ begin;
 
     comment on function public._full_name(public.account) is E'@graphql({"name": "wholeName"})';
 
+    select graphql.rebuild_schema();
+
     select
         name
     from

--- a/test/sql/override_relationship_field_name.sql
+++ b/test/sql/override_relationship_field_name.sql
@@ -13,6 +13,9 @@ begin;
     on blog
     is E'@graphql({"foreign_name": "author", "local_name": "blogz"})';
 
+
+    select graphql.rebuild_schema();
+
     -- expect: 'author'
     select
         name

--- a/test/sql/override_type_name.sql
+++ b/test/sql/override_type_name.sql
@@ -6,6 +6,8 @@ begin;
 
     comment on table public.account is E'@graphql({"name": "UserAccount"})';
 
+    select graphql.rebuild_schema();
+
     select name from graphql.type where entity = 'public.account'::regclass order by name;
 
 rollback;

--- a/test/sql/permissions_table_level.sql
+++ b/test/sql/permissions_table_level.sql
@@ -16,6 +16,8 @@ begin;
     grant usage on schema public to api;
     grant all on all tables in schema public to api;
 
+    select graphql.rebuild_schema();
+
     savepoint a;
 
     -- Nothing is excluded

--- a/test/sql/permissions_types.sql
+++ b/test/sql/permissions_types.sql
@@ -5,6 +5,8 @@ begin;
     create schema xyz;
     create type xyz.light as enum ('red');
 
+    select graphql.rebuild_schema();
+
     -- expect nothing b/c not in search_path
     select name from graphql.type t where t.enum is not null;
 

--- a/test/sql/primary_key_is_required.sql
+++ b/test/sql/primary_key_is_required.sql
@@ -6,6 +6,8 @@ begin;
         id serial primary key
     );
 
+    select graphql.rebuild_schema();
+
     -- Should be visible because it has a primary ky
     select * from graphql.entity;
 

--- a/test/sql/search_path_filters_visibility.sql
+++ b/test/sql/search_path_filters_visibility.sql
@@ -10,6 +10,8 @@ begin;
         id serial primary key
     );
 
+    select graphql.rebuild_schema();
+
     -- public.foo is visible, other.bar is not
     select
         name

--- a/test/sql/type_name.sql
+++ b/test/sql/type_name.sql
@@ -2,6 +2,8 @@ begin;
     create table account(id int primary key);
     create type post_status as enum ('published', 'unpublished');
 
+    select graphql.rebuild_schema();
+
     select
         (rec).type_kind,
         (rec).meta_kind,


### PR DESCRIPTION
## What kind of change does this PR introduce?
resolves #144 

- An event_trigger first after each ddl event and increments a sequence `graphql.seq_schema_version`
- On each request, the last processed schema version from table `graphql.schema_version(ver)` is compared with the sequences' current value
- If the values differ, the schema is rebuilt

This removes the need to call `graphql.rebuild_schema()` manually after ddl changes.


Note: many tests (that use private api) were updated, but no public facing api is impacted