### PR TITLE
Entities read inflect_name directive from owning schema, not current_…

### DIFF
--- a/src/sql/pg/to_regnamespace.sql
+++ b/src/sql/pg/to_regnamespace.sql
@@ -1,0 +1,16 @@
+create function graphql.to_regnamespace(regclass)
+    returns regnamespace
+    language sql
+    set search_path to ''
+    immutable
+as
+$$ select (parse_ident($1::text))[1]::regnamespace $$;
+
+
+create function graphql.to_regnamespace(regproc)
+    returns regnamespace
+    language sql
+    set search_path to ''
+    immutable
+as
+$$ select (parse_ident($1::text))[1]::regnamespace $$;

--- a/src/sql/reflection/field/field.sql
+++ b/src/sql/reflection/field/field.sql
@@ -73,7 +73,7 @@ as $$
     select
         coalesce(
             graphql.comment_directive_name($1, $2),
-            case graphql.comment_directive_inflect_names(current_schema::regnamespace)
+            case graphql.comment_directive_inflect_names(graphql.to_regnamespace(entity))
                 when true then graphql.to_camel_case($2)
                 else $2
             end
@@ -136,7 +136,7 @@ create or replace function graphql.field_name_for_to_one(foreign_entity regclass
     language plpgsql
 as $$
 declare
-    is_inflection_on bool = graphql.comment_directive_inflect_names(current_schema::regnamespace);
+    is_inflection_on bool = graphql.comment_directive_inflect_names(graphql.to_regnamespace(foreign_entity));
 
     has_req_suffix text = case is_inflection_on
         when true then '\_id'
@@ -190,7 +190,7 @@ as $$
     select
         coalesce(
             graphql.comment_directive_name(func),
-            case graphql.comment_directive_inflect_names(current_schema::regnamespace)
+            case graphql.comment_directive_inflect_names(graphql.to_regnamespace(func))
                 when true then graphql.to_camel_case(ltrim(graphql.to_function_name(func), '_'))
                 else ltrim(graphql.to_function_name(func), '_')
             end

--- a/src/sql/reflection/type/tables/_type.sql
+++ b/src/sql/reflection/type/tables/_type.sql
@@ -41,7 +41,7 @@ as $$
                     -- Explicit name has firts priority
                     graphql.comment_directive_name(rec.entity),
                     -- When the schema has "inflect_names: true then inflect. otherwise, use table name
-                    case graphql.comment_directive_inflect_names(current_schema::regnamespace)
+                    case graphql.comment_directive_inflect_names(graphql.to_regnamespace(rec.entity))
                         when true then graphql.inflect_type_default(graphql.to_table_name(rec.entity))
                         else graphql.to_table_name(rec.entity)
                     end

--- a/test/expected/issue_201.out
+++ b/test/expected/issue_201.out
@@ -1,0 +1,48 @@
+begin;
+    /*
+    When the extension is installed via
+        create extension pg_graphql with schema xyz;
+
+    The initial build runs with search_path = 'xyz';
+
+    While names are being inflected, we check if the inflect_names comment
+    directive is active. The bug was that we checked in `current_schema`
+    rather than the schema associated with the entity being named
+
+    This test confirms that inflection rules are pulled from the owning schema
+    rather than the search path.
+    */
+    comment on schema public is '@graphql({"inflect_names": true})';
+    create schema xyz;
+    create table account_holder(
+        id serial primary key,
+        email_address varchar(255) not null
+    );
+    drop extension pg_graphql;
+    create extension pg_graphql with schema xyz;
+    select name from graphql.type where name ilike 'a%';
+            name             
+-----------------------------
+ AccountHolder
+ AccountHolderEdge
+ AccountHolderConnection
+ AccountHolderOrderBy
+ AccountHolderFilter
+ AccountHolderInsertInput
+ AccountHolderUpdateInput
+ AccountHolderInsertResponse
+ AccountHolderUpdateResponse
+ AccountHolderDeleteResponse
+(10 rows)
+
+    select name from graphql.field where parent_type ilike 'AccountHolder%' and name ilike 'email%';
+     name     
+--------------
+ emailAddress
+ emailAddress
+ emailAddress
+ emailAddress
+ emailAddress
+(5 rows)
+
+rollback;

--- a/test/expected/search_path_filters_visibility.out
+++ b/test/expected/search_path_filters_visibility.out
@@ -37,7 +37,7 @@ begin;
         and meta_kind = 'Node';
  name 
 ------
- Bar
+ bar
 (1 row)
 
 rollback;

--- a/test/sql/issue_201.sql
+++ b/test/sql/issue_201.sql
@@ -1,0 +1,31 @@
+begin;
+    /*
+    When the extension is installed via
+        create extension pg_graphql with schema xyz;
+
+    The initial build runs with search_path = 'xyz';
+
+    While names are being inflected, we check if the inflect_names comment
+    directive is active. The bug was that we checked in `current_schema`
+    rather than the schema associated with the entity being named
+
+    This test confirms that inflection rules are pulled from the owning schema
+    rather than the search path.
+    */
+
+    comment on schema public is '@graphql({"inflect_names": true})';
+
+    create schema xyz;
+
+    create table account_holder(
+        id serial primary key,
+        email_address varchar(255) not null
+    );
+
+    drop extension pg_graphql;
+    create extension pg_graphql with schema xyz;
+
+    select name from graphql.type where name ilike 'a%';
+    select name from graphql.field where parent_type ilike 'AccountHolder%' and name ilike 'email%';
+
+rollback;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix: entities should read `inflect_names` comment directive from their owning schema rather than the `current_schema`

resolves #201 