### PR TITLE
Rc Table copies rather than cloning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ regex = "1"
 base64 = "0.13"
 lazy_static = "1"
 pgx-contrib-spiext = { git = "https://github.com/supabase/pgx-contrib-spiext", rev = "153ad2db8bb8634332ad36ffc66dcb017353bf93" }
+quick_cache = "0.1.1"
 
 [dev-dependencies]
 pgx-tests = "~0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ regex = "1"
 base64 = "0.13"
 lazy_static = "1"
 pgx-contrib-spiext = { git = "https://github.com/supabase/pgx-contrib-spiext", rev = "153ad2db8bb8634332ad36ffc66dcb017353bf93" }
-quick_cache = "0.1.1"
 
 [dev-dependencies]
 pgx-tests = "~0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,14 @@ crate-type = ["cdylib"]
 
 [features]
 default = ["pg14"]
-pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
-pg15 = ["pgx/pg15", "pgx-tests/pg15" ]
+pg14 = ["pgx/pg14", "pgx-tests/pg14"]
+pg15 = ["pgx/pg15", "pgx-tests/pg15"]
 pg_test = []
 
 [dependencies]
 pgx = "~0.6.1"
 graphql-parser = "0.4"
-serde = "1.0"
+serde = { version = "1.0", features = ["rc"] }
 serde_json = "1.0"
 itertools = "0.10.3"
 cached = "0.34.0"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -4,6 +4,7 @@ use crate::sql_types::*;
 use graphql_parser::query::*;
 use serde::Serialize;
 use std::collections::HashMap;
+use std::rc::Rc;
 use std::str::FromStr;
 
 #[derive(Clone, Debug)]
