### PR TITLE
Bump version number to 0.5.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_graphql"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bumps the extension version number for 0.5.2 in prep for automated release