### PR TITLE
Fix spelling on reflection.md

### DIFF
--- a/docs/reflection.md
+++ b/docs/reflection.md
@@ -12,7 +12,7 @@ Table, column, and relationship type and field names may also be [manually overr
 
 ### Connection Types
 
-Connection types hande pagination best practices according to the [relay spec](https://relay.dev/graphql/connections.htm#). `pg_graphql` uses keyset pagination to enable consistent retrival times on every page.
+Connection types handle pagination best practices according to the [relay spec](https://relay.dev/graphql/connections.htm#). `pg_graphql` uses keyset pagination to enable consistent retrival times on every page.
 
 ## Example
 


### PR DESCRIPTION
Change "hande" to "handle".

## What kind of change does this PR introduce?

Documentation spelling fix.

## What is the current behavior?

"Connection types **hande** pagination best practices according to the [relay spec](https://relay.dev/graphql/connections.htm#)."

## What is the new behavior?

Connection types **handle** pagination best practices according to the [relay spec](https://relay.dev/graphql/connections.htm#)."

## Additional context

N/A