### PR TITLE
Support JSON/JSONB types for queries and mutations

### DIFF
--- a/nix/libgraphqlparser/builder.sh
+++ b/nix/libgraphqlparser/builder.sh
@@ -1,13 +1,10 @@
 source $stdenv/setup
 
-tar xvfz $src
-
 PATH=$cmake/bin:$PATH
 PATH=$python2/bin:$PATH
 
 echo $PATH
 
-cd $name
-cmake -DCMAKE_INSTALL_PREFIX:PATH=$out .
+cmake -S $src -DCMAKE_INSTALL_PREFIX:PATH=$out .
 make
 make install #prefix=$out

--- a/nix/libgraphqlparser/default.nix
+++ b/nix/libgraphqlparser/default.nix
@@ -6,8 +6,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "graphql";
     repo = "libgraphqlparser";
-    rev = "7e6c35c7b9e919d0c40b28020fb9358c3cf2679c";
-    sha256 = "sha256-4syYEE80HA7YuSjgRnK5KqF6yUSPHqDmbHnGEiLW98g=";
+    rev = "3b64cd52d13621921990a5801ba019e8a9402599";
+    sha256 = "sha256-0ubcB2GykZnId4CL+pb4U0Ry2JftqwaEUh2DqeghHo0=";
   };
   buildInputs = [ python2 ];
   inherit cmake;

