### PR TITLE
Use checked SPI for query entry points

### DIFF
--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -2,7 +2,7 @@ use crate::builder::*;
 use crate::graphql::*;
 use crate::omit::*;
 use crate::parser_util::*;
-use crate::transpile::Entrypoint;
+use crate::transpile::{MutationEntrypoint, QueryEntrypoint};
 use graphql_parser::query::{
     Definition, Document, FragmentDefinition, Mutation, OperationDefinition, Query, Selection,
     SelectionSet, Text,

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -2,6 +2,7 @@ use crate::builder::*;
 use crate::graphql::*;
 use crate::omit::*;
 use crate::parser_util::*;
+use crate::transpile::Entrypoint;
 use graphql_parser::query::{
     Definition, Document, FragmentDefinition, Mutation, OperationDefinition, Query, Selection,
     SelectionSet, Text,

--- a/src/transpile.rs
+++ b/src/transpile.rs
@@ -33,15 +33,15 @@ pub fn rand_block_name() -> String {
     )
 }
 
-pub trait Entrypoint {
-    fn to_sql(&self, param_context: &mut ParamContext) -> Result<String, String>;
+pub trait MutationEntrypoint {
+    fn to_sql_entrypoint(&self, param_context: &mut ParamContext) -> Result<String, String>;
 
     fn execute(
         &self,
         xact: SubTransaction<SpiClientWrapper>,
     ) -> Result<(serde_json::Value, SubTransaction<SpiClientWrapper>), String> {
         let mut param_context = ParamContext { params: vec![] };
-        let sql = &self.to_sql(&mut param_context);
+        let sql = &self.to_sql_entrypoint(&mut param_context);
         let sql = match sql {
             Ok(sql) => sql,
             Err(err) => {
@@ -68,6 +68,41 @@ pub trait Entrypoint {
         };
 
         Ok((res.0, next_xact))
+    }
+}
+
+pub trait QueryEntrypoint {
+    fn to_sql_entrypoint(&self, param_context: &mut ParamContext) -> Result<String, String>;
+
+    fn execute(&self) -> Result<serde_json::Value, String> {
+        let mut param_context = ParamContext { params: vec![] };
+        let sql = &self.to_sql_entrypoint(&mut param_context);
+        let sql = match sql {
+            Ok(sql) => sql,
+            Err(err) => {
+                return Err(err.to_string());
+            }
+        };
+
+        let spi_result: Option<Result<Option<pgx::JsonB>, CaughtError>> = Spi::connect(|c| {
+            //Create subtransaction
+            let sub_txn_result: Result<Option<pgx::JsonB>, CaughtError> =
+                c.sub_transaction(|xact| {
+                    let (val, _) = xact.checked_select(sql, Some(1), Some(param_context.params))?;
+                    // Get a value from the query
+                    let out_val: Option<pgx::JsonB> = val.first().get_datum::<pgx::JsonB>(1);
+                    Ok(out_val)
+                });
+
+            // Return that value from the closure
+            Ok(Some(sub_txn_result))
+        });
+
+        match spi_result {
+            Some(Ok(Some(jsonb))) => Ok(jsonb.0),
+            Some(Ok(None)) => Ok(serde_json::Value::Null),
+            _ => Err("Internal Error: Failed to execute transpiled query".to_string()),
+        }
     }
 }
 
@@ -220,8 +255,8 @@ impl Table {
     }
 }
 
-impl Entrypoint for InsertBuilder {
-    fn to_sql(&self, param_context: &mut ParamContext) -> Result<String, String> {
+impl MutationEntrypoint for InsertBuilder {
+    fn to_sql_entrypoint(&self, param_context: &mut ParamContext) -> Result<String, String> {
         let quoted_block_name = rand_block_name();
         let quoted_schema = quote_ident(&self.table.schema);
         let quoted_table = quote_ident(&self.table.name);
@@ -356,8 +391,8 @@ impl DeleteSelection {
     }
 }
 
-impl Entrypoint for UpdateBuilder {
-    fn to_sql(&self, param_context: &mut ParamContext) -> Result<String, String> {
+impl MutationEntrypoint for UpdateBuilder {
+    fn to_sql_entrypoint(&self, param_context: &mut ParamContext) -> Result<String, String> {
         let quoted_block_name = rand_block_name();
         let quoted_schema = quote_ident(&self.table.schema);
         let quoted_table = quote_ident(&self.table.name);
@@ -440,8 +475,8 @@ impl Entrypoint for UpdateBuilder {
     }
 }
 
-impl Entrypoint for DeleteBuilder {
-    fn to_sql(&self, param_context: &mut ParamContext) -> Result<String, String> {
+impl MutationEntrypoint for DeleteBuilder {
+    fn to_sql_entrypoint(&self, param_context: &mut ParamContext) -> Result<String, String> {
         let quoted_block_name = rand_block_name();
         let quoted_schema = quote_ident(&self.table.schema);
         let quoted_table = quote_ident(&self.table.name);
@@ -792,15 +827,11 @@ impl ConnectionBuilder {
             )"
         ))
     }
+}
 
-    pub fn execute(&self) -> Result<serde_json::Value, String> {
-        let mut param_context = ParamContext { params: vec![] };
-        let sql = &self.to_sql(None, &mut param_context)?;
-
-        let res: pgx::JsonB = Spi::get_one_with_args(sql, param_context.params)
-            .ok_or("Internal Error: Failed to execute transpiled query")?;
-
-        Ok(res.0)
+impl QueryEntrypoint for ConnectionBuilder {
+    fn to_sql_entrypoint(&self, param_context: &mut ParamContext) -> Result<String, String> {
+        self.to_sql(None, param_context)
     }
 }
 
@@ -1012,11 +1043,10 @@ impl NodeBuilder {
             )"
         ))
     }
+}
 
-    pub fn to_query_entrypoint_sql(
-        &self,
-        param_context: &mut ParamContext,
-    ) -> Result<String, String> {
+impl QueryEntrypoint for NodeBuilder {
+    fn to_sql_entrypoint(&self, param_context: &mut ParamContext) -> Result<String, String> {
         let quoted_block_name = rand_block_name();
         let quoted_schema = quote_ident(&self.table.schema);
         let quoted_table = quote_ident(&self.table.name);
@@ -1045,16 +1075,6 @@ impl NodeBuilder {
             )
             "
         ))
-    }
-
-    pub fn execute(&self) -> Result<serde_json::Value, String> {
-        let mut param_context = ParamContext { params: vec![] };
-        let sql = &self.to_query_entrypoint_sql(&mut param_context)?;
-
-        let res: pgx::JsonB = Spi::get_one_with_args(sql, param_context.params)
-            .unwrap_or(pgx::JsonB(serde_json::Value::Null));
-
-        Ok(res.0)
     }
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Uses checked SPI (errors a catchable/caught) for query entrypoints similar to how we did mutation entrypoints