### PR TITLE
Bugfix: order by clause on pg15

### DIFF
--- a/bin/installcheck
+++ b/bin/installcheck
@@ -11,6 +11,8 @@ export PGDATABASE=postgres
 export PGTZ=UTC
 export PG_COLOR=auto
 
+# PATH=~/.pgx/15.1/pgx-install/bin/:$PATH
+
 ####################
 # Ensure Clean Env #
 ####################

--- a/src/transpile.rs
+++ b/src/transpile.rs
@@ -540,7 +540,7 @@ impl MutationEntrypoint<'_> for DeleteBuilder {
 
 impl OrderByBuilder {
     fn to_order_by_clause(&self, block_name: &str) -> String {
-        let mut frags = vec!["true".to_string()];
+        let mut frags = vec![];
 
         for elem in &self.elems {
             let quoted_column_name = quote_ident(&elem.column.name);


### PR DESCRIPTION
## What kind of change does this PR introduce?
Updates the order by clause builder to remove the default first element `true` that is not supported by pg15

This bug highlights the need for testing abasing pg15 on CI.
Task added for that at #281 