--- a/nix/libgraphqlparser/default.nix
+++ b/nix/libgraphqlparser/default.nix
@@ -1,11 +1,13 @@
-{ stdenv, fetchurl, cmake, python2 }:
+{ stdenv, fetchFromGitHub, cmake, python2 }:
 
 stdenv.mkDerivation {
-  name = "libgraphqlparser-0.7.0";
+  name = "libgraphqlparser";
   builder = ./builder.sh;
-  src = fetchurl {
-    url = "https://github.com/graphql/libgraphqlparser/archive/refs/tags/0.7.0.tar.gz";
-    sha256 = "63dae018f970dc2bdce431cbafbfa0bd3e6b10bba078bb997a3c1a40894aa35c";
+  src = fetchFromGitHub {
+    owner = "graphql";
+    repo = "libgraphqlparser";
+    rev = "7e6c35c7b9e919d0c40b28020fb9358c3cf2679c";
+    sha256 = "sha256-4syYEE80HA7YuSjgRnK5KqF6yUSPHqDmbHnGEiLW98g=";
   };
   buildInputs = [ python2 ];
   inherit cmake;

--- a/pg_graphql--0.3.1.sql
+++ b/pg_graphql--0.3.1.sql
@@ -3616,6 +3616,8 @@ begin
         from
             jsonb_array_elements(values_var) with ordinality row_(elem, ix),
             unnest(values_all_field_keys) vfk(field_name)
+            join unnest(allowed_columns) ac
+                on vfk.field_name = ac.name
             left join jsonb_each_text(row_.elem) row_col(field_name, field_val)
                 on vfk.field_name = row_col.field_name
         group by

--- a/pg_graphql--0.3.1.sql
+++ b/pg_graphql--0.3.1.sql
@@ -1745,7 +1745,6 @@ begin
                 on gt.entity = es.entity
         where
             gt.meta_kind = 'Node'
-            and not es.column_type in ('json', 'jsonb')
             and not es.is_composite;
 
     -- Node
@@ -2153,7 +2152,6 @@ begin
             gf.meta_kind = 'ObjectsArg'
             and not ec.is_generated -- skip generated columns
             and not ec.is_serial -- skip (big)serial columns
-            and not ec.column_type in ('json', 'jsonb')
             and not ec.is_array -- disallow arrays
             and not ec.is_composite; -- disallow arrays
 
@@ -2275,7 +2273,6 @@ begin
             gf.meta_kind = 'UpdateSetArg'
             and not ec.is_generated -- skip generated columns
             and not ec.is_serial -- skip (big)serial columns
-            and not ec.column_type in ('json', 'jsonb')
             and not ec.is_array -- disallow arrays
             and not ec.is_composite; -- disallow composite
 
@@ -3097,6 +3094,11 @@ begin
                                     block_name,
                                     gf_s.column_name
                                 )
+                                when gf_s.column_name is not null and gf_s.column_type in ('json'::regtype, 'jsonb'::regtype) then format(
+                                    $j$(%I.%I) #>> '{}'$j$,
+                                    block_name,
+                                    gf_s.column_name
+                                )
                                 when gf_s.column_name is not null then format('%I.%I', block_name, gf_s.column_name)
                                 when gf_s.local_columns is not null and gf_s.meta_kind = 'Relationship.toOne' then
                                     graphql.build_node_query(
@@ -3399,6 +3401,11 @@ begin
                                             graphql.alias_or_name_literal(x.sel),
                                             case
                                                 when nf.column_name is not null and nf.column_type = 'bigint'::regtype then format('(%I.%I)::text', block_name, nf.column_name)
+                                                when nf.column_name is not null and nf.column_type in ('json'::regtype, 'jsonb'::regtype) then format(
+                                                    $j$(%I.%I) #>> '{}'$j$,
+                                                    block_name,
+                                                    nf.column_name
+                                                )
                                                 when nf.column_name is not null then format('%I.%I', block_name, nf.column_name)
                                                 when nf.meta_kind = 'Function' then format('%s(%I)', nf.func, block_name)
                                                 when nf.name = '__typename' then format('%L', top_fields.type_)
@@ -3648,6 +3655,11 @@ begin
                                             graphql.alias_or_name_literal(x.sel),
                                             case
                                                 when nf.column_name is not null and nf.column_type = 'bigint'::regtype then format('(%I.%I)::text', block_name, nf.column_name)
+                                                when nf.column_name is not null and nf.column_type in ('json'::regtype, 'jsonb'::regtype) then format(
+                                                    $j$(%I.%I) #>> '{}'$j$,
+                                                    block_name,
+                                                    nf.column_name
+                                                )
                                                 when nf.column_name is not null then format('%I.%I', block_name, nf.column_name)
                                                 when nf.meta_kind = 'Function' then format('%s(%I)', nf.func, block_name)
                                                 when nf.name = '__typename' then format('%L', top_fields.type_)
@@ -3743,6 +3755,11 @@ as $$
                     graphql.alias_or_name_literal(x.sel),
                     case
                         when nf.column_name is not null and nf.column_type = 'bigint'::regtype then format('(%I.%I)::text', block_name, nf.column_name)
+                        when nf.column_name is not null and nf.column_type in ('json'::regtype, 'jsonb'::regtype) then format(
+                            $j$(%I.%I) #>> '{}'$j$,
+                            block_name,
+                            nf.column_name
+                        )
                         when nf.column_name is not null then format('%I.%I', block_name, nf.column_name)
                         when nf.meta_kind = 'Function' then format('%s(%I)', nf.func, block_name)
                         when nf.name = '__typename' then format('%L', (c.type_).name)
@@ -3895,6 +3912,11 @@ begin
                                             graphql.alias_or_name_literal(x.sel),
                                             case
                                                 when nf.column_name is not null and nf.column_type = 'bigint'::regtype then format('(%I.%I)::text', block_name, nf.column_name)
+                                                when nf.column_name is not null and nf.column_type in ('json'::regtype, 'jsonb'::regtype) then format(
+                                                    $j$(%I.%I) #>> '{}'$j$,
+                                                    block_name,
+                                                    nf.column_name
+                                                )
                                                 when nf.column_name is not null then format('%I.%I', block_name, nf.column_name)
                                                 when nf.meta_kind = 'Function' then format('%I(%I)', nf.func, block_name)
                                                 when nf.name = '__typename' then format('%L', top_fields.type_)

--- a/pg_graphql--0.3.1.sql
+++ b/pg_graphql--0.3.1.sql
@@ -311,6 +311,7 @@ $$
     select
         case arg ->> 'kind'
             when 'Argument'     then graphql.arg_to_jsonb(arg -> 'value', variables)
+            when 'NullValue'    then to_jsonb(null::bool)
             when 'IntValue'     then to_jsonb((arg ->> 'value')::int)
             when 'FloatValue'   then to_jsonb((arg ->> 'value')::float)
             when 'BooleanValue' then to_jsonb((arg ->> 'value')::bool)

--- a/src/sql/ast/arg_to_jsonb.sql
+++ b/src/sql/ast/arg_to_jsonb.sql
@@ -10,6 +10,7 @@ $$
     select
         case arg ->> 'kind'
             when 'Argument'     then graphql.arg_to_jsonb(arg -> 'value', variables)
+            when 'NullValue'    then to_jsonb(null::bool)
             when 'IntValue'     then to_jsonb((arg ->> 'value')::int)
             when 'FloatValue'   then to_jsonb((arg ->> 'value')::float)
             when 'BooleanValue' then to_jsonb((arg ->> 'value')::bool)

--- a/src/sql/reflection/field/field.sql
+++ b/src/sql/reflection/field/field.sql
@@ -418,7 +418,6 @@ begin
                 on gt.entity = es.entity
         where
             gt.meta_kind = 'Node'
-            and not es.column_type in ('json', 'jsonb')
             and not es.is_composite;
 
     -- Node
@@ -826,7 +825,6 @@ begin
             gf.meta_kind = 'ObjectsArg'
             and not ec.is_generated -- skip generated columns
             and not ec.is_serial -- skip (big)serial columns
-            and not ec.column_type in ('json', 'jsonb')
             and not ec.is_array -- disallow arrays
             and not ec.is_composite; -- disallow arrays
 
@@ -948,7 +946,6 @@ begin
             gf.meta_kind = 'UpdateSetArg'
             and not ec.is_generated -- skip generated columns
             and not ec.is_serial -- skip (big)serial columns
-            and not ec.column_type in ('json', 'jsonb')
             and not ec.is_array -- disallow arrays
             and not ec.is_composite; -- disallow composite
 

--- a/src/sql/resolve/transpile/build_connection.sql
+++ b/src/sql/resolve/transpile/build_connection.sql
@@ -195,6 +195,11 @@ begin
                                     block_name,
                                     gf_s.column_name
                                 )
+                                when gf_s.column_name is not null and gf_s.column_type in ('json'::regtype, 'jsonb'::regtype) then format(
+                                    $j$(%I.%I) #>> '{}'$j$,
+                                    block_name,
+                                    gf_s.column_name
+                                )
                                 when gf_s.column_name is not null then format('%I.%I', block_name, gf_s.column_name)
                                 when gf_s.local_columns is not null and gf_s.meta_kind = 'Relationship.toOne' then
                                     graphql.build_node_query(

--- a/src/sql/resolve/transpile/build_delete.sql
+++ b/src/sql/resolve/transpile/build_delete.sql
@@ -59,6 +59,11 @@ begin
                                             graphql.alias_or_name_literal(x.sel),
                                             case
                                                 when nf.column_name is not null and nf.column_type = 'bigint'::regtype then format('(%I.%I)::text', block_name, nf.column_name)
+                                                when nf.column_name is not null and nf.column_type in ('json'::regtype, 'jsonb'::regtype) then format(
+                                                    $j$(%I.%I) #>> '{}'$j$,
+                                                    block_name,
+                                                    nf.column_name
+                                                )
                                                 when nf.column_name is not null then format('%I.%I', block_name, nf.column_name)
                                                 when nf.meta_kind = 'Function' then format('%s(%I)', nf.func, block_name)
                                                 when nf.name = '__typename' then format('%L', top_fields.type_)

--- a/src/sql/resolve/transpile/build_insert.sql
+++ b/src/sql/resolve/transpile/build_insert.sql
@@ -111,6 +111,8 @@ begin
         from
             jsonb_array_elements(values_var) with ordinality row_(elem, ix),
             unnest(values_all_field_keys) vfk(field_name)
+            join unnest(allowed_columns) ac
+                on vfk.field_name = ac.name
             left join jsonb_each_text(row_.elem) row_col(field_name, field_val)
                 on vfk.field_name = row_col.field_name
         group by

--- a/src/sql/resolve/transpile/build_insert.sql
+++ b/src/sql/resolve/transpile/build_insert.sql
@@ -150,6 +150,11 @@ begin
                                             graphql.alias_or_name_literal(x.sel),
                                             case
                                                 when nf.column_name is not null and nf.column_type = 'bigint'::regtype then format('(%I.%I)::text', block_name, nf.column_name)
+                                                when nf.column_name is not null and nf.column_type in ('json'::regtype, 'jsonb'::regtype) then format(
+                                                    $j$(%I.%I) #>> '{}'$j$,
+                                                    block_name,
+                                                    nf.column_name
+                                                )
                                                 when nf.column_name is not null then format('%I.%I', block_name, nf.column_name)
                                                 when nf.meta_kind = 'Function' then format('%s(%I)', nf.func, block_name)
                                                 when nf.name = '__typename' then format('%L', top_fields.type_)

--- a/src/sql/resolve/transpile/build_node.sql
+++ b/src/sql/resolve/transpile/build_node.sql
@@ -29,6 +29,11 @@ as $$
                     graphql.alias_or_name_literal(x.sel),
                     case
                         when nf.column_name is not null and nf.column_type = 'bigint'::regtype then format('(%I.%I)::text', block_name, nf.column_name)
+                        when nf.column_name is not null and nf.column_type in ('json'::regtype, 'jsonb'::regtype) then format(
+                            $j$(%I.%I) #>> '{}'$j$,
+                            block_name,
+                            nf.column_name
+                        )
                         when nf.column_name is not null then format('%I.%I', block_name, nf.column_name)
                         when nf.meta_kind = 'Function' then format('%s(%I)', nf.func, block_name)
                         when nf.name = '__typename' then format('%L', (c.type_).name)

--- a/src/sql/resolve/transpile/build_update.sql
+++ b/src/sql/resolve/transpile/build_update.sql
@@ -94,6 +94,11 @@ begin
                                             graphql.alias_or_name_literal(x.sel),
                                             case
                                                 when nf.column_name is not null and nf.column_type = 'bigint'::regtype then format('(%I.%I)::text', block_name, nf.column_name)
+                                                when nf.column_name is not null and nf.column_type in ('json'::regtype, 'jsonb'::regtype) then format(
+                                                    $j$(%I.%I) #>> '{}'$j$,
+                                                    block_name,
+                                                    nf.column_name
+                                                )
                                                 when nf.column_name is not null then format('%I.%I', block_name, nf.column_name)
                                                 when nf.meta_kind = 'Function' then format('%I(%I)', nf.func, block_name)
                                                 when nf.name = '__typename' then format('%L', top_fields.type_)

--- a/test/expected/json_is_stringified.out
+++ b/test/expected/json_is_stringified.out
@@ -1,0 +1,78 @@
+begin;
+    create table blog_post(
+        id int primary key,
+        data jsonb ,
+        parent_id int references blog_post(id)
+    );
+    select graphql.resolve($$
+    mutation {
+      insertIntoBlogPostCollection(objects: [{
+        id: 1
+        data: "{\"key\": \"value\"}"
+        parentId: 1 
+      }]) {
+        records {
+          id
+          data
+        }
+      }
+    }
+    $$);
+                                               resolve                                                
+------------------------------------------------------------------------------------------------------
+ {"data": {"insertIntoBlogPostCollection": {"records": [{"id": 1, "data": "{\"key\": \"value\"}"}]}}}
+(1 row)
+
+    select graphql.resolve($$
+    mutation {
+      updateBlogPostCollection(set: {
+        data: "{\"key\": \"value2\"}"
+      }) {
+        records {
+          id
+          data
+        }
+      }
+    }
+    $$);
+                                              resolve                                              
+---------------------------------------------------------------------------------------------------
+ {"data": {"updateBlogPostCollection": {"records": [{"id": 1, "data": "{\"key\": \"value2\"}"}]}}}
+(1 row)
+
+    select graphql.resolve($$
+    {
+      blogPostCollection {
+        edges {
+          node {
+            data
+            parent {
+              id
+              data
+            }
+          }
+        }
+      }
+    }
+    $$);
+                                                                     resolve                                                                      
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ {"data": {"blogPostCollection": {"edges": [{"node": {"data": "{\"key\": \"value2\"}", "parent": {"id": 1, "data": "{\"key\": \"value2\"}"}}}]}}}
+(1 row)
+
+    select graphql.resolve($$
+    mutation {
+      deleteFromBlogPostCollection {
+        records {
+          id
+          data
+        }
+      }
+    }
+    $$);
+                                                resolve                                                
+-------------------------------------------------------------------------------------------------------
+ {"data": {"deleteFromBlogPostCollection": {"records": [{"id": 1, "data": "{\"key\": \"value2\"}"}]}}}
+(1 row)
+
+rollback;

--- a/test/expected/json_is_stringified.out
+++ b/test/expected/json_is_stringified.out
@@ -1,7 +1,7 @@
 begin;
     create table blog_post(
         id int primary key,
-        data jsonb ,
+        data jsonb,
         parent_id int references blog_post(id)
     );
     select graphql.resolve($$
@@ -23,6 +23,12 @@ begin;
  {"data": {"insertIntoBlogPostCollection": {"records": [{"id": 1, "data": "{\"key\": \"value\"}"}]}}}
 (1 row)
 
+    select * from blog_post;
+ id |       data       | parent_id 
+----+------------------+-----------
+  1 | {"key": "value"} |         1
+(1 row)
+
     select graphql.resolve($$
     mutation {
       updateBlogPostCollection(set: {
@@ -38,6 +44,12 @@ begin;
                                               resolve                                              
 ---------------------------------------------------------------------------------------------------
  {"data": {"updateBlogPostCollection": {"records": [{"id": 1, "data": "{\"key\": \"value2\"}"}]}}}
+(1 row)
+
+    select * from blog_post;
+ id |       data        | parent_id 
+----+-------------------+-----------
+  1 | {"key": "value2"} |         1
 (1 row)
 
     select graphql.resolve($$

--- a/test/expected/json_is_stringified.out
+++ b/test/expected/json_is_stringified.out
@@ -9,7 +9,7 @@ begin;
       insertIntoBlogPostCollection(objects: [{
         id: 1
         data: "{\"key\": \"value\"}"
-        parentId: 1 
+        parentId: 1
       }]) {
         records {
           id

--- a/test/expected/null_argument.out
+++ b/test/expected/null_argument.out
@@ -1,0 +1,25 @@
+begin;
+    -- Test that the argument parser can handle null values
+    create table account(
+        id serial primary key,
+        email text
+    );
+    select graphql.resolve($$
+    mutation {
+      insertIntoAccountCollection(objects: [
+        { email: null }
+      ]) {
+        affectedCount
+        records {
+          id
+          email
+        }
+      }
+    }
+    $$);
+                                                resolve                                                 
+--------------------------------------------------------------------------------------------------------
+ {"data": {"insertIntoAccountCollection": {"records": [{"id": 1, "email": null}], "affectedCount": 1}}}
+(1 row)
+
+rollback;

--- a/test/expected/omit_exotic_types.out
+++ b/test/expected/omit_exotic_types.out
@@ -32,15 +32,21 @@ begin;
  name |     parent_type      |      type_       | is_not_null | is_array | is_arg 
 ------+----------------------+------------------+-------------+----------+--------
  id   | Something            | Int              | t           | f        | f
+ js   | Something            | JSON             | f           | f        | f
+ jsb  | Something            | JSON             | f           | f        | f
  name | Something            | String           | t           | f        | f
  tags | Something            | String           | f           | t        | f
  id   | SomethingFilter      | IntFilter        | f           | f        | f
  name | SomethingFilter      | StringFilter     | f           | f        | f
+ js   | SomethingInsertInput | JSON             | f           | f        | t
+ jsb  | SomethingInsertInput | JSON             | f           | f        | t
  name | SomethingInsertInput | String           | f           | f        | t
  id   | SomethingOrderBy     | OrderByDirection | f           | f        | f
  name | SomethingOrderBy     | OrderByDirection | f           | f        | f
  tags | SomethingOrderBy     | OrderByDirection | f           | f        | f
+ js   | SomethingUpdateInput | JSON             | f           | f        | t
+ jsb  | SomethingUpdateInput | JSON             | f           | f        | t
  name | SomethingUpdateInput | String           | f           | f        | t
-(10 rows)
+(16 rows)
 
 rollback;

--- a/test/sql/json_is_stringified.sql
+++ b/test/sql/json_is_stringified.sql
@@ -2,7 +2,7 @@ begin;
 
     create table blog_post(
         id int primary key,
-        data jsonb ,
+        data jsonb,
         parent_id int references blog_post(id)
     );
 
@@ -21,6 +21,8 @@ begin;
     }
     $$);
 
+    select * from blog_post;
+
     select graphql.resolve($$
     mutation {
       updateBlogPostCollection(set: {
@@ -33,6 +35,8 @@ begin;
       }
     }
     $$);
+
+    select * from blog_post;
 
     select graphql.resolve($$
     {

--- a/test/sql/json_is_stringified.sql
+++ b/test/sql/json_is_stringified.sql
@@ -1,0 +1,64 @@
+begin;
+
+    create table blog_post(
+        id int primary key,
+        data jsonb ,
+        parent_id int references blog_post(id)
+    );
+
+    select graphql.resolve($$
+    mutation {
+      insertIntoBlogPostCollection(objects: [{
+        id: 1
+        data: "{\"key\": \"value\"}"
+        parentId: 1
+      }]) {
+        records {
+          id
+          data
+        }
+      }
+    }
+    $$);
+
+    select graphql.resolve($$
+    mutation {
+      updateBlogPostCollection(set: {
+        data: "{\"key\": \"value2\"}"
+      }) {
+        records {
+          id
+          data
+        }
+      }
+    }
+    $$);
+
+    select graphql.resolve($$
+    {
+      blogPostCollection {
+        edges {
+          node {
+            data
+            parent {
+              id
+              data
+            }
+          }
+        }
+      }
+    }
+    $$);
+
+    select graphql.resolve($$
+    mutation {
+      deleteFromBlogPostCollection {
+        records {
+          id
+          data
+        }
+      }
+    }
+    $$);
+
+rollback;

--- a/test/sql/null_argument.sql
+++ b/test/sql/null_argument.sql
@@ -1,0 +1,23 @@
+begin;
+    -- Test that the argument parser can handle null values
+
+    create table account(
+        id serial primary key,
+        email text
+    );
+
+    select graphql.resolve($$
+    mutation {
+      insertIntoAccountCollection(objects: [
+        { email: null }
+      ]) {
+        affectedCount
+        records {
+          id
+          email
+        }
+      }
+    }
+    $$);
+
+rollback;


### PR DESCRIPTION
## What kind of change does this PR introduce?
Adds support for JSON and JSONB types in queries and mutations

Note:
JSON/B fields continue to be unavailable as targets for filtering or sorting because it isn't clear which operations should be supported, or how they should behave

resolves #105 