### PR TITLE
Remove unused format call preventing strings with %

### DIFF
--- a/pg_graphql--0.4.0.sql
+++ b/pg_graphql--0.4.0.sql
@@ -3525,19 +3525,17 @@ begin
     with value_rows(r) as (
         select
             format(
-                format(
-                    '(%s)',
-                    string_agg(
-                        format(
-                            '%s',
-                            case
-                                when row_col.field_val is null then 'default'
-                                else format('%L', row_col.field_val)
-                            end
-                        ),
-                        ', '
-                        order by vfk.field_name asc
-                    )
+                '(%s)',
+                string_agg(
+                    format(
+                        '%s',
+                        case
+                            when row_col.field_val is null then 'default'
+                            else format('%L', row_col.field_val)
+                        end
+                    ),
+                    ', '
+                    order by vfk.field_name asc
                 )
             )
         from

--- a/src/sql/resolve/transpile/build_insert.sql
+++ b/src/sql/resolve/transpile/build_insert.sql
@@ -93,19 +93,17 @@ begin
     with value_rows(r) as (
         select
             format(
-                format(
-                    '(%s)',
-                    string_agg(
-                        format(
-                            '%s',
-                            case
-                                when row_col.field_val is null then 'default'
-                                else format('%L', row_col.field_val)
-                            end
-                        ),
-                        ', '
-                        order by vfk.field_name asc
-                    )
+                '(%s)',
+                string_agg(
+                    format(
+                        '%s',
+                        case
+                            when row_col.field_val is null then 'default'
+                            else format('%L', row_col.field_val)
+                        end
+                    ),
+                    ', '
+                    order by vfk.field_name asc
                 )
             )
         from

--- a/test/expected/issue_211.out
+++ b/test/expected/issue_211.out
@@ -1,0 +1,24 @@
+begin;
+    create table project(
+        id serial primary key,
+        name varchar(255) not null
+    );
+    select graphql.resolve($$
+    mutation {
+      insertIntoProjectCollection(objects: [
+        { name: "aaaa%aaaa"},
+      ]) {
+        affectedCount
+        records {
+          id
+          name
+        }
+      }
+    }
+    $$);
+                                                   resolve                                                    
+--------------------------------------------------------------------------------------------------------------
+ {"data": {"insertIntoProjectCollection": {"records": [{"id": 1, "name": "aaaa%aaaa"}], "affectedCount": 1}}}
+(1 row)
+
+rollback;

--- a/test/sql/issue_211.sql
+++ b/test/sql/issue_211.sql
@@ -1,0 +1,22 @@
+begin;
+
+    create table project(
+        id serial primary key,
+        name varchar(255) not null
+    );
+
+    select graphql.resolve($$
+    mutation {
+      insertIntoProjectCollection(objects: [
+        { name: "aaaa%aaaa"},
+      ]) {
+        affectedCount
+        records {
+          id
+          name
+        }
+      }
+    }
+    $$);
+
+rollback;


### PR DESCRIPTION
## What kind of change does this PR introduce?
Resolve a bug preventing inserts where any input value contains a `%`.

There was an unused call to format 
https://github.com/supabase/pg_graphql/compare/or/issue_211?expand=1#diff-8f3a50dce91843a34436a48c660b994588e9d849b0599d0b0e0f1edd617e30adL95

which caused postgres to interpret strings containing a '%' as a format string, rather than a literal.

resolves #211 