### PR TITLE
Rebuild fields from _type to avoid interactions with perms + search path

### DIFF
--- a/pg_graphql--0.3.1.sql
+++ b/pg_graphql--0.3.1.sql
@@ -1638,7 +1638,7 @@ begin
         t.id,
         x.*
     from
-        graphql.type t,
+        graphql._type t,
         lateral (
             values
                 (graphql.type_id('__Type'),   '__type',   true,  false, null::boolean, true,  null::text),
@@ -1670,10 +1670,10 @@ begin
             fs.description,
             fs.is_hidden_from_schema
         from
-            graphql.type conn
-            join graphql.type edge
+            graphql._type conn
+            join graphql._type edge
                 on conn.entity = edge.entity
-            join graphql.type node
+            join graphql._type node
                 on edge.entity = node.entity,
             lateral (
                 values
@@ -1701,7 +1701,7 @@ begin
             false as is_array,
             'The total number of records matching the `filter` criteria'
         from
-            graphql.type conn
+            graphql._type conn
         where
             conn.meta_kind = 'Connection'
             and graphql.comment_directive_totalCount_enabled(conn.entity);
@@ -1718,7 +1718,7 @@ begin
             false,
             true
         from
-            graphql.type t
+            graphql._type t
         where
             t.type_kind = 'OBJECT';
 
@@ -1740,7 +1740,7 @@ begin
             es.column_attribute_num,
             false as is_hidden_from_schema
         from
-            graphql.type gt
+            graphql._type gt
             join graphql.entity_column es
                 on gt.entity = es.entity
         where
@@ -1764,7 +1764,7 @@ begin
             false as is_hidden_from_schema,
             pp.oid::regproc as func
         from
-            graphql.type gt
+            graphql._type gt
             join pg_class pc
                 on gt.entity = pc.oid
             join pg_proc pp
@@ -1808,10 +1808,10 @@ begin
             rel.foreign_columns,
             rel.foreign_name_override
         from
-            graphql.type node
+            graphql._type node
             join graphql.relationship rel
                 on node.entity = rel.local_entity
-            join graphql.type conn
+            join graphql._type conn
                 on conn.entity = rel.foreign_entity
                 and (
                     (conn.meta_kind = 'Node' and rel.foreign_cardinality = 'ONE')
@@ -1836,7 +1836,7 @@ begin
             gt.entity,
             null::text description
         from
-            graphql.type gt
+            graphql._type gt
             join graphql.entity_column ec
                 on gt.entity = ec.entity
         where
@@ -1855,7 +1855,7 @@ begin
             false,
             null::text as description
         from
-            graphql.type gt -- IntFilter
+            graphql._type gt -- IntFilter
             join (
                 values
                     ('eq'),
@@ -1887,10 +1887,10 @@ begin
             gt.entity,
             null::text description
         from
-            graphql.type gt
+            graphql._type gt
             join graphql.entity_column ec
                 on gt.entity = ec.entity
-            join graphql.type gt_scalar
+            join graphql._type gt_scalar
                 on graphql.type_id(ec.column_type) = gt_scalar.graphql_type_id
                 and gt_scalar.meta_kind = 'FilterType'
         where
@@ -1918,7 +1918,7 @@ begin
         null::text as description
     from
         graphql._field f
-        join graphql.type t
+        join graphql._type t
             on f.type_id = t.id
     where
         t.meta_kind in ('__Field', '__EnumValue', '__InputValue', '__Directive');
@@ -1938,9 +1938,9 @@ begin
         null::text as description
     from
         graphql._field f
-        join graphql.type t
+        join graphql._type t
             on f.type_id = t.id
-        join graphql.type pt
+        join graphql._type pt
             on f.parent_type_id = pt.id
     where
         t.meta_kind = '__Type'
@@ -1960,7 +1960,7 @@ begin
         f.id parent_arg_field_id,
         y.description
     from
-        graphql.type t
+        graphql._type t
         inner join graphql._field f
             on t.id = f.type_id,
         lateral (
@@ -1984,7 +1984,7 @@ begin
         f.id parent_arg_field_id,
         y.description
     from
-        graphql.type t
+        graphql._type t
         inner join graphql._field f
             on t.id = f.type_id,
         lateral (
@@ -2009,11 +2009,11 @@ begin
         f.id parent_arg_field_name,
         'Sort order to apply to the collection' as description
     from
-        graphql.type t
+        graphql._type t
         inner join graphql._field f
             on t.id = f.type_id
             and t.meta_kind = 'Connection'
-        inner join graphql.type tt
+        inner join graphql._type tt
             on t.entity = tt.entity
             and tt.meta_kind = 'OrderBy';
 
@@ -2030,11 +2030,11 @@ begin
         f.id parent_arg_field_id,
         'Filters to apply to the results set when querying from the collection' as description
     from
-        graphql.type t
+        graphql._type t
         inner join graphql._field f
             on t.id = f.type_id
             and t.meta_kind = 'Connection'
-        inner join graphql.type tt
+        inner join graphql._type tt
             on t.entity = tt.entity
             and tt.meta_kind = 'FilterEntity';
 
@@ -2051,7 +2051,7 @@ begin
             fs.description,
             false as is_hidden_from_schema
         from
-            graphql.type node,
+            graphql._type node,
             lateral (
                 values
                     ('Mutation.insert', node.id, false, false, false, format('Adds one or more `%s` records to the collection', node.name))
@@ -2072,7 +2072,7 @@ begin
             fs.description,
             false as is_hidden_from_schema
         from
-            graphql.type ret_type,
+            graphql._type ret_type,
             lateral (
                 values
                     ('Mutation.update', ret_type.id, true,  false,  false,  'Updates zero or more records in the collection')
@@ -2093,7 +2093,7 @@ begin
             fs.description,
             false as is_hidden_from_schema
         from
-            graphql.type ret_type,
+            graphql._type ret_type,
             lateral (
                 values
                     ('Mutation.delete', ret_type.id, true,  false,  false,  'Deletes zero or more records from the collection')
@@ -2116,11 +2116,11 @@ begin
             f.id parent_arg_field_id,
             null as description
         from
-            graphql.type t
+            graphql._type t
             inner join graphql._field f
                 on t.id = f.type_id
                 and f.meta_kind = 'Mutation.insert'
-            inner join graphql.type tt
+            inner join graphql._type tt
                 on t.entity = tt.entity
                 and tt.meta_kind = 'InsertNode',
             lateral (
@@ -2174,8 +2174,8 @@ begin
         x.is_array_not_null,
         x.description
     from
-        graphql.type t
-        join graphql.type t_base
+        graphql._type t
+        join graphql._type t_base
             on t.entity = t_base.entity
             and t_base.meta_kind = 'Node',
         lateral (
@@ -2202,7 +2202,7 @@ begin
         'Restricts the mutation''s impact to records matching the critera' as description
     from
         graphql._field f
-        inner join graphql.type tt
+        inner join graphql._type tt
             on f.entity = tt.entity
             and tt.meta_kind = 'FilterEntity'
     where
@@ -2244,7 +2244,7 @@ begin
             'Fields that are set will be updated for all records matching the `filter`' as description
         from
             graphql._field f
-            inner join graphql.type tt
+            inner join graphql._type tt
                 on tt.meta_kind = 'UpdateNode'
                 and f.entity = tt.entity
             where

--- a/src/sql/reflection/field/field.sql
+++ b/src/sql/reflection/field/field.sql
@@ -311,7 +311,7 @@ begin
         t.id,
         x.*
     from
-        graphql.type t,
+        graphql._type t,
         lateral (
             values
                 (graphql.type_id('__Type'),   '__type',   true,  false, null::boolean, true,  null::text),
@@ -343,10 +343,10 @@ begin
             fs.description,
             fs.is_hidden_from_schema
         from
-            graphql.type conn
-            join graphql.type edge
+            graphql._type conn
+            join graphql._type edge
                 on conn.entity = edge.entity
-            join graphql.type node
+            join graphql._type node
                 on edge.entity = node.entity,
             lateral (
                 values
@@ -374,7 +374,7 @@ begin
             false as is_array,
             'The total number of records matching the `filter` criteria'
         from
-            graphql.type conn
+            graphql._type conn
         where
             conn.meta_kind = 'Connection'
             and graphql.comment_directive_totalCount_enabled(conn.entity);
@@ -391,7 +391,7 @@ begin
             false,
             true
         from
-            graphql.type t
+            graphql._type t
         where
             t.type_kind = 'OBJECT';
 
@@ -413,7 +413,7 @@ begin
             es.column_attribute_num,
             false as is_hidden_from_schema
         from
-            graphql.type gt
+            graphql._type gt
             join graphql.entity_column es
                 on gt.entity = es.entity
         where
@@ -437,7 +437,7 @@ begin
             false as is_hidden_from_schema,
             pp.oid::regproc as func
         from
-            graphql.type gt
+            graphql._type gt
             join pg_class pc
                 on gt.entity = pc.oid
             join pg_proc pp
@@ -481,10 +481,10 @@ begin
             rel.foreign_columns,
             rel.foreign_name_override
         from
-            graphql.type node
+            graphql._type node
             join graphql.relationship rel
                 on node.entity = rel.local_entity
-            join graphql.type conn
+            join graphql._type conn
                 on conn.entity = rel.foreign_entity
                 and (
                     (conn.meta_kind = 'Node' and rel.foreign_cardinality = 'ONE')
@@ -509,7 +509,7 @@ begin
             gt.entity,
             null::text description
         from
-            graphql.type gt
+            graphql._type gt
             join graphql.entity_column ec
                 on gt.entity = ec.entity
         where
@@ -528,7 +528,7 @@ begin
             false,
             null::text as description
         from
-            graphql.type gt -- IntFilter
+            graphql._type gt -- IntFilter
             join (
                 values
                     ('eq'),
@@ -560,10 +560,10 @@ begin
             gt.entity,
             null::text description
         from
-            graphql.type gt
+            graphql._type gt
             join graphql.entity_column ec
                 on gt.entity = ec.entity
-            join graphql.type gt_scalar
+            join graphql._type gt_scalar
                 on graphql.type_id(ec.column_type) = gt_scalar.graphql_type_id
                 and gt_scalar.meta_kind = 'FilterType'
         where
@@ -591,7 +591,7 @@ begin
         null::text as description
     from
         graphql._field f
-        join graphql.type t
+        join graphql._type t
             on f.type_id = t.id
     where
         t.meta_kind in ('__Field', '__EnumValue', '__InputValue', '__Directive');
@@ -611,9 +611,9 @@ begin
         null::text as description
     from
         graphql._field f
-        join graphql.type t
+        join graphql._type t
             on f.type_id = t.id
-        join graphql.type pt
+        join graphql._type pt
             on f.parent_type_id = pt.id
     where
         t.meta_kind = '__Type'
@@ -633,7 +633,7 @@ begin
         f.id parent_arg_field_id,
         y.description
     from
-        graphql.type t
+        graphql._type t
         inner join graphql._field f
             on t.id = f.type_id,
         lateral (
@@ -657,7 +657,7 @@ begin
         f.id parent_arg_field_id,
         y.description
     from
-        graphql.type t
+        graphql._type t
         inner join graphql._field f
             on t.id = f.type_id,
         lateral (
@@ -682,11 +682,11 @@ begin
         f.id parent_arg_field_name,
         'Sort order to apply to the collection' as description
     from
-        graphql.type t
+        graphql._type t
         inner join graphql._field f
             on t.id = f.type_id
             and t.meta_kind = 'Connection'
-        inner join graphql.type tt
+        inner join graphql._type tt
             on t.entity = tt.entity
             and tt.meta_kind = 'OrderBy';
 
@@ -703,11 +703,11 @@ begin
         f.id parent_arg_field_id,
         'Filters to apply to the results set when querying from the collection' as description
     from
-        graphql.type t
+        graphql._type t
         inner join graphql._field f
             on t.id = f.type_id
             and t.meta_kind = 'Connection'
-        inner join graphql.type tt
+        inner join graphql._type tt
             on t.entity = tt.entity
             and tt.meta_kind = 'FilterEntity';
 
@@ -724,7 +724,7 @@ begin
             fs.description,
             false as is_hidden_from_schema
         from
-            graphql.type node,
+            graphql._type node,
             lateral (
                 values
                     ('Mutation.insert', node.id, false, false, false, format('Adds one or more `%s` records to the collection', node.name))
@@ -745,7 +745,7 @@ begin
             fs.description,
             false as is_hidden_from_schema
         from
-            graphql.type ret_type,
+            graphql._type ret_type,
             lateral (
                 values
                     ('Mutation.update', ret_type.id, true,  false,  false,  'Updates zero or more records in the collection')
@@ -766,7 +766,7 @@ begin
             fs.description,
             false as is_hidden_from_schema
         from
-            graphql.type ret_type,
+            graphql._type ret_type,
             lateral (
                 values
                     ('Mutation.delete', ret_type.id, true,  false,  false,  'Deletes zero or more records from the collection')
@@ -789,11 +789,11 @@ begin
             f.id parent_arg_field_id,
             null as description
         from
-            graphql.type t
+            graphql._type t
             inner join graphql._field f
                 on t.id = f.type_id
                 and f.meta_kind = 'Mutation.insert'
-            inner join graphql.type tt
+            inner join graphql._type tt
                 on t.entity = tt.entity
                 and tt.meta_kind = 'InsertNode',
             lateral (
@@ -847,8 +847,8 @@ begin
         x.is_array_not_null,
         x.description
     from
-        graphql.type t
-        join graphql.type t_base
+        graphql._type t
+        join graphql._type t_base
             on t.entity = t_base.entity
             and t_base.meta_kind = 'Node',
         lateral (
@@ -875,7 +875,7 @@ begin
         'Restricts the mutation''s impact to records matching the critera' as description
     from
         graphql._field f
-        inner join graphql.type tt
+        inner join graphql._type tt
             on f.entity = tt.entity
             and tt.meta_kind = 'FilterEntity'
     where
@@ -917,7 +917,7 @@ begin
             'Fields that are set will be updated for all records matching the `filter`' as description
         from
             graphql._field f
-            inner join graphql.type tt
+            inner join graphql._type tt
                 on tt.meta_kind = 'UpdateNode'
                 and f.entity = tt.entity
             where


### PR DESCRIPTION
## What kind of change does this PR introduce?
When rebuilding the graphql schema, reference the `_type` table instead of `type` view to avoid filtering out entities that are not visible to the user that triggered the refresh + the current search path.

## What is the current behavior?
Only entities are on the `search_path` at the time of the schema rebuild and visible to the `current_role` are entered into the `_field` table

## What is the new behavior?
All entries in `_type` have their fields added to `_field`

## Additional context
This bug was found when the default install command was changed from `create extension pg_graphql` to `create extension pg_graphql with schema extensions` because it manipulates the `search_path` during install. As a result, the initial schema build (on install) did not populate `_field` with entities from (e.g.) the `public` schema, because it was no longer on the search path.

This bug has always existed but was masked by `public` consistently being on the search path during extension creation
