### PR TITLE
Update graphiql version to fix issue for text color in dark mode

### DIFF
--- a/dockerfiles/graphiql/index.html
+++ b/dockerfiles/graphiql/index.html
@@ -1,16 +1,13 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <title>GraphiQL - pg_graphql</title>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/graphiql/2.0.4/graphiql.css" rel="stylesheet" />
-    <style>
-      table, tr, td{
-        color: hsla(var(--color-neutral),1);
-      }
-    </style>
-  </head>
-  <body style="margin: 0;">
-    <div id="graphiql" style="height: 100vh;"></div>
 
+    <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+  </head>
+
+  <body style="margin: 0">
+    <div id="graphiql" style="height: 100vh"></div>
     <script
       crossorigin
       src="https://unpkg.com/react/umd/react.production.min.js"
@@ -21,15 +18,15 @@
     ></script>
     <script
       crossorigin
-      src="https://cdnjs.cloudflare.com/ajax/libs/graphiql/2.0.4/graphiql.js"
+      src="https://unpkg.com/graphiql/graphiql.min.js"
     ></script>
     <script>
       const fetcher = GraphiQL.createFetcher({
-             url: 'http://localhost:3001/rpc/graphql',
+        url: "http://localhost:3001/rpc/graphql",
       });
       ReactDOM.render(
         React.createElement(GraphiQL, { fetcher: fetcher }),
-        document.getElementById('graphiql'),
+        document.getElementById("graphiql")
       );
     </script>
   </body>

--- a/dockerfiles/graphiql/index.html
+++ b/dockerfiles/graphiql/index.html
@@ -2,6 +2,11 @@
   <head>
     <title>GraphiQL - pg_graphql</title>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/graphiql/2.0.4/graphiql.css" rel="stylesheet" />
+    <style>
+      table, tr, td{
+        color: hsla(var(--color-neutral),1);
+      }
+    </style>
   </head>
   <body style="margin: 0;">
     <div id="graphiql" style="height: 100vh;"></div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds a style fix for short keys dialog table in dark mode when running the graphiql web app.

## What is the current behavior?

In the dark mode the short keys dialog show the text black on MacOS chrome with a dark grey background, making it less readable for a user. 
 #291 

## What is the new behavior?

<img width="824" alt="image" src="https://user-images.githubusercontent.com/34878926/208352893-d32538af-a9dc-4df6-b541-666cab48b52e.png">

