### PR TITLE
Add tests for nulls in orderBy argument

### DIFF
--- a/test/expected/issue_225.out
+++ b/test/expected/issue_225.out
@@ -1,0 +1,142 @@
+begin;
+    -- https://github.com/supabase/pg_graphql/issues/225
+    create table post(
+        id int primary key,
+        title text
+    );
+    insert into public.post(id, title)
+    select x.id, (10-x.id)::text from generate_series(1,3) x(id);
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              postCollection( orderBy: [{id: DescNullsFirst, title: null}]) {
+                edges {
+                  node {
+                    id
+                    title
+                  }
+                }
+              }
+            }
+        $$)
+    );
+             jsonb_pretty             
+--------------------------------------
+ {                                   +
+     "data": {                       +
+         "postCollection": {         +
+             "edges": [              +
+                 {                   +
+                     "node": {       +
+                         "id": 3,    +
+                         "title": "7"+
+                     }               +
+                 },                  +
+                 {                   +
+                     "node": {       +
+                         "id": 2,    +
+                         "title": "8"+
+                     }               +
+                 },                  +
+                 {                   +
+                     "node": {       +
+                         "id": 1,    +
+                         "title": "9"+
+                     }               +
+                 }                   +
+             ]                       +
+         }                           +
+     }                               +
+ }
+(1 row)
+
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              postCollection( orderBy: [{id: null, title: DescNullsLast}]) {
+                edges {
+                  node {
+                    id
+                    title
+                  }
+                }
+              }
+            }
+        $$)
+    );
+             jsonb_pretty             
+--------------------------------------
+ {                                   +
+     "data": {                       +
+         "postCollection": {         +
+             "edges": [              +
+                 {                   +
+                     "node": {       +
+                         "id": 1,    +
+                         "title": "9"+
+                     }               +
+                 },                  +
+                 {                   +
+                     "node": {       +
+                         "id": 2,    +
+                         "title": "8"+
+                     }               +
+                 },                  +
+                 {                   +
+                     "node": {       +
+                         "id": 3,    +
+                         "title": "7"+
+                     }               +
+                 }                   +
+             ]                       +
+         }                           +
+     }                               +
+ }
+(1 row)
+
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              postCollection( orderBy: [{id: null}, { title: DescNullsLast}]) {
+                edges {
+                  node {
+                    id
+                    title
+                  }
+                }
+              }
+            }
+        $$)
+    );
+             jsonb_pretty             
+--------------------------------------
+ {                                   +
+     "data": {                       +
+         "postCollection": {         +
+             "edges": [              +
+                 {                   +
+                     "node": {       +
+                         "id": 1,    +
+                         "title": "9"+
+                     }               +
+                 },                  +
+                 {                   +
+                     "node": {       +
+                         "id": 2,    +
+                         "title": "8"+
+                     }               +
+                 },                  +
+                 {                   +
+                     "node": {       +
+                         "id": 3,    +
+                         "title": "7"+
+                     }               +
+                 }                   +
+             ]                       +
+         }                           +
+     }                               +
+ }
+(1 row)
+
+    
+rollback;

--- a/test/expected/issue_225.out
+++ b/test/expected/issue_225.out
@@ -138,5 +138,4 @@ begin;
  }
 (1 row)
 
-    
 rollback;

--- a/test/sql/issue_225.sql
+++ b/test/sql/issue_225.sql
@@ -1,0 +1,58 @@
+begin;
+    -- https://github.com/supabase/pg_graphql/issues/225
+
+    create table post(
+        id int primary key,
+        title text
+    );
+
+    insert into public.post(id, title)
+    select x.id, (10-x.id)::text from generate_series(1,3) x(id);
+
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              postCollection( orderBy: [{id: DescNullsFirst, title: null}]) {
+                edges {
+                  node {
+                    id
+                    title
+                  }
+                }
+              }
+            }
+        $$)
+    );
+
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              postCollection( orderBy: [{id: null, title: DescNullsLast}]) {
+                edges {
+                  node {
+                    id
+                    title
+                  }
+                }
+              }
+            }
+        $$)
+    );
+
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              postCollection( orderBy: [{id: null}, { title: DescNullsLast}]) {
+                edges {
+                  node {
+                    id
+                    title
+                  }
+                }
+              }
+            }
+        $$)
+    );
+
+
+rollback;


### PR DESCRIPTION
## What kind of change does this PR introduce?
Adds tests to verify behavior of nulls in various places in an `orderBy` argument.

Current behavior is correct, the purpose of this PR is to prevent regressions.

resolves #225