### PR TITLE
SQL insert statements to omit columns that were never referenced by the user

### DIFF
--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::*;
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ColumnPermissions {
     pub is_insertable: bool,
     pub is_selectable: bool,
@@ -15,13 +15,13 @@ pub struct ColumnPermissions {
     // alterable?
 }
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ColumnDirectives {
     pub inflect_names: bool,
     pub name: Option<String>,
 }
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Column {
     pub name: String,
     pub type_oid: u32,

--- a/test/expected/issue_300.out
+++ b/test/expected/issue_300.out
@@ -1,0 +1,54 @@
+begin;
+
+    THIS IS INTENTIONALLY FAILING TEST OUTPUT
+
+    -- https://github.com/supabase/pg_graphql/issues/300
+	create role api;
+    create table project (
+    	id serial primary key,
+        title text not null,
+        created_at timestamptz not null default now(),
+        updated_at timestamptz not null default now()
+    );
+    grant usage on schema graphql to api;
+	revoke all on table project from api;
+	grant select on table project to api;
+	grant insert (id, title) on table project to api;
+	grant update (title) on table project to api;
+	grant delete on table project to api;
+    set role to 'api';
+    select jsonb_pretty(
+        graphql.resolve($$
+
+	mutation CreateProject {
+	  insertIntoProjectCollection(objects: [
+		{title: "foo"}
+	  ]) {
+		affectedCount
+		records {
+		  id
+		  title
+		  createdAt
+		  updatedAt
+		}
+	  }
+	}
+	$$
+		)
+	);
+
+
+ERROR: THIS SHOULD WORK
+                         jsonb_pretty                         
+--------------------------------------------------------------
+ {                                                           +
+     "data": null,                                           +
+     "errors": [                                             +
+         {                                                   +
+             "message": "permission denied for table project"+
+         }                                                   +
+     ]                                                       +
+ }
+(1 row)
+
+rollback;

--- a/test/expected/issue_300.out
+++ b/test/expected/issue_300.out
@@ -1,53 +1,55 @@
 begin;
-
-    THIS IS INTENTIONALLY FAILING TEST OUTPUT
-
     -- https://github.com/supabase/pg_graphql/issues/300
-	create role api;
+    create role api;
     create table project (
-    	id serial primary key,
+        id serial primary key,
         title text not null,
-        created_at timestamptz not null default now(),
-        updated_at timestamptz not null default now()
+        created_at int not null default '1',
+        updated_at int not null default '2'
     );
     grant usage on schema graphql to api;
-	revoke all on table project from api;
-	grant select on table project to api;
-	grant insert (id, title) on table project to api;
-	grant update (title) on table project to api;
-	grant delete on table project to api;
+    grant usage on all sequences in schema public to api;
+    revoke all on table project from api;
+    grant select on table project to api;
+    grant insert (id, title) on table project to api;
+    grant update (title) on table project to api;
+    grant delete on table project to api;
     set role to 'api';
     select jsonb_pretty(
         graphql.resolve($$
 
-	mutation CreateProject {
-	  insertIntoProjectCollection(objects: [
-		{title: "foo"}
-	  ]) {
-		affectedCount
-		records {
-		  id
-		  title
-		  createdAt
-		  updatedAt
-		}
-	  }
-	}
-	$$
-		)
-	);
-
-
-ERROR: THIS SHOULD WORK
-                         jsonb_pretty                         
---------------------------------------------------------------
- {                                                           +
-     "data": null,                                           +
-     "errors": [                                             +
-         {                                                   +
-             "message": "permission denied for table project"+
-         }                                                   +
-     ]                                                       +
+    mutation CreateProject {
+      insertIntoProjectCollection(objects: [
+        {title: "foo"}
+      ]) {
+        affectedCount
+        records {
+          id
+          title
+          createdAt
+          updatedAt
+        }
+      }
+    }
+    $$
+        )
+    );
+               jsonb_pretty               
+------------------------------------------
+ {                                       +
+     "data": {                           +
+         "insertIntoProjectCollection": {+
+             "records": [                +
+                 {                       +
+                     "id": 1,            +
+                     "title": "foo",     +
+                     "createdAt": 1,     +
+                     "updatedAt": 2      +
+                 }                       +
+             ],                          +
+             "affectedCount": 1          +
+         }                               +
+     }                                   +
  }
 (1 row)
 

--- a/test/sql/issue_300.sql
+++ b/test/sql/issue_300.sql
@@ -1,0 +1,42 @@
+begin;
+    -- https://github.com/supabase/pg_graphql/issues/300
+    create role api;
+
+    create table project (
+        id serial primary key,
+        title text not null,
+        created_at timestamptz not null default now(),
+        updated_at timestamptz not null default now()
+    );
+
+    grant usage on schema graphql to api;
+
+    revoke all on table project from api;
+    grant select on table project to api;
+    grant insert (id, title) on table project to api;
+    grant update (title) on table project to api;
+    grant delete on table project to api;
+
+    set role to 'api';
+
+    select jsonb_pretty(
+        graphql.resolve($$
+
+    mutation CreateProject {
+      insertIntoProjectCollection(objects: [
+        {title: "foo"}
+      ]) {
+        affectedCount
+        records {
+          id
+          title
+          createdAt
+          updatedAt
+        }
+      }
+    }
+    $$
+        )
+    );
+
+rollback;

--- a/test/sql/issue_300.sql
+++ b/test/sql/issue_300.sql
@@ -5,11 +5,12 @@ begin;
     create table project (
         id serial primary key,
         title text not null,
-        created_at timestamptz not null default now(),
-        updated_at timestamptz not null default now()
+        created_at int not null default '1',
+        updated_at int not null default '2'
     );
 
     grant usage on schema graphql to api;
+    grant usage on all sequences in schema public to api;
 
     revoke all on table project from api;
     grant select on table project to api;


### PR DESCRIPTION
Updates SQL insert statements to omit columns that were never referenced by the user

For example:

```graphql
mutation CreateProject {
  insertIntoProjectCollection(objects: [
    {id: "foo", title: "some title"},
    {id: "bar"} # Note: no title
  ]) {
    ...
}
```
So right now we'd emit

```sql
insert into app.project(id, title, created_at, updated_at)
values
  ('foo', 'some title', default, default),
  ('bar', default, default, default);
```
To resolve that problem, we should only include columns where the user provided at least one value.
From the previous example, that would be:

```sql
insert into app.project(id, title)
values
  ('foo', 'some title'),
  ('bar', default);
```

resolves #300