### PR TITLE
Fix all but one clippy error

### DIFF
--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 
 impl Context {
     fn inflect_names(&self, schema_oid: u32) -> bool {
-        let schema = self.schemas.iter().filter(|x| x.oid == schema_oid).next();
+        let schema = self.schemas.iter().find(|x| x.oid == schema_oid);
         schema.map(|s| s.directives.inflect_names).unwrap_or(false)
     }
 }
@@ -27,7 +27,7 @@ fn to_base_type_name(
         false => table_name.to_string(),
         true => {
             let mut padded = "+".to_string();
-            padded.push_str(&table_name);
+            padded.push_str(table_name);
 
             // account_BY_email => Account_By_Email
             let casing: String = padded
@@ -86,7 +86,7 @@ impl Function {
         }
 
         // remove underscore prefix from function name before inflecting
-        let trimmed_function_name = &self.name.strip_prefix("_").unwrap_or(&self.name);
+        let trimmed_function_name = &self.name.strip_prefix('_').unwrap_or(&self.name);
 
         let base_type_name = to_base_type_name(
             trimmed_function_name,
@@ -258,7 +258,7 @@ pub trait ___Type {
 
     fn field_map(&self) -> HashMap<String, __Field> {
         let mut hmap = HashMap::new();
-        let fields = self.fields(true).unwrap_or(vec![]);
+        let fields = self.fields(true).unwrap_or_default();
         for field in fields {
             hmap.insert(field.name(), field);
         }
@@ -278,7 +278,7 @@ pub trait ___Type {
 
     fn input_field_map(&self) -> HashMap<String, __InputValue> {
         let mut hmap = HashMap::new();
-        let fields = self.input_fields().unwrap_or(vec![]);
+        let fields = self.input_fields().unwrap_or_default();
         for field in fields {
             hmap.insert(field.name(), field);
         }
@@ -377,7 +377,7 @@ impl ___Field for __Field {
 
     // isDeprecated: Boolean!
     fn is_deprecated(&self) -> bool {
-        !self.deprecation_reason().is_none()
+        self.deprecation_reason().is_some()
     }
 
     // deprecationReason: String
@@ -418,7 +418,7 @@ impl __InputValue {
 
     // isDeprecated: Boolean!
     pub fn is_deprecated(&self) -> bool {
-        !self.deprecation_reason().is_none()
+        self.deprecation_reason().is_some()
     }
 
     // deprecationReason: String
@@ -427,7 +427,7 @@ impl __InputValue {
     }
 }
 
-#[allow(non_camel_case_types)]
+#[allow(non_camel_case_types, clippy::upper_case_acronyms)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum __TypeKind {
     SCALAR,
@@ -459,7 +459,7 @@ impl __EnumValue {
 
     // isDeprecated: Boolean!
     pub fn is_deprecated(&self) -> bool {
-        !self.deprecation_reason.is_none()
+        self.deprecation_reason.is_some()
     }
 
     // deprecationReason: String
@@ -749,6 +749,7 @@ impl __Type {
     }
 }
 
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Scalar {
     ID,
@@ -1005,7 +1006,7 @@ impl ___Type for QueryType {
         // If there are no fields other than the default __type and __schema
         // inject heartbeat so introspection does not fail (all objects must have > 0 fields &
         // Query is a required type)
-        if f.len() == 0 {
+        if f.is_empty() {
             f.push(__Field {
                 name_: "heartbeat".to_string(),
                 type_: __Type::Scalar(Scalar::Datetime),
@@ -1044,7 +1045,7 @@ impl ___Type for QueryType {
             },
         ]);
 
-        f.sort_by(|a, b| a.name().cmp(&b.name()));
+        f.sort_by_key(|a| a.name());
         Some(f)
     }
 }
@@ -1194,7 +1195,7 @@ impl ___Type for MutationType {
                 }
             }
         }
-        f.sort_by(|a, b| a.name().cmp(&b.name()));
+        f.sort_by_key(|a| a.name());
         Some(f)
     }
 }
@@ -1220,10 +1221,7 @@ impl ___Type for EnumType {
 
     fn name(&self) -> Option<String> {
         let inflect_names = self.schema.context.inflect_names(self.enum_.schema_oid);
-        Some(format!(
-            "{}",
-            self.enum_.graphql_base_type_name(inflect_names)
-        ))
+        Some(self.enum_.graphql_base_type_name(inflect_names))
     }
 
     fn fields(&self, _include_deprecated: bool) -> Option<Vec<__Field>> {
@@ -1456,7 +1454,7 @@ impl ___Type for NodeType {
     }
 
     fn name(&self) -> Option<String> {
-        Some(format!("{}", self.table.graphql_base_type_name()))
+        Some(self.table.graphql_base_type_name())
     }
 
     fn fields(&self, _include_deprecated: bool) -> Option<Vec<__Field>> {
@@ -1516,8 +1514,7 @@ impl ___Type for NodeType {
                 .context
                 .schemas
                 .iter()
-                .map(|x| x.tables.iter())
-                .flatten()
+                .flat_map(|x| x.tables.iter())
                 .find(|x| x.oid == fkey.referenced_table_meta.oid);
             // this should never happen but if there is an unhandled edge case panic-ing here
             // would block
@@ -1551,10 +1548,8 @@ impl ___Type for NodeType {
             .context
             .schemas
             .iter()
-            .map(|schema| schema.tables.iter())
-            .flatten()
-            .map(|tab| tab.foreign_keys.iter())
-            .flatten()
+            .flat_map(|schema| schema.tables.iter())
+            .flat_map(|tab| tab.foreign_keys.iter())
             .filter(|x| x.permissions.is_selectable)
             // inbound references
             .filter(|x| x.referenced_table_meta.oid == self.table.oid)
@@ -1565,8 +1560,7 @@ impl ___Type for NodeType {
                 .context
                 .schemas
                 .iter()
-                .map(|x| x.tables.iter())
-                .flatten()
+                .flat_map(|x| x.tables.iter())
                 .find(|x| x.oid == fkey.local_table_meta.oid);
             // this should never happen but if there is an unhandled edge case panic-ing here
             // would block
@@ -2850,7 +2844,7 @@ impl ___Type for FilterTypeType {
             }
         };
 
-        infields.sort_by(|a, b| a.name().cmp(&b.name()));
+        infields.sort_by_key(|a| a.name());
         Some(infields)
     }
 }
@@ -2881,7 +2875,7 @@ impl ___Type for FilterEntityType {
                 .filter(|x| !self.schema.context.is_composite(x.type_oid))
                 // No filtering on json/b. they do not support = or <>
                 .filter(|x| !vec!["json", "jsonb"].contains(&x.type_name.as_ref()))
-                .map(|col| {
+                .filter_map(|col| {
                     // Should be a scalar
                     let utype = sql_column_to_graphql_type(col, &self.schema).unmodified_type();
 
@@ -2908,7 +2902,6 @@ impl ___Type for FilterEntityType {
                         _ => None,
                     }
                 })
-                .filter_map(|x| x)
                 .collect(),
         )
     }
@@ -3169,7 +3162,7 @@ impl __Schema {
             }
         }
 
-        types_.sort_by(|a, b| a.name().cmp(&b.name()));
+        types_.sort_by_key(|a| a.name());
         types_
     }
 
@@ -3187,8 +3180,7 @@ impl __Schema {
         self.context
             .schemas
             .iter()
-            .map(|x| x.tables.iter())
-            .flatten()
+            .flat_map(|x| x.tables.iter())
             .filter(|x| x.graphql_select_types_are_valid())
             .any(|x| {
                 x.permissions.is_selectable
@@ -3215,7 +3207,7 @@ impl __Schema {
             schema: Rc::new(self.clone()),
         };
 
-        match mutation.fields(true).unwrap_or(vec![]).len() {
+        match mutation.fields(true).unwrap_or_default().len() {
             0 => None,
             _ => Some(__Type::Mutation(mutation)),
         }

--- a/src/omit.rs
+++ b/src/omit.rs
@@ -9,9 +9,6 @@ pub enum Omit<T> {
 
 impl<T> Omit<T> {
     pub fn is_omit(&self) -> bool {
-        match &self {
-            Self::Omitted => true,
-            _ => false,
-        }
+        matches!(self, Self::Omitted)
     }
 }

--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -173,7 +173,7 @@ pub struct Table {
 
 impl Table {
     pub fn primary_key(&self) -> Option<&Index> {
-        self.indexes.iter().filter(|x| x.is_primary_key).next()
+        self.indexes.iter().find(|x| x.is_primary_key)
     }
 
     pub fn primary_key_columns(&self) -> Vec<&Column> {
@@ -184,34 +184,21 @@ impl Table {
             .map(|col_num| {
                 self.columns
                     .iter()
-                    .filter(|col| &col.attribute_num == col_num)
-                    .next()
+                    .find(|col| &col.attribute_num == col_num)
                     .expect("Failed to unwrap pkey by attnum")
             })
             .collect::<Vec<&Column>>()
     }
 
     pub fn is_any_column_selectable(&self) -> bool {
-        self.columns
-            .iter()
-            .filter(|x| x.permissions.is_selectable)
-            .next()
-            .is_some()
+        self.columns.iter().any(|x| x.permissions.is_selectable)
     }
     pub fn is_any_column_insertable(&self) -> bool {
-        self.columns
-            .iter()
-            .filter(|x| x.permissions.is_insertable)
-            .next()
-            .is_some()
+        self.columns.iter().any(|x| x.permissions.is_insertable)
     }
 
     pub fn is_any_column_updatable(&self) -> bool {
-        self.columns
-            .iter()
-            .filter(|x| x.permissions.is_updatable)
-            .next()
-            .is_some()
+        self.columns.iter().any(|x| x.permissions.is_updatable)
     }
 }
 
@@ -257,11 +244,7 @@ pub struct Context {
 
 impl Context {
     pub fn is_composite(&self, type_oid: u32) -> bool {
-        self.composites
-            .iter()
-            .filter(|x| x.oid == type_oid)
-            .next()
-            .is_some()
+        self.composites.iter().any(|x| x.oid == type_oid)
     }
 }
 
@@ -297,7 +280,7 @@ mod tests {
         let config = load_sql_config();
         let context = load_sql_context(&config);
         assert!(context.schemas.len() == 1);
-        assert!(context.schemas[0].tables.len() == 0);
+        assert!(context.schemas[0].tables.is_empty());
     }
 
     #[pg_test]

--- a/src/transpile.rs
+++ b/src/transpile.rs
@@ -91,13 +91,13 @@ impl Table {
 
         )"
         */
-        if cursor.elems.len() == 0 {
+        if cursor.elems.is_empty() {
             return Ok(format!("{allow_equality}"));
         }
         let mut next_cursor = cursor.clone();
         let cursor_elem = next_cursor.elems.remove(0);
 
-        if order_by.elems.len() == 0 {
+        if order_by.elems.is_empty() {
             return Err("orderBy clause incompatible with pagination cursor".to_string());
         }
         let mut next_order_by = order_by.clone();
@@ -268,7 +268,7 @@ impl InsertSelection {
                 )
             }
             Self::Typename { alias, typename } => {
-                format!("{}, {}", quote_literal(&alias), quote_literal(&typename))
+                format!("{}, {}", quote_literal(alias), quote_literal(typename))
             }
         };
         Ok(r)
@@ -293,7 +293,7 @@ impl UpdateSelection {
                 )
             }
             Self::Typename { alias, typename } => {
-                format!("{}, {}", quote_literal(&alias), quote_literal(&typename))
+                format!("{}, {}", quote_literal(alias), quote_literal(typename))
             }
         };
         Ok(r)
@@ -318,7 +318,7 @@ impl DeleteSelection {
                 )
             }
             Self::Typename { alias, typename } => {
-                format!("{}, {}", quote_literal(&alias), quote_literal(&typename))
+                format!("{}, {}", quote_literal(alias), quote_literal(typename))
             }
         };
 
@@ -349,8 +349,7 @@ impl UpdateBuilder {
                     .table
                     .columns
                     .iter()
-                    .filter(|x| &x.name == column_name)
-                    .next()
+                    .find(|x| &x.name == column_name)
                     .expect("Failed to find field in update builder");
 
                 let value_clause = param_context.clause_for(val, &column.type_name);
@@ -584,47 +583,31 @@ impl ConnectionBuilder {
     fn requested_total(&self) -> bool {
         self.selections
             .iter()
-            .filter(|x| match x {
-                ConnectionSelection::TotalCount { alias: _ } => true,
-                _ => false,
-            })
-            .next()
-            .is_some()
+            .any(|x| matches!(&x, ConnectionSelection::TotalCount { alias: _ }))
     }
 
     fn page_selections(&self) -> Vec<PageInfoSelection> {
         self.selections
             .iter()
-            .map(|x| match x {
+            .flat_map(|x| match x {
                 ConnectionSelection::PageInfo(page_info_builder) => {
                     page_info_builder.selections.clone()
                 }
                 _ => vec![],
             })
-            .flatten()
             .collect()
     }
 
     fn requested_next_page(&self) -> bool {
         self.page_selections()
             .iter()
-            .filter(|x| match x {
-                PageInfoSelection::HasNextPage { alias: _ } => true,
-                _ => false,
-            })
-            .next()
-            .is_some()
+            .any(|x| matches!(&x, PageInfoSelection::HasNextPage { alias: _ }))
     }
 
     fn requested_previous_page(&self) -> bool {
         self.page_selections()
             .iter()
-            .filter(|x| match x {
-                PageInfoSelection::HasPreviousPage { alias: _ } => true,
-                _ => false,
-            })
-            .next()
-            .is_some()
+            .any(|x| matches!(&x, PageInfoSelection::HasPreviousPage { alias: _ }))
     }
 
     pub fn to_sql(
@@ -681,11 +664,11 @@ impl ConnectionBuilder {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let limit: i64 = cmp::min(self.first.unwrap_or(self.last.unwrap_or(30)), 30);
+        let limit: i64 = cmp::min(self.first.unwrap_or_else(|| self.last.unwrap_or(30)), 30);
 
         let object_clause = frags.join(", ");
 
-        let cursor = &self.before.clone().or(self.after.clone());
+        let cursor = &self.before.clone().or_else(|| self.after.clone());
 
         let pagination_clause = {
             let order_by = match self.last.is_some() {
@@ -696,7 +679,7 @@ impl ConnectionBuilder {
                 Some(cursor) => self.table.to_pagination_clause(
                     &quoted_block_name,
                     &order_by,
-                    &cursor,
+                    cursor,
                     param_context,
                     false,
                 )?,
@@ -788,7 +771,7 @@ impl ConnectionBuilder {
         let mut param_context = ParamContext { params: vec![] };
         let sql = &self.to_sql(None, &mut param_context)?;
 
-        let res: pgx::JsonB = Spi::get_one_with_args(&sql, param_context.params)
+        let res: pgx::JsonB = Spi::get_one_with_args(sql, param_context.params)
             .ok_or("Internal Error: Failed to execute transpiled query")?;
 
         Ok(res.0)
@@ -852,7 +835,7 @@ impl PageInfoSelection {
                 )
             }
             Self::Typename { alias, typename } => {
-                format!("{}, {}", quote_literal(&alias), quote_literal(&typename))
+                format!("{}, {}", quote_literal(alias), quote_literal(typename))
             }
         })
     }
@@ -884,11 +867,11 @@ impl ConnectionSelection {
             Self::TotalCount { alias } => {
                 format!(
                     "{}, coalesce(min(__total_count.___total_count), 0)",
-                    quote_literal(&alias)
+                    quote_literal(alias)
                 )
             }
             Self::Typename { alias, typename } => {
-                format!("{}, {}", quote_literal(&alias), quote_literal(&typename))
+                format!("{}, {}", quote_literal(alias), quote_literal(typename))
             }
         })
     }
@@ -905,7 +888,7 @@ impl EdgeBuilder {
         let frags: Vec<String> = self
             .selections
             .iter()
-            .map(|x| x.to_sql(&block_name, order_by, table, param_context))
+            .map(|x| x.to_sql(block_name, order_by, table, param_context))
             .collect::<Result<Vec<_>, _>>()?;
 
         let x = frags.join(", ");
@@ -942,7 +925,7 @@ impl EdgeSelection {
                 builder.to_sql(block_name, param_context)?
             ),
             Self::Typename { alias, typename } => {
-                format!("{}, {}", quote_literal(&alias), quote_literal(typename))
+                format!("{}, {}", quote_literal(alias), quote_literal(typename))
             }
         })
     }
@@ -957,7 +940,7 @@ impl NodeBuilder {
         let frags: Vec<String> = self
             .selections
             .iter()
-            .map(|x| x.to_sql(&block_name, param_context))
+            .map(|x| x.to_sql(block_name, param_context))
             .collect::<Result<Vec<_>, _>>()?;
         Ok(format!("jsonb_build_object({})", frags.join(", ")))
     }
@@ -1044,7 +1027,7 @@ impl NodeSelection {
                 builder.to_sql(block_name)?
             ),
             Self::Typename { alias, typename } => {
-                format!("{}, {}", quote_literal(&alias), quote_literal(&typename))
+                format!("{}, {}", quote_literal(alias), quote_literal(typename))
             }
         })
     }


### PR DESCRIPTION
This PR fixes all but one problem reported by Clippy - Rust's lovely linter - making the recent [Rust port](https://github.com/supabase/pg_graphql/pull/221 ) a bit cleaner and more idiomatic.

Most of the changes are rather mechanic and uncontroversial (in my opinion 😄).

The remaining issue cannot be fixed easily as the cache macro changes the function name, so `#[allow(dead_code)]` doesn't work. I guess `#![allow(dead_code)]` would work, but I didn't want to enable it for the entire file.

```
warning: function `load_sql_context_prime_cache` is never used
   --> src/sql_types.rs:264:8
    |
264 | pub fn load_sql_context(_config: &Config) -> Context {
    |        ^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default
```

If this gets merged, we should also add `cargo clippy -- -D warnings` to GitHub Actions.