### PR TITLE
Bugfix: newline in encoded string

### DIFF
--- a/src/transpile.rs
+++ b/src/transpile.rs
@@ -3,9 +3,7 @@ use crate::graphql::*;
 use crate::sql_types::{Column, ForeignKey, ForeignKeyTableInfo, Table};
 use pgx::pg_sys::submodules::panic::CaughtError;
 use pgx::prelude::*;
-use pgx::SpiClient;
 use pgx::*;
-use pgx_contrib_spiext::*;
 use pgx_contrib_spiext::{checked::*, subtxn::*};
 use serde::ser::{Serialize, SerializeMap, Serializer};
 use std::cmp;
@@ -70,7 +68,7 @@ impl Table {
 
         let clause = frags.join(", ");
 
-        format!("encode(convert_to(jsonb_build_array({clause})::text, 'utf-8'), 'base64')")
+        format!("translate(encode(convert_to(jsonb_build_array({clause})::text, 'utf-8'), 'base64'), E'\n', '')")
     }
 
     fn to_pagination_clause(
@@ -1212,7 +1210,7 @@ impl NodeIdBuilder {
         let schema_name = quote_literal(&self.schema_name);
         let table_name = quote_literal(&self.table_name);
         Ok(format!(
-            "encode(convert_to(jsonb_build_array({schema_name}, {table_name}, {column_clause})::text, 'utf-8'), 'base64')"
+            "translate(encode(convert_to(jsonb_build_array({schema_name}, {table_name}, {column_clause})::text, 'utf-8'), 'base64'), E'\n', '')"
         ))
     }
 }

--- a/test/expected/roundtrip_types.out
+++ b/test/expected/roundtrip_types.out
@@ -235,24 +235,24 @@ begin;
             }
         $$)
     );
-                                                                                                               jsonb_pretty                                                                                                                
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {                                                                                                                                                                                                                                        +
-     "data": {                                                                                                                                                                                                                            +
-         "mainTypeCollection": {                                                                                                                                                                                                          +
-             "edges": [                                                                                                                                                                                                                   +
-                 {                                                                                                                                                                                                                        +
-                     "node": {                                                                                                                                                                                                            +
-                         "id": 1                                                                                                                                                                                                          +
-                     }                                                                                                                                                                                                                    +
-                 }                                                                                                                                                                                                                        +
-             ],                                                                                                                                                                                                                           +
-             "pageInfo": {                                                                                                                                                                                                                +
-                 "endCursor": "WzEsIDEsICJiMiIsICJiMiIsICJiMiIsICJlNGY0N2VmNS1mYjI1LTRkMmEtODNiMi1kNWZhYjEx\nNGEyZTYiLCAiMjAwMC0wMS0wMSIsICIxNzoyMzowMCIsICIyMDAwLTAxLTAxVDE4OjAwOjAwLTA4\nOjAwIiwgIkdSRUVOIiwgMzAsIDIxLjUsIDAuMTAsIDFd", +
-                 "startCursor": "WzEsIDEsICJiMiIsICJiMiIsICJiMiIsICJlNGY0N2VmNS1mYjI1LTRkMmEtODNiMi1kNWZhYjEx\nNGEyZTYiLCAiMjAwMC0wMS0wMSIsICIxNzoyMzowMCIsICIyMDAwLTAxLTAxVDE4OjAwOjAwLTA4\nOjAwIiwgIkdSRUVOIiwgMzAsIDIxLjUsIDAuMTAsIDFd"+
-             }                                                                                                                                                                                                                            +
-         }                                                                                                                                                                                                                                +
-     }                                                                                                                                                                                                                                    +
+                                                                                                             jsonb_pretty                                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {                                                                                                                                                                                                                                    +
+     "data": {                                                                                                                                                                                                                        +
+         "mainTypeCollection": {                                                                                                                                                                                                      +
+             "edges": [                                                                                                                                                                                                               +
+                 {                                                                                                                                                                                                                    +
+                     "node": {                                                                                                                                                                                                        +
+                         "id": 1                                                                                                                                                                                                      +
+                     }                                                                                                                                                                                                                +
+                 }                                                                                                                                                                                                                    +
+             ],                                                                                                                                                                                                                       +
+             "pageInfo": {                                                                                                                                                                                                            +
+                 "endCursor": "WzEsIDEsICJiMiIsICJiMiIsICJiMiIsICJlNGY0N2VmNS1mYjI1LTRkMmEtODNiMi1kNWZhYjExNGEyZTYiLCAiMjAwMC0wMS0wMSIsICIxNzoyMzowMCIsICIyMDAwLTAxLTAxVDE4OjAwOjAwLTA4OjAwIiwgIkdSRUVOIiwgMzAsIDIxLjUsIDAuMTAsIDFd", +
+                 "startCursor": "WzEsIDEsICJiMiIsICJiMiIsICJiMiIsICJlNGY0N2VmNS1mYjI1LTRkMmEtODNiMi1kNWZhYjExNGEyZTYiLCAiMjAwMC0wMS0wMSIsICIxNzoyMzowMCIsICIyMDAwLTAxLTAxVDE4OjAwOjAwLTA4OjAwIiwgIkdSRUVOIiwgMzAsIDIxLjUsIDAuMTAsIDFd"+
+             }                                                                                                                                                                                                                        +
+         }                                                                                                                                                                                                                            +
+     }                                                                                                                                                                                                                                +
  }
 (1 row)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Resolve intermittent failure when encoded `ID!` results in a newline character

Example failures

Example encoded id for a public.post table with given UUID
```
select encode(
	convert_to(jsonb_build_array('public', 'posts', '501b1490-127c-4c6d-9477-9f1cb1ad5e77')::text, 'utf-8')
	, 'base64')
```
Output (notice the `\n` newline)
```
WyJwdWJsaWMiLCAicG9zdHMiLCAiNTAxYjE0OTAtMTI3Yy00YzZkLTk0NzctOWYxY2IxYWQ1ZTc3\nIl0=
```

Tasks:
- [x] resolve
- [x] add a test for it 