### PR TITLE
feat(operators): initial support for like/ilike

### DIFF
--- a/src/sql/resolve/clause/filter/text_to_comparison_op.sql
+++ b/src/sql/resolve/clause/filter/text_to_comparison_op.sql
@@ -12,6 +12,8 @@ $$
             when 'neq' then '<>'
             when 'gte' then '>='
             when 'gt' then '>'
+            when 'like' then 'like'
+            when 'ilike' then 'ilike'
             else graphql.exception('Invalid comaprison operator')
         end::graphql.comparison_op
 $$;

--- a/src/sql/resolve/clause/filter/types/comparison_op.sql
+++ b/src/sql/resolve/clause/filter/types/comparison_op.sql
@@ -1,1 +1,1 @@
-create type graphql.comparison_op as enum ('=', '<', '<=', '<>', '>=', '>');
+create type graphql.comparison_op as enum ('=', '<', '<=', '<>', '>=', '>', 'like', 'ilike');


### PR DESCRIPTION
## What kind of change does this PR introduce?

Support for `like`/`ilike` operators

## What is the current behavior?

#193 

## What is the new behavior?

Filter operators added for `like`/`ilike`

## Additional context

I've only tried this out in the DB from Supabase CLI so I could only run rebuild_schema() to refresh my changes, but I was unable to get either operator to appear when introspecting the gql endpoint. Running queries regarless with like/ilike worked perfectly though.

### Missing:

* Introspection (may have been due to how I was testing this?)
* `not like`/`not ilike`. I'm not sure how to go about this
* Tests are missing

resolves #193