@@ -14,7 +15,7 @@ pub struct InsertBuilder {
     pub objects: Vec<InsertRowBuilder>,
 
     // metadata
-    pub table: Table,
+    pub table: Rc<Table>,
 
     //fields
     pub selections: Vec<InsertSelection>,
@@ -304,7 +305,7 @@ pub struct UpdateBuilder {
     pub at_most: i32,
 
     // metadata
-    pub table: Table,
+    pub table: Rc<Table>,
 
     //fields
     pub selections: Vec<UpdateSelection>,
@@ -463,7 +464,7 @@ pub struct DeleteBuilder {
     pub at_most: i32,
 
     // metadata
-    pub table: Table,
+    pub table: Rc<Table>,
 
     //fields
     pub selections: Vec<DeleteSelection>,
@@ -561,7 +562,7 @@ pub struct ConnectionBuilder {
     pub order_by: OrderByBuilder,
 
     // metadata
-    pub table: Table,
+    pub table: Rc<Table>,
     pub fkey: Option<ForeignKey>,
     pub reverse_reference: Option<bool>,
 
@@ -778,7 +779,7 @@ pub struct NodeBuilder {
     pub alias: String,
 
     // metadata
-    pub table: Table,
+    pub table: Rc<Table>,
     pub fkey: Option<ForeignKey>,
     pub reverse_reference: Option<bool>,
 

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -836,7 +836,6 @@ pub struct NonNullType {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SchemaType {
     pub schema: Rc<__Schema>,
-    //pub context: Context,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -851,37 +850,37 @@ pub struct MutationType {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InsertInputType {
-    pub table: Table,
+    pub table: Rc<Table>,
     pub schema: Rc<__Schema>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpdateInputType {
-    pub table: Table,
+    pub table: Rc<Table>,
     pub schema: Rc<__Schema>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InsertResponseType {
-    pub table: Table,
+    pub table: Rc<Table>,
     pub schema: Rc<__Schema>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpdateResponseType {
-    pub table: Table,
+    pub table: Rc<Table>,
     pub schema: Rc<__Schema>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DeleteResponseType {
-    pub table: Table,
+    pub table: Rc<Table>,
     pub schema: Rc<__Schema>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ConnectionType {
-    pub table: Table,
+    pub table: Rc<Table>,
 
     // If one is present, both should be present
     // could be improved
@@ -902,7 +901,7 @@ pub struct OrderByType {}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct OrderByEntityType {
-    pub table: Table,
+    pub table: Rc<Table>,
     pub schema: Rc<__Schema>,
 }
 
@@ -919,19 +918,19 @@ pub struct FilterTypeType {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FilterEntityType {
-    pub table: Table,
+    pub table: Rc<Table>,
     pub schema: Rc<__Schema>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EdgeType {
-    pub table: Table,
+    pub table: Rc<Table>,
     pub schema: Rc<__Schema>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NodeType {
-    pub table: Table,
+    pub table: Rc<Table>,
 
     // If one is present, both should be present
     // could be improved
@@ -997,7 +996,7 @@ impl ___Type for QueryType {
                         lowercase_first_letter(&table.graphql_base_type_name())
                     ),
                     type_: __Type::Connection(ConnectionType {
-                        table: table.clone(),
+                        table: Rc::clone(table),
                         fkey: None,
                         reverse_reference: None,
                         schema: self.schema.clone(),
@@ -1034,7 +1033,7 @@ impl ___Type for QueryType {
                         __InputValue {
                             name_: "filter".to_string(),
                             type_: __Type::FilterEntity(FilterEntityType {
-                                table: table.clone(),
+                                table: Rc::clone(table),
                                 schema: self.schema.clone(),
                             }),
                             description: Some("Filters to apply to the results set when querying from the collection".to_string()),
@@ -1047,7 +1046,7 @@ impl ___Type for QueryType {
                                 type_: Box::new(__Type::NonNull(NonNullType {
                                     type_: Box::new(__Type::OrderByEntity(
                                         OrderByEntityType {
-                                            table: table.clone(),
+                                            table: Rc::clone(table),
                                             schema: self.schema.clone(),
                                         },
                                     )),
@@ -1126,7 +1125,7 @@ impl ___Type for MutationType {
                     f.push(__Field {
                         name_: format!("insertInto{}Collection", table.graphql_base_type_name()),
                         type_: __Type::InsertResponse(InsertResponseType {
-                            table: table.clone(),
+                            table: Rc::clone(table),
                             schema: self.schema.clone(),
                         }),
                         args: vec![__InputValue {
@@ -1135,7 +1134,7 @@ impl ___Type for MutationType {
                                 type_: Box::new(__Type::List(ListType {
                                     type_: Box::new(__Type::NonNull(NonNullType {
                                         type_: Box::new(__Type::InsertInput(InsertInputType {
-                                            table: table.clone(),
+                                            table: Rc::clone(table),
                                             schema: self.schema.clone(),
                                         })),
                                     })),
@@ -1159,7 +1158,7 @@ impl ___Type for MutationType {
                         name_: format!("update{}Collection", table.graphql_base_type_name()),
                         type_: __Type::NonNull(NonNullType {
                             type_: Box::new(__Type::UpdateResponse(UpdateResponseType {
-                                table: table.clone(),
+                                table: Rc::clone(table),
                                 schema: self.schema.clone(),
                             })),
                         }),
@@ -1168,7 +1167,7 @@ impl ___Type for MutationType {
                                 name_: "set".to_string(),
                                 type_: __Type::NonNull(NonNullType {
                                     type_: Box::new(__Type::UpdateInput(UpdateInputType {
-                                        table: table.clone(),
+                                        table: Rc::clone(table),
                                         schema: self.schema.clone(),
                                     })),
                                 }),
@@ -1179,7 +1178,7 @@ impl ___Type for MutationType {
                             __InputValue {
                                 name_: "filter".to_string(),
                                 type_: __Type::FilterEntity(FilterEntityType {
-                                    table: table.clone(),
+                                    table: Rc::clone(table),
                                     schema: self.schema.clone(),
                                 }),
                                 description: Some("Restricts the mutation's impact to records matching the criteria".to_string()),
@@ -1210,7 +1209,7 @@ impl ___Type for MutationType {
                         name_: format!("deleteFrom{}Collection", table.graphql_base_type_name()),
                         type_: __Type::NonNull(NonNullType {
                             type_: Box::new(__Type::DeleteResponse(DeleteResponseType {
-                                table: table.clone(),
+                                table: Rc::clone(table),
                                 schema: self.schema.clone(),
                             })),
                         }),
@@ -1218,7 +1217,7 @@ impl ___Type for MutationType {
                             __InputValue {
                                 name_: "filter".to_string(),
                                 type_: __Type::FilterEntity(FilterEntityType {
-                                    table: table.clone(),
+                                    table: Rc::clone(table),
                                     schema: self.schema.clone(),
                                 }),
                                 description: Some(
@@ -1640,7 +1639,7 @@ impl ___Type for NodeType {
             .filter(|x| x.permissions.is_selectable)
         {
             let reverse_reference = false;
-            let foreign_table: Option<&Table> = self
+            let foreign_table: Option<&Rc<Table>> = self
                 .schema
                 .context
                 .schemas
@@ -1661,7 +1660,7 @@ impl ___Type for NodeType {
                 name_: fkey.graphql_field_name(reverse_reference),
                 // XXX: column nullability ignored for NonNull type to match pg_graphql
                 type_: __Type::Node(NodeType {
-                    table: foreign_table.clone(),
+                    table: Rc::clone(foreign_table),
                     fkey: Some(fkey.clone()),
                     reverse_reference: Some(reverse_reference),
                     schema: self.schema.clone(),
@@ -1686,7 +1685,7 @@ impl ___Type for NodeType {
             .filter(|x| x.referenced_table_meta.oid == self.table.oid)
         {
             let reverse_reference = true;
-            let foreign_table: Option<&Table> = self
+            let foreign_table: Option<&Rc<Table>> = self
                 .schema
                 .context
                 .schemas
@@ -1709,7 +1708,7 @@ impl ___Type for NodeType {
                         name_: fkey.graphql_field_name(reverse_reference),
                         // XXX: column nullability ignored for NonNull type to match pg_graphql
                         type_: __Type::Connection(ConnectionType {
-                                table: foreign_table.clone(),
+                                table: Rc::clone(foreign_table),
                                 fkey: Some(fkey.clone()),
                                 reverse_reference: Some(reverse_reference),
                                 schema: self.schema.clone(),
@@ -1746,7 +1745,7 @@ impl ___Type for NodeType {
                             __InputValue {
                                 name_: "filter".to_string(),
                                 type_: __Type::FilterEntity(FilterEntityType {
-                                    table: foreign_table.clone(),
+                                    table: Rc::clone(foreign_table),
                                     schema: self.schema.clone(),
                                 }),
                                 description: Some("Filters to apply to the results set when querying from the collection".to_string()),
@@ -1759,7 +1758,7 @@ impl ___Type for NodeType {
                                     type_: Box::new(__Type::NonNull(NonNullType {
                                         type_: Box::new(__Type::OrderByEntity(
                                             OrderByEntityType {
-                                                table: foreign_table.clone(),
+                                                table: Rc::clone(foreign_table),
                                                 schema: self.schema.clone(),
                                             },
                                         )),
@@ -1780,7 +1779,7 @@ impl ___Type for NodeType {
                         name_: fkey.graphql_field_name(reverse_reference),
                         // XXX: column nullability ignored for NonNull type to match pg_graphql
                         type_: __Type::Node(NodeType {
-                            table: foreign_table.clone(),
+                            table: Rc::clone(foreign_table),
                             fkey: Some(fkey.clone()),
                             reverse_reference: Some(reverse_reference),
                             schema: self.schema.clone(),
@@ -3184,7 +3183,7 @@ pub struct GraphQLResponse {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct __Schema {
-    pub context: Context,
+    pub context: Rc<Context>,
 }
 
 impl __Schema {
@@ -3267,57 +3266,57 @@ impl __Schema {
                 .filter(|x| x.graphql_select_types_are_valid())
             {
                 types_.push(__Type::Node(NodeType {
-                    table: table.clone(),
+                    table: Rc::clone(table),
                     fkey: None,
                     reverse_reference: None,
                     schema: schema_rc.clone(),
                 }));
                 types_.push(__Type::Edge(EdgeType {
-                    table: table.clone(),
+                    table: Rc::clone(table),
                     schema: schema_rc.clone(),
                 }));
                 types_.push(__Type::Connection(ConnectionType {
-                    table: table.clone(),
+                    table: Rc::clone(table),
                     fkey: None,
                     reverse_reference: None,
                     schema: schema_rc.clone(),
                 }));
 
                 types_.push(__Type::FilterEntity(FilterEntityType {
-                    table: table.clone(),
+                    table: Rc::clone(table),
                     schema: schema_rc.clone(),
                 }));
 
                 types_.push(__Type::OrderByEntity(OrderByEntityType {
-                    table: table.clone(),
+                    table: Rc::clone(table),
                     schema: schema_rc.clone(),
                 }));
 
                 if table.graphql_insert_types_are_valid() {
                     types_.push(__Type::InsertInput(InsertInputType {
-                        table: table.clone(),
+                        table: Rc::clone(table),
                         schema: schema_rc.clone(),
                     }));
                     types_.push(__Type::InsertResponse(InsertResponseType {
-                        table: table.clone(),
+                        table: Rc::clone(table),
                         schema: schema_rc.clone(),
                     }));
                 }
 
                 if table.graphql_update_types_are_valid() {
                     types_.push(__Type::UpdateInput(UpdateInputType {
-                        table: table.clone(),
+                        table: Rc::clone(table),
                         schema: schema_rc.clone(),
                     }));
                     types_.push(__Type::UpdateResponse(UpdateResponseType {
-                        table: table.clone(),
+                        table: Rc::clone(table),
                         schema: schema_rc.clone(),
                     }));
                 }
 
                 if table.graphql_delete_types_are_valid() {
                     types_.push(__Type::DeleteResponse(DeleteResponseType {
-                        table: table.clone(),
+                        table: Rc::clone(table),
                         schema: schema_rc.clone(),
                     }));
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@ use graphql_parser::query::parse_query;
 use pgx::*;
 use resolve::resolve_inner;
 use serde_json::json;
-use std::rc::Rc;
 
 mod builder;
 mod graphql;
@@ -45,22 +44,7 @@ fn resolve(
         }
         Ok(query_ast) => {
             let sql_config = sql_types::load_sql_config();
-
-            // TODO: COMMENT HERE ABOUNT CACHING, THREAD, ETC
-            let cache = unsafe {
-                let _ = CACHE.get_or_init(|| Cache::new(250, 250));
-                CACHE.get_mut()
-            }
-            .unwrap();
-
-            let context = if let Some(rc_sql_context) = cache.get(&sql_config) {
-                rc_sql_context.clone()
-            } else {
-                let sql_context = sql_types::load_sql_context(&sql_config);
-                let rc_sql_context = Rc::new(sql_context);
-                cache.insert(sql_config, rc_sql_context.clone());
-                rc_sql_context
-            };
+            let context = sql_types::load_sql_context(&sql_config);
 
             let graphql_schema = __Schema { context };
             let variables = variables.map_or(json!({}), |v| v.0);
@@ -72,11 +56,6 @@ fn resolve(
 
     pgx::JsonB(value)
 }
-
-use once_cell::unsync::OnceCell;
-use quick_cache::unsync::Cache;
-
-static mut CACHE: OnceCell<Cache<sql_types::Config, Rc<sql_types::Context>>> = OnceCell::new();
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]

--- a/src/transpile.rs
+++ b/src/transpile.rs
@@ -7,6 +7,7 @@ use pgx::*;
 use pgx_contrib_spiext::{checked::*, subtxn::*};
 use serde::ser::{Serialize, SerializeMap, Serializer};
 use std::cmp;
+use std::sync::Arc;
 
 pub fn quote_ident(ident: &str) -> String {
     unsafe {
@@ -119,7 +120,7 @@ impl Table {
     /// a priamry key tuple clause selects the columns of the primary key as a composite record
     /// that is useful in "has_previous_page" by letting us compare records on a known unique key
     fn to_primary_key_tuple_clause(&self, block_name: &str) -> String {
-        let pkey_cols: Vec<&Column> = self.primary_key_columns();
+        let pkey_cols: Vec<&Arc<Column>> = self.primary_key_columns();
 
         let pkey_frags: Vec<String> = pkey_cols
             .iter()
@@ -271,7 +272,7 @@ impl MutationEntrypoint<'_> for InsertBuilder {
 
         let select_clause = frags.join(", ");
 
-        let columns: &Vec<Column> = &self.table.columns;
+        let columns: &Vec<Arc<Column>> = &self.table.columns;
 
         let mut values_rows_clause: Vec<String> = vec![];
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Removes all clones of `sql_types::XXX` by replacing them with `Arc<sql_types::XXX>`

Note:
Arc was required (vs Rc) because the sql `Context` is cached and must be send + sync for thread safety, even though we know there is no threading behavior

Performance:

The impact differs depending on SQL schema size. For this test there were 11 tables, each with 5 columns. Benchmarking the whole HTTP stack (with Postgrest v10) introduced too much noise so instead I measured how long it took to run the same simple query 10k times in sql before and after

```sql
explain analyze
select graphql.resolve(
$$
	{ accountCollection{ edges { node { id }}}}
$$
)
from generate_series(1,10000)
```

Before: 3098.789 ms
After: 2198.692 ms

~ 30% reduction in graphql overhead for simple queries on a moderate sized schema.