### PR TITLE
SQL Context Refactoring

### DIFF
--- a/sql/load_sql_context.sql
+++ b/sql/load_sql_context.sql
@@ -171,6 +171,7 @@ select
                                                             'name', pp.proname::text,
                                                             'type_oid', pp.prorettype::oid::int,
                                                             'type_name', pp.prorettype::regtype::text,
+                                                            'schema_oid', pronamespace::int,
                                                             'schema_name', pronamespace::regnamespace::text,
                                                             'comment', pg_catalog.obj_description(pp.oid, 'pg_proc'),
                                                             'directives', jsonb_build_object(
@@ -231,6 +232,7 @@ select
                                                         'name', pa.attname::text,
                                                         'type_oid', pa.atttypid::int,
                                                         'type_name', pa.atttypid::regtype::text,
+                                                        'schema_oid', pn.oid::int,
                                                         'is_not_null', pa.attnotnull,
                                                         'attribute_num', pa.attnum,
                                                         'has_default', pd.adbin is not null, -- pg_get_expr(pd.adbin, pd.adrelid) shows expression

--- a/sql/load_sql_context.sql
+++ b/sql/load_sql_context.sql
@@ -1,5 +1,20 @@
 with search_path_oids(schema_oid) as (
     select y::regnamespace::oid from unnest(current_schemas(false)) x(y)
+),
+schemas_(oid, name) as (
+    select
+        pn.oid::int, pn.nspname::text
+    from
+        pg_namespace pn
+        -- filter to current schemas only
+        join search_path_oids cur_schemas(oid)
+            on pn.oid = cur_schemas.oid
+    where
+        pg_catalog.has_schema_privilege(
+            current_user,
+            pn.oid,
+            'USAGE'
+        )
 )
 select
     jsonb_build_object(
@@ -45,8 +60,8 @@ select
                     pg_enum
                     join pg_type pt
                         on pt.oid = pg_enum.enumtypid
-                    join search_path_oids spo
-                        on pt.typnamespace = spo.schema_oid
+                    join schemas_ spo
+                        on pt.typnamespace = spo.oid
             ),
             jsonb_build_object()
         ),
@@ -78,8 +93,8 @@ select
                     )
                 from
                     pg_type pt
-                    join search_path_oids spo
-                        on pt.typnamespace = spo.schema_oid
+                    join schemas_ spo
+                        on pt.typnamespace = spo.oid
             ),
             jsonb_build_object()
         ),
@@ -94,8 +109,8 @@ select
                     )
                 from
                     pg_type pt
-                    join search_path_oids spo
-                        on pt.typnamespace = spo.schema_oid
+                    join schemas_ spo
+                        on pt.typnamespace = spo.oid
                 where
                     pt.typtype = 'c'
             ),
@@ -159,216 +174,206 @@ select
             )
         ),
         'schemas', coalesce(
-            jsonb_agg(
-                jsonb_build_object(
-                    'oid', pn.oid::int,
-                    'name', pn.nspname::text,
-                    'comment', pg_catalog.obj_description(pn.oid, 'pg_namespace'),
-                    'directives', jsonb_build_object(
-                        'inflect_names', schema_directives.inflect_names,
-                        'max_rows', schema_directives.max_rows
-                    ),
-                    'tables', coalesce(
-                        (
-                            select
-                                jsonb_agg(
-                                    jsonb_build_object(
-                                        'oid', pc.oid::int,
-                                        'name', pc.relname::text,
-                                        'relkind', pc.relkind::text,
-                                        'schema', pn.nspname::text,
-                                        'schema_oid', pn.oid::int,
-                                        'comment', pg_catalog.obj_description(pc.oid, 'pg_class'),
-                                        'directives', jsonb_build_object(
-                                            'inflect_names', schema_directives.inflect_names,
-                                            'name', graphql.comment_directive(pg_catalog.obj_description(pc.oid, 'pg_class')) ->> 'name',
-                                            'total_count', jsonb_build_object(
-                                                'enabled', coalesce(
-                                                    (
-                                                        graphql.comment_directive(
-                                                            pg_catalog.obj_description(pc.oid, 'pg_class')
-                                                        ) -> 'totalCount' ->> 'enabled' = 'true'
-                                                    ),
-                                                    false
+            (
+                select
+                    jsonb_object_agg(
+                        pn.oid::int,
+                        jsonb_build_object(
+                            'oid', pn.oid::int,
+                            'name', pn.name,
+                            'comment', pg_catalog.obj_description(pn.oid, 'pg_namespace'),
+                            'directives', jsonb_build_object(
+                                'inflect_names', coalesce(
+                                    (graphql.comment_directive(pg_catalog.obj_description(pn.oid, 'pg_namespace')) -> 'inflect_names') = to_jsonb(true),
+                                    false
+                                ),
+                                'max_rows', coalesce(
+                                    (graphql.comment_directive(pg_catalog.obj_description(pn.oid, 'pg_namespace')) ->> 'max_rows')::int,
+                                    30
+                                )
+                            )
+                        )
+                    )
+                from
+                    schemas_ pn
+            ),
+            jsonb_build_object()
+        ),
+        'tables', coalesce(
+            (
+                select
+                    jsonb_object_agg(
+                        pc.oid::int,
+                        jsonb_build_object(
+                            'oid', pc.oid::int,
+                            'name', pc.relname::text,
+                            'relkind', pc.relkind::text,
+                            'schema', schemas_.name,
+                            'schema_oid', pc.relnamespace::int,
+                            'comment', pg_catalog.obj_description(pc.oid, 'pg_class'),
+                            'directives', jsonb_build_object(
+                                'name', graphql.comment_directive(pg_catalog.obj_description(pc.oid, 'pg_class')) ->> 'name',
+                                'total_count', jsonb_build_object(
+                                    'enabled', coalesce(
+                                        (
+                                            graphql.comment_directive(
+                                                pg_catalog.obj_description(pc.oid, 'pg_class')
+                                            ) -> 'totalCount' ->> 'enabled' = 'true'
+                                        ),
+                                        false
+                                    )
+                                ),
+                                'primary_key_columns', graphql.comment_directive(pg_catalog.obj_description(pc.oid, 'pg_class')) -> 'primary_key_columns',
+                                'foreign_keys', graphql.comment_directive(pg_catalog.obj_description(pc.oid, 'pg_class')) -> 'foreign_keys'
+                            ),
+                            'functions', coalesce(
+                                (
+                                    select
+                                        jsonb_agg(
+                                            jsonb_build_object(
+                                                'oid', pp.oid::int,
+                                                'name', pp.proname::text,
+                                                'type_oid', pp.prorettype::oid::int,
+                                                'type_name', pp.prorettype::regtype::text,
+                                                'schema_oid', pronamespace::int,
+                                                'schema_name', pronamespace::regnamespace::text,
+                                                'comment', pg_catalog.obj_description(pp.oid, 'pg_proc'),
+                                                'directives', jsonb_build_object(
+                                                    'name', graphql.comment_directive(pg_catalog.obj_description(pp.oid, 'pg_proc')) ->> 'name'
+                                                ),
+                                                'permissions', jsonb_build_object(
+                                                    'is_executable', pg_catalog.has_function_privilege(
+                                                        current_user,
+                                                        pp.oid,
+                                                        'EXECUTE'
+                                                    )
                                                 )
-                                            ),
-                                            'primary_key_columns', graphql.comment_directive(pg_catalog.obj_description(pc.oid, 'pg_class')) -> 'primary_key_columns',
-                                            'foreign_keys', graphql.comment_directive(pg_catalog.obj_description(pc.oid, 'pg_class')) -> 'foreign_keys'
-                                        ),
-                                        'functions', coalesce(
-                                            (
-                                                select
-                                                    jsonb_agg(
-                                                        jsonb_build_object(
-                                                            'oid', pp.oid::int,
-                                                            'name', pp.proname::text,
-                                                            'type_oid', pp.prorettype::oid::int,
-                                                            'type_name', pp.prorettype::regtype::text,
-                                                            'schema_oid', pronamespace::int,
-                                                            'schema_name', pronamespace::regnamespace::text,
-                                                            'comment', pg_catalog.obj_description(pp.oid, 'pg_proc'),
-                                                            'directives', jsonb_build_object(
-                                                                'inflect_names', schema_directives.inflect_names,
-                                                                'name', graphql.comment_directive(pg_catalog.obj_description(pp.oid, 'pg_proc')) ->> 'name'
-                                                            ),
-                                                            'permissions', jsonb_build_object(
-                                                                'is_executable', pg_catalog.has_function_privilege(
-                                                                    current_user,
-                                                                    pp.oid,
-                                                                    'EXECUTE'
-                                                                )
-                                                            )
-                                                        )
-                                                    )
-                                                from
-                                                    pg_catalog.pg_proc pp
-                                                where
-                                                    pp.pronargs = 1 -- one argument
-                                                    and pp.proargtypes[0] = pc.reltype -- first argument is table type
-                                                    and pp.proname like '\_%' -- starts with underscore
-                                            ),
-                                            jsonb_build_array()
-                                        ),
-                                        'indexes', coalesce(
-                                            (
-                                                select
-                                                    jsonb_agg(
-                                                        jsonb_build_object(
-                                                            'table_oid', pi.indrelid::int,
-                                                            'column_names', coalesce(
-                                                                (
-                                                                    select
-                                                                        array_agg(pa_i.attname)
-                                                                    from
-                                                                        unnest(pi.indkey) pic(attnum)
-                                                                        join pg_catalog.pg_attribute pa_i
-                                                                            on pa_i.attrelid = pi.indrelid -- same table
-                                                                            and pic.attnum = pa_i.attnum -- same attribute
-                                                                ),
-                                                                array[]::text[]
-                                                            ),
-                                                            'is_unique', pi.indisunique,
-                                                            'is_primary_key', pi.indisprimary
-                                                        )
-                                                    )
-                                                from
-                                                    pg_catalog.pg_index pi
-                                                where
-                                                    pi.indrelid = pc.oid
-                                            ),
-                                            jsonb_build_array()
-                                        ),
-                                        'columns', (
-                                            select
-                                                jsonb_agg(
-                                                    jsonb_build_object(
-                                                        'name', pa.attname::text,
-                                                        'type_oid', pa.atttypid::int,
-                                                        'type_name', pa.atttypid::regtype::text,
-                                                        'schema_oid', pn.oid::int,
-                                                        'is_not_null', pa.attnotnull,
-                                                        'attribute_num', pa.attnum,
-                                                        'has_default', pd.adbin is not null, -- pg_get_expr(pd.adbin, pd.adrelid) shows expression
-                                                        'is_serial', pg_get_serial_sequence(pc.oid::regclass::text, pa.attname::text) is not null,
-                                                        'is_generated', pa.attgenerated <> ''::"char",
-                                                        'permissions', jsonb_build_object(
-                                                            'is_insertable', pg_catalog.has_column_privilege(
-                                                                current_user,
-                                                                pa.attrelid,
-                                                                pa.attname,
-                                                                'INSERT'
-                                                            ),
-                                                            'is_selectable', pg_catalog.has_column_privilege(
-                                                                current_user,
-                                                                pa.attrelid,
-                                                                pa.attname,
-                                                                'SELECT'
-                                                            ),
-                                                            'is_updatable', pg_catalog.has_column_privilege(
-                                                                current_user,
-                                                                pa.attrelid,
-                                                                pa.attname,
-                                                                'UPDATE'
-                                                            )
-                                                        ),
-                                                        'comment', pg_catalog.col_description(pc.oid, pa.attnum),
-                                                        'directives', jsonb_build_object(
-                                                            'inflect_names', schema_directives.inflect_names,
-                                                            'name', graphql.comment_directive(pg_catalog.col_description(pc.oid, pa.attnum)) ->> 'name'
-                                                        )
-                                                    )
-                                                    order by pa.attnum
-                                                )
-                                            from
-                                                pg_catalog.pg_attribute pa
-                                                left join pg_catalog.pg_attrdef pd
-                                                    on (pa.attrelid, pa.attnum) = (pd.adrelid, pd.adnum)
-                                            where
-                                                pc.oid = pa.attrelid
-                                                and pa.attnum > 0
-                                                and not pa.attisdropped
-                                        ),
-                                        'permissions', jsonb_build_object(
-                                            'is_insertable', pg_catalog.has_table_privilege(
-                                                current_user,
-                                                pc.oid,
-                                                'INSERT'
-                                            ),
-                                            'is_selectable', pg_catalog.has_table_privilege(
-                                                current_user,
-                                                pc.oid,
-                                                'SELECT'
-                                            ),
-                                            'is_updatable', pg_catalog.has_table_privilege(
-                                                current_user,
-                                                pc.oid,
-                                                'UPDATE'
-                                            ),
-                                            'is_deletable', pg_catalog.has_table_privilege(
-                                                current_user,
-                                                pc.oid,
-                                                'DELETE'
                                             )
                                         )
+                                    from
+                                        pg_catalog.pg_proc pp
+                                    where
+                                        pp.pronargs = 1 -- one argument
+                                        and pp.proargtypes[0] = pc.reltype -- first argument is table type
+                                        and pp.proname like '\_%' -- starts with underscore
+                                ),
+                                jsonb_build_array()
+                            ),
+                            'indexes', coalesce(
+                                (
+                                    select
+                                        jsonb_agg(
+                                            jsonb_build_object(
+                                                'table_oid', pi.indrelid::int,
+                                                'column_names', coalesce(
+                                                    (
+                                                        select
+                                                            array_agg(pa_i.attname)
+                                                        from
+                                                            unnest(pi.indkey) pic(attnum)
+                                                            join pg_catalog.pg_attribute pa_i
+                                                                on pa_i.attrelid = pi.indrelid -- same table
+                                                                and pic.attnum = pa_i.attnum -- same attribute
+                                                    ),
+                                                    array[]::text[]
+                                                ),
+                                                'is_unique', pi.indisunique,
+                                                'is_primary_key', pi.indisprimary
+                                            )
+                                        )
+                                    from
+                                        pg_catalog.pg_index pi
+                                    where
+                                        pi.indrelid = pc.oid
+                                ),
+                                jsonb_build_array()
+                            ),
+                            'columns', (
+                                select
+                                    jsonb_agg(
+                                        jsonb_build_object(
+                                            'name', pa.attname::text,
+                                            'type_oid', pa.atttypid::int,
+                                            'type_name', pa.atttypid::regtype::text,
+                                            'schema_oid', schemas_.oid::int,
+                                            'is_not_null', pa.attnotnull,
+                                            'attribute_num', pa.attnum,
+                                            'has_default', pd.adbin is not null, -- pg_get_expr(pd.adbin, pd.adrelid) shows expression
+                                            'is_serial', pg_get_serial_sequence(pc.oid::regclass::text, pa.attname::text) is not null,
+                                            'is_generated', pa.attgenerated <> ''::"char",
+                                            'permissions', jsonb_build_object(
+                                                'is_insertable', pg_catalog.has_column_privilege(
+                                                    current_user,
+                                                    pa.attrelid,
+                                                    pa.attname,
+                                                    'INSERT'
+                                                ),
+                                                'is_selectable', pg_catalog.has_column_privilege(
+                                                    current_user,
+                                                    pa.attrelid,
+                                                    pa.attname,
+                                                    'SELECT'
+                                                ),
+                                                'is_updatable', pg_catalog.has_column_privilege(
+                                                    current_user,
+                                                    pa.attrelid,
+                                                    pa.attname,
+                                                    'UPDATE'
+                                                )
+                                            ),
+                                            'comment', pg_catalog.col_description(pc.oid, pa.attnum),
+                                            'directives', jsonb_build_object(
+                                                'name', graphql.comment_directive(pg_catalog.col_description(pc.oid, pa.attnum)) ->> 'name'
+                                            )
+                                        )
+                                        order by pa.attnum
                                     )
+                                from
+                                    pg_catalog.pg_attribute pa
+                                    left join pg_catalog.pg_attrdef pd
+                                        on (pa.attrelid, pa.attnum) = (pd.adrelid, pd.adnum)
+                                where
+                                    pc.oid = pa.attrelid
+                                    and pa.attnum > 0
+                                    and not pa.attisdropped
+                            ),
+                            'permissions', jsonb_build_object(
+                                'is_insertable', pg_catalog.has_table_privilege(
+                                    current_user,
+                                    pc.oid,
+                                    'INSERT'
+                                ),
+                                'is_selectable', pg_catalog.has_table_privilege(
+                                    current_user,
+                                    pc.oid,
+                                    'SELECT'
+                                ),
+                                'is_updatable', pg_catalog.has_table_privilege(
+                                    current_user,
+                                    pc.oid,
+                                    'UPDATE'
+                                ),
+                                'is_deletable', pg_catalog.has_table_privilege(
+                                    current_user,
+                                    pc.oid,
+                                    'DELETE'
                                 )
-                        from
-                            pg_class pc
-                        where
-                            pc.relnamespace = pn.oid
-                            and pc.relkind in (
-                                'r', -- table
-                                'v', -- view
-                                'm', -- mat view
-                                'f'  -- foreign table
                             )
-                        ),
-                        jsonb_build_array()
+                        )
                     )
+            from
+                pg_class pc
+                join schemas_
+                    on pc.relnamespace = schemas_.oid
+            where
+                pc.relkind in (
+                    'r', -- table
+                    'v', -- view
+                    'm', -- mat view
+                    'f'  -- foreign table
                 )
             ),
-            jsonb_build_array()
+            jsonb_build_object()
         )
-    )
-from
-    pg_namespace pn
-    -- filter to current schemas only
-    join search_path_oids cur_schemas(oid)
-        on pn.oid = cur_schemas.oid,
-    lateral (
-        select
-            coalesce(
-                (graphql.comment_directive(pg_catalog.obj_description(pn.oid, 'pg_namespace')) -> 'inflect_names') = to_jsonb(true),
-                false
-            ) as inflect_names,
-            coalesce(
-                (graphql.comment_directive(pg_catalog.obj_description(pn.oid, 'pg_namespace')) ->> 'max_rows')::int,
-                30
-            ) as max_rows
-    ) schema_directives
-where
-    pg_catalog.has_schema_privilege(
-        current_user,
-        pn.oid,
-        'USAGE'
+
     )

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -174,7 +174,7 @@ where
 
     let mut objects: Vec<InsertRowBuilder> = vec![];
 
-    let insert_type_field_map = insert_type.input_field_map();
+    let insert_type_field_map = input_field_map(&__Type::InsertInput(insert_type));
 
     // validated user input kv map
     match validated {
@@ -236,7 +236,7 @@ where
     let type_name = type_
         .name()
         .ok_or("Encountered type without name in connection builder")?;
-    let field_map = type_.field_map();
+    let field_map = field_map(&type_);
     let alias = alias_or_name(query_field);
 
     match &type_ {
@@ -341,7 +341,7 @@ where
 
     let mut set: HashMap<String, serde_json::Value> = HashMap::new();
 
-    let update_type_field_map = update_type.input_field_map();
+    let update_type_field_map = input_field_map(&__Type::UpdateInput(update_type));
 
     // validated user input kv map
     match validated {
@@ -389,7 +389,7 @@ where
     let type_name = type_
         .name()
         .ok_or("Encountered type without name in update builder")?;
-    let field_map = type_.field_map();
+    let field_map = field_map(&type_);
     let alias = alias_or_name(query_field);
 
     match &type_ {
@@ -485,7 +485,7 @@ where
     let type_name = type_
         .name()
         .ok_or("Encountered type without name in delete builder")?;
-    let field_map = type_.field_map();
+    let field_map = field_map(&type_);
     let alias = alias_or_name(query_field);
 
     match &type_ {
@@ -868,7 +868,7 @@ where
         _ => return Err("Filter re-validation errror".to_string()),
     };
 
-    let filter_field_map = filter_type.input_field_map();
+    let filter_field_map = input_field_map(&__Type::FilterEntity(filter_type));
     for (k, op_to_v) in kv_map.iter() {
         // k = str, v = {"eq": 1}
         let filter_iv: &__InputValue = match filter_field_map.get(k) {
@@ -935,7 +935,7 @@ where
 
     let mut orders = vec![];
 
-    let order_field_map = order_type.input_field_map();
+    let order_field_map = input_field_map(&__Type::OrderByEntity(order_type.clone()));
 
     // validated user input kv map
     match validated {
@@ -978,7 +978,7 @@ where
     };
 
     // To acheive consistent pagination, sorting should always include primary key
-    let pkey = order_type
+    let pkey = &order_type
         .table
         .primary_key()
         .ok_or_else(|| "Found table with no primary key".to_string())?;
@@ -1041,7 +1041,7 @@ where
     let type_name = type_
         .name()
         .ok_or("Encountered type without name in connection builder")?;
-    let field_map = type_.field_map();
+    let field_map = field_map(&type_);
     let alias = alias_or_name(query_field);
 
     match &type_ {
@@ -1171,7 +1171,7 @@ where
         "Encountered type without name in page info builder: {:?}",
         type_
     ))?;
-    let field_map = type_.field_map();
+    let field_map = field_map(&type_);
     let alias = alias_or_name(query_field);
 
     match type_ {
@@ -1231,7 +1231,7 @@ where
         "Encountered type without name in edge builder: {:?}",
         type_
     ))?;
-    let field_map = type_.field_map();
+    let field_map = field_map(&type_);
     let alias = alias_or_name(query_field);
 
     match type_ {
@@ -1337,7 +1337,8 @@ where
     let type_name = xtype
         .name()
         .ok_or("Encountered type without name in node builder")?;
-    let field_map = xtype.field_map();
+
+    let field_map = field_map(&__Type::Node(xtype.clone()));
 
     let mut builder_fields = vec![];
     restrict_allowed_arguments(vec!["nodeId"], query_field)?;
@@ -1809,7 +1810,7 @@ impl __Schema {
     where
         T: Text<'a> + Eq + AsRef<str>,
     {
-        let field_map = __Type::__Type(__TypeType {}).field_map();
+        let field_map = field_map(&__Type::__Type(__TypeType {}));
 
         let selection_fields = normalize_selection_set(
             &query_field.selection_set,
@@ -1992,7 +1993,7 @@ impl __Schema {
         let type_name = type_
             .name()
             .ok_or("Encountered type without name in schema builder")?;
-        let field_map = type_.field_map();
+        let field_map = field_map(&type_);
 
         match type_ {
             __Type::__Schema(_) => {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1075,7 +1075,7 @@ where
                 .schema
                 .context
                 .schemas
-                .iter()
+                .values()
                 .find(|s| s.oid == xtype.table.schema_oid)
                 .map(|x| x.directives.max_rows)
                 .unwrap_or(30);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1752,7 +1752,6 @@ impl __Schema {
         fragment_definitions: &Vec<FragmentDefinition<'a, T>>,
         mut type_name: Option<String>,
         variables: &serde_json::Value,
-        type_map: &HashMap<String, __Type>,
     ) -> Result<Option<__TypeBuilder>, String>
     where
         T: Text<'a> + Eq + AsRef<str>,
@@ -1782,6 +1781,7 @@ impl __Schema {
         }
         let type_name = type_name.unwrap();
 
+        let type_map = type_map(&self);
         let requested_type: Option<&__Type> = type_map.get(&type_name);
 
         match requested_type {
@@ -1994,8 +1994,6 @@ impl __Schema {
             .ok_or("Encountered type without name in schema builder")?;
         let field_map = type_.field_map();
 
-        let type_map = self.type_map();
-
         match type_ {
             __Type::__Schema(_) => {
                 let mut builder_fields: Vec<__SchemaSelection> = vec![];
@@ -2029,7 +2027,6 @@ impl __Schema {
                                                 fragment_definitions,
                                                 t.name(),
                                                 variables,
-                                                &type_map,
                                             )
                                             .map(|x| x.unwrap())
                                         })
@@ -2044,7 +2041,6 @@ impl __Schema {
                                         fragment_definitions,
                                         Some("Query".to_string()),
                                         variables,
-                                        &type_map,
                                     )?;
                                     __SchemaField::QueryType(builder.unwrap())
                                 }
@@ -2055,7 +2051,6 @@ impl __Schema {
                                         fragment_definitions,
                                         Some("Mutation".to_string()),
                                         variables,
-                                        &type_map,
                                     )?;
                                     __SchemaField::MutationType(builder)
                                 }

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1,10 +1,11 @@
 use crate::sql_types::*;
+use cached::proc_macro::cached;
+use cached::SizedCache;
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use regex::Regex;
 use serde::Serialize;
 use std::collections::HashMap;
-use std::rc::Rc;
 use std::sync::Arc;
 
 lazy_static! {
@@ -816,47 +817,47 @@ pub struct NonNullType {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SchemaType {
-    pub schema: Rc<__Schema>,
+    pub schema: Arc<__Schema>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct QueryType {
-    pub schema: Rc<__Schema>,
+    pub schema: Arc<__Schema>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MutationType {
-    pub schema: Rc<__Schema>,
+    pub schema: Arc<__Schema>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InsertInputType {
     pub table: Arc<Table>,
-    pub schema: Rc<__Schema>,
+    pub schema: Arc<__Schema>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpdateInputType {
     pub table: Arc<Table>,
-    pub schema: Rc<__Schema>,
+    pub schema: Arc<__Schema>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InsertResponseType {
     pub table: Arc<Table>,
-    pub schema: Rc<__Schema>,
+    pub schema: Arc<__Schema>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpdateResponseType {
     pub table: Arc<Table>,
-    pub schema: Rc<__Schema>,
+    pub schema: Arc<__Schema>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DeleteResponseType {
     pub table: Arc<Table>,
-    pub schema: Rc<__Schema>,
+    pub schema: Arc<__Schema>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -868,7 +869,7 @@ pub struct ConnectionType {
     pub fkey: Option<Arc<ForeignKey>>,
     pub reverse_reference: Option<bool>,
 
-    pub schema: Rc<__Schema>,
+    pub schema: Arc<__Schema>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -880,7 +881,7 @@ pub enum EnumSource {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EnumType {
     pub enum_: EnumSource,
-    pub schema: Rc<__Schema>,
+    pub schema: Arc<__Schema>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -889,7 +890,7 @@ pub struct OrderByType {}
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct OrderByEntityType {
     pub table: Arc<Table>,
-    pub schema: Rc<__Schema>,
+    pub schema: Arc<__Schema>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -901,19 +902,19 @@ pub enum FilterableType {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FilterTypeType {
     pub entity: FilterableType,
-    pub schema: Rc<__Schema>,
+    pub schema: Arc<__Schema>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FilterEntityType {
     pub table: Arc<Table>,
-    pub schema: Rc<__Schema>,
+    pub schema: Arc<__Schema>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EdgeType {
     pub table: Arc<Table>,
-    pub schema: Rc<__Schema>,
+    pub schema: Arc<__Schema>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -925,12 +926,12 @@ pub struct NodeType {
     pub fkey: Option<Arc<ForeignKey>>,
     pub reverse_reference: Option<bool>,
 
-    pub schema: Rc<__Schema>,
+    pub schema: Arc<__Schema>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NodeInterfaceType {
-    pub schema: Rc<__Schema>,
+    pub schema: Arc<__Schema>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -955,7 +956,7 @@ impl ___Type for QueryType {
         let single_entrypoint = __Field {
             name_: "node".to_string(),
             type_: __Type::NodeInterface(NodeInterfaceType {
-                schema: Rc::clone(&self.schema),
+                schema: Arc::clone(&self.schema),
             }),
             args: vec![__InputValue {
                 name_: "nodeId".to_string(),
@@ -991,7 +992,7 @@ impl ___Type for QueryType {
                         table: Arc::clone(table),
                         fkey: None,
                         reverse_reference: None,
-                        schema: Rc::clone(&self.schema),
+                        schema: Arc::clone(&self.schema),
                     }),
                     args: vec![
                         __InputValue {
@@ -1119,7 +1120,7 @@ impl ___Type for MutationType {
                     name_: format!("insertInto{}Collection", table_base_type_name),
                     type_: __Type::InsertResponse(InsertResponseType {
                         table: Arc::clone(table),
-                        schema: Rc::clone(&self.schema),
+                        schema: Arc::clone(&self.schema),
                     }),
                     args: vec![__InputValue {
                         name_: "objects".to_string(),
@@ -1128,7 +1129,7 @@ impl ___Type for MutationType {
                                 type_: Box::new(__Type::NonNull(NonNullType {
                                     type_: Box::new(__Type::InsertInput(InsertInputType {
                                         table: Arc::clone(table),
-                                        schema: Rc::clone(&self.schema),
+                                        schema: Arc::clone(&self.schema),
                                     })),
                                 })),
                             })),
@@ -1152,7 +1153,7 @@ impl ___Type for MutationType {
                     type_: __Type::NonNull(NonNullType {
                         type_: Box::new(__Type::UpdateResponse(UpdateResponseType {
                             table: Arc::clone(table),
-                            schema: Rc::clone(&self.schema),
+                            schema: Arc::clone(&self.schema),
                         })),
                     }),
                     args: vec![
@@ -1161,7 +1162,7 @@ impl ___Type for MutationType {
                             type_: __Type::NonNull(NonNullType {
                                 type_: Box::new(__Type::UpdateInput(UpdateInputType {
                                     table: Arc::clone(table),
-                                    schema: Rc::clone(&self.schema),
+                                    schema: Arc::clone(&self.schema),
                                 })),
                             }),
                             description: Some("Fields that are set will be updated for all records matching the `filter`".to_string()),
@@ -1172,7 +1173,7 @@ impl ___Type for MutationType {
                             name_: "filter".to_string(),
                             type_: __Type::FilterEntity(FilterEntityType {
                                 table: Arc::clone(table),
-                                schema: Rc::clone(&self.schema),
+                                schema: Arc::clone(&self.schema),
                             }),
                             description: Some("Restricts the mutation's impact to records matching the criteria".to_string()),
                             default_value: None,
@@ -1203,7 +1204,7 @@ impl ___Type for MutationType {
                     type_: __Type::NonNull(NonNullType {
                         type_: Box::new(__Type::DeleteResponse(DeleteResponseType {
                             table: Arc::clone(table),
-                            schema: Rc::clone(&self.schema),
+                            schema: Arc::clone(&self.schema),
                         })),
                     }),
                     args: vec![
@@ -1211,7 +1212,7 @@ impl ___Type for MutationType {
                             name_: "filter".to_string(),
                             type_: __Type::FilterEntity(FilterEntityType {
                                 table: Arc::clone(table),
-                                schema: Rc::clone(&self.schema),
+                                schema: Arc::clone(&self.schema),
                             }),
                             description: Some(
                                 "Restricts the mutation's impact to records matching the criteria"
@@ -1330,7 +1331,7 @@ impl ___Type for ConnectionType {
                         type_: Box::new(__Type::NonNull(NonNullType {
                             type_: Box::new(__Type::Edge(EdgeType {
                                 table: Arc::clone(&self.table),
-                                schema: Rc::clone(&self.schema),
+                                schema: Arc::clone(&self.schema),
                             })),
                         })),
                     })),
@@ -1387,7 +1388,11 @@ impl ___Type for NodeInterfaceType {
 
         let mut possible_types = vec![];
 
-        for type_ in self.schema.types() {
+        // Use type_map(..) not types() because its cached
+        for type_ in type_map(&self.schema)
+            .into_values()
+            .sorted_by(|a, b| a.name().cmp(&b.name()))
+        {
             let type_interfaces: Vec<__Type> = type_.interfaces().unwrap_or(vec![]);
             let interface_names: Vec<String> =
                 type_interfaces.iter().map(|x| x.name().unwrap()).collect();
@@ -1444,7 +1449,7 @@ impl ___Type for EdgeType {
                         table: Arc::clone(&self.table),
                         fkey: None,
                         reverse_reference: None,
-                        schema: Rc::clone(&self.schema),
+                        schema: Arc::clone(&self.schema),
                     })),
                 }),
                 args: vec![],
@@ -1456,7 +1461,7 @@ impl ___Type for EdgeType {
     }
 }
 
-pub fn sql_type_to_graphql_type(type_oid: u32, type_name: &str, schema: &Rc<__Schema>) -> __Type {
+pub fn sql_type_to_graphql_type(type_oid: u32, type_name: &str, schema: &Arc<__Schema>) -> __Type {
     let mut type_w_list_mod = match type_oid {
         20 => __Type::Scalar(Scalar::BigInt),     // bigint "
         16 => __Type::Scalar(Scalar::Boolean),    // boolean "
@@ -1544,7 +1549,7 @@ pub fn sql_type_to_graphql_type(type_oid: u32, type_name: &str, schema: &Rc<__Sc
                             type_w_list_mod = __Type::List(ListType {
                                 type_: Box::new(__Type::Enum(EnumType {
                                     enum_: EnumSource::Enum(Arc::clone(base_enum)),
-                                    schema: Rc::clone(schema),
+                                    schema: Arc::clone(schema),
                                 })),
                             })
                         }
@@ -1558,7 +1563,7 @@ pub fn sql_type_to_graphql_type(type_oid: u32, type_name: &str, schema: &Rc<__Sc
     type_w_list_mod
 }
 
-pub fn sql_column_to_graphql_type(col: &Column, schema: &Rc<__Schema>) -> __Type {
+pub fn sql_column_to_graphql_type(col: &Column, schema: &Arc<__Schema>) -> __Type {
     let type_w_list_mod = sql_type_to_graphql_type(col.type_oid, col.type_name.as_str(), schema);
 
     match col.is_not_null {
@@ -1583,7 +1588,7 @@ impl ___Type for NodeType {
 
         if self.table.primary_key().is_some() {
             interfaces.push(__Type::NodeInterface(NodeInterfaceType {
-                schema: Rc::clone(&self.schema),
+                schema: Arc::clone(&self.schema),
             }))
         }
 
@@ -1696,7 +1701,7 @@ impl ___Type for NodeType {
                     table: Arc::clone(foreign_table),
                     fkey: Some(Arc::clone(fkey)),
                     reverse_reference: Some(reverse_reference),
-                    schema: Rc::clone(&self.schema),
+                    schema: Arc::clone(&self.schema),
                 }),
                 args: vec![],
                 description: None,
@@ -1741,7 +1746,7 @@ impl ___Type for NodeType {
                                 table: Arc::clone(foreign_table),
                                 fkey: Some(Arc::clone(fkey)),
                                 reverse_reference: Some(reverse_reference),
-                                schema: Rc::clone(&self.schema),
+                                schema: Arc::clone(&self.schema),
                             }),
                         args: vec![
                             __InputValue {
@@ -1776,7 +1781,7 @@ impl ___Type for NodeType {
                                 name_: "filter".to_string(),
                                 type_: __Type::FilterEntity(FilterEntityType {
                                     table: Arc::clone(foreign_table),
-                                    schema: Rc::clone(&self.schema),
+                                    schema: Arc::clone(&self.schema),
                                 }),
                                 description: Some("Filters to apply to the results set when querying from the collection".to_string()),
                                 default_value: None,
@@ -1789,7 +1794,7 @@ impl ___Type for NodeType {
                                         type_: Box::new(__Type::OrderByEntity(
                                             OrderByEntityType {
                                                 table: Arc::clone(foreign_table),
-                                                schema: Rc::clone(&self.schema),
+                                                schema: Arc::clone(&self.schema),
                                             },
                                         )),
                                     })),
@@ -1814,7 +1819,7 @@ impl ___Type for NodeType {
                             table: Arc::clone(foreign_table),
                             fkey: Some(Arc::clone(fkey)),
                             reverse_reference: Some(reverse_reference),
-                            schema: Rc::clone(&self.schema),
+                            schema: Arc::clone(&self.schema),
                         }),
                         args: vec![],
                         description: None,
@@ -2076,8 +2081,6 @@ impl ___Type for __DirectiveLocationType {
         ])
     }
 }
-
-// __Type::NonNull(NonNullType{ type_: Box::new( __Type::List(ListType { type_: Box::new(__Type::NonNull( NonNullType { type_: Box::new(__Type::__Type) } ) )}))})
 
 impl ___Type for __SchemaType {
     fn kind(&self) -> __TypeKind {
@@ -2740,7 +2743,7 @@ impl ___Type for InsertResponseType {
                                 table: Arc::clone(&self.table),
                                 fkey: None,
                                 reverse_reference: None,
-                                schema: Rc::clone(&self.schema),
+                                schema: Arc::clone(&self.schema),
                             })),
                         })),
                     })),
@@ -2825,7 +2828,7 @@ impl ___Type for UpdateResponseType {
                                 table: Arc::clone(&self.table),
                                 fkey: None,
                                 reverse_reference: None,
-                                schema: Rc::clone(&self.schema),
+                                schema: Arc::clone(&self.schema),
                             })),
                         })),
                     })),
@@ -2872,7 +2875,7 @@ impl ___Type for DeleteResponseType {
                                 table: Arc::clone(&self.table),
                                 fkey: None,
                                 reverse_reference: None,
-                                schema: Rc::clone(&self.schema),
+                                schema: Arc::clone(&self.schema),
                             })),
                         })),
                     })),
@@ -2952,7 +2955,7 @@ impl ___Type for FilterTypeType {
                                 name_: "is".to_string(),
                                 type_: __Type::Enum(EnumType {
                                     enum_: EnumSource::FilterIs,
-                                    schema: Rc::clone(&self.schema),
+                                    schema: Arc::clone(&self.schema),
                                 }),
                                 description: None,
                                 default_value: None,
@@ -3011,7 +3014,7 @@ impl ___Type for FilterTypeType {
                             name_: "is".to_string(),
                             type_: __Type::Enum(EnumType {
                                 enum_: EnumSource::FilterIs,
-                                schema: Rc::clone(&self.schema),
+                                schema: Arc::clone(&self.schema),
                             }),
                             description: None,
                             default_value: None,
@@ -3052,7 +3055,7 @@ impl ___Type for FilterTypeType {
                         name_: "is".to_string(),
                         type_: __Type::Enum(EnumType {
                             enum_: EnumSource::FilterIs,
-                            schema: Rc::clone(&self.schema),
+                            schema: Arc::clone(&self.schema),
                         }),
                         description: None,
                         default_value: None,
@@ -3106,7 +3109,7 @@ impl ___Type for FilterEntityType {
                         name_: column_graphql_name,
                         type_: __Type::FilterType(FilterTypeType {
                             entity: FilterableType::Scalar(s),
-                            schema: Rc::clone(&self.schema),
+                            schema: Arc::clone(&self.schema),
                         }),
                         description: None,
                         default_value: None,
@@ -3117,7 +3120,7 @@ impl ___Type for FilterEntityType {
                         name_: column_graphql_name,
                         type_: __Type::FilterType(FilterTypeType {
                             entity: FilterableType::Enum(s),
-                            schema: Rc::clone(&self.schema),
+                            schema: Arc::clone(&self.schema),
                         }),
                         description: None,
                         default_value: None,
@@ -3141,7 +3144,7 @@ impl ___Type for FilterEntityType {
                 name_: "nodeId".to_string(),
                 type_: __Type::FilterType(FilterTypeType {
                     entity: FilterableType::Scalar(Scalar::ID),
-                    schema: Rc::clone(&self.schema),
+                    schema: Arc::clone(&self.schema),
                 }),
                 description: None,
                 default_value: None,
@@ -3259,11 +3262,27 @@ pub struct __Schema {
     pub context: Arc<Context>,
 }
 
+#[cached(
+    type = "SizedCache<String, HashMap<String, __Type>>",
+    create = "{ SizedCache::with_size(200) }",
+    convert = r#"{ serde_json::ser::to_string(&schema.context.config).unwrap() }"#,
+    sync_writes = true
+)]
+pub fn type_map(schema: &__Schema) -> HashMap<String, __Type> {
+    let tmap: HashMap<String, __Type> = schema
+        .types()
+        .into_iter()
+        .filter(|x| x.name().is_some())
+        .map(|x| (x.name().unwrap(), x))
+        .collect();
+    tmap
+}
+
 impl __Schema {
     // types: [__Type!]!
     pub fn types(&self) -> Vec<__Type> {
         // This is is lightweight because context is Rc
-        let schema_rc = Rc::new(self.clone());
+        let schema_rc = Arc::new(self.clone());
 
         let mut types_: Vec<__Type> = vec![
             __Type::__TypeKind(__TypeKindType),
@@ -3289,48 +3308,48 @@ impl __Schema {
             __Type::Scalar(Scalar::Cursor),
             __Type::Enum(EnumType {
                 enum_: EnumSource::FilterIs,
-                schema: Rc::clone(&schema_rc),
+                schema: Arc::clone(&schema_rc),
             }),
             __Type::OrderBy(OrderByType {}),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::Scalar(Scalar::ID),
-                schema: Rc::clone(&schema_rc),
+                schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::Scalar(Scalar::Int),
-                schema: Rc::clone(&schema_rc),
+                schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::Scalar(Scalar::Float),
-                schema: Rc::clone(&schema_rc),
+                schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::Scalar(Scalar::String),
-                schema: Rc::clone(&schema_rc),
+                schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::Scalar(Scalar::Boolean),
-                schema: Rc::clone(&schema_rc),
+                schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::Scalar(Scalar::Date),
-                schema: Rc::clone(&schema_rc),
+                schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::Scalar(Scalar::Time),
-                schema: Rc::clone(&schema_rc),
+                schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::Scalar(Scalar::Datetime),
-                schema: Rc::clone(&schema_rc),
+                schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::Scalar(Scalar::BigInt),
-                schema: Rc::clone(&schema_rc),
+                schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::Scalar(Scalar::UUID),
-                schema: Rc::clone(&schema_rc),
+                schema: Arc::clone(&schema_rc),
             }),
             __Type::Query(QueryType {
                 schema: schema_rc.clone(),
@@ -3342,7 +3361,7 @@ impl __Schema {
 
         if self.mutations_exist() {
             types_.push(__Type::Mutation(MutationType {
-                schema: Rc::clone(&schema_rc),
+                schema: Arc::clone(&schema_rc),
             }));
         }
 
@@ -3356,55 +3375,55 @@ impl __Schema {
                 table: Arc::clone(table),
                 fkey: None,
                 reverse_reference: None,
-                schema: Rc::clone(&schema_rc),
+                schema: Arc::clone(&schema_rc),
             }));
             types_.push(__Type::Edge(EdgeType {
                 table: Arc::clone(table),
-                schema: Rc::clone(&schema_rc),
+                schema: Arc::clone(&schema_rc),
             }));
             types_.push(__Type::Connection(ConnectionType {
                 table: Arc::clone(table),
                 fkey: None,
                 reverse_reference: None,
-                schema: Rc::clone(&schema_rc),
+                schema: Arc::clone(&schema_rc),
             }));
 
             types_.push(__Type::FilterEntity(FilterEntityType {
                 table: Arc::clone(table),
-                schema: Rc::clone(&schema_rc),
+                schema: Arc::clone(&schema_rc),
             }));
 
             types_.push(__Type::OrderByEntity(OrderByEntityType {
                 table: Arc::clone(table),
-                schema: Rc::clone(&schema_rc),
+                schema: Arc::clone(&schema_rc),
             }));
 
             if self.graphql_table_insert_types_are_valid(table) {
                 types_.push(__Type::InsertInput(InsertInputType {
                     table: Arc::clone(table),
-                    schema: Rc::clone(&schema_rc),
+                    schema: Arc::clone(&schema_rc),
                 }));
                 types_.push(__Type::InsertResponse(InsertResponseType {
                     table: Arc::clone(table),
-                    schema: Rc::clone(&schema_rc),
+                    schema: Arc::clone(&schema_rc),
                 }));
             }
 
             if self.graphql_table_update_types_are_valid(table) {
                 types_.push(__Type::UpdateInput(UpdateInputType {
                     table: Arc::clone(table),
-                    schema: Rc::clone(&schema_rc),
+                    schema: Arc::clone(&schema_rc),
                 }));
                 types_.push(__Type::UpdateResponse(UpdateResponseType {
                     table: Arc::clone(table),
-                    schema: Rc::clone(&schema_rc),
+                    schema: Arc::clone(&schema_rc),
                 }));
             }
 
             if self.graphql_table_delete_types_are_valid(table) {
                 types_.push(__Type::DeleteResponse(DeleteResponseType {
                     table: Arc::clone(table),
-                    schema: Rc::clone(&schema_rc),
+                    schema: Arc::clone(&schema_rc),
                 }));
             }
         }
@@ -3417,14 +3436,14 @@ impl __Schema {
         {
             let enum_type = EnumType {
                 enum_: EnumSource::Enum(Arc::clone(&enum_)),
-                schema: Rc::clone(&schema_rc),
+                schema: Arc::clone(&schema_rc),
             };
 
             types_.push(__Type::Enum(enum_type.clone()));
 
             let enum_filter = __Type::FilterType(FilterTypeType {
                 entity: FilterableType::Enum(enum_type.clone()),
-                schema: Rc::clone(&schema_rc),
+                schema: Arc::clone(&schema_rc),
             });
 
             types_.push(__Type::Enum(enum_type));
@@ -3433,16 +3452,6 @@ impl __Schema {
 
         types_.sort_by_key(|a| a.name());
         types_
-    }
-
-    pub fn type_map(&self) -> HashMap<String, __Type> {
-        let tmap: HashMap<String, __Type> = self
-            .types()
-            .into_iter()
-            .filter(|x| x.name().is_some())
-            .map(|x| (x.name().unwrap(), x))
-            .collect();
-        tmap
     }
 
     pub fn mutations_exist(&self) -> bool {
@@ -3462,7 +3471,7 @@ impl __Schema {
     #[allow(dead_code)]
     pub fn query_type(&self) -> __Type {
         __Type::Query(QueryType {
-            schema: Rc::new(self.clone()),
+            schema: Arc::new(self.clone()),
         })
     }
 
@@ -3470,7 +3479,7 @@ impl __Schema {
     #[allow(dead_code)]
     pub fn mutation_type(&self) -> Option<__Type> {
         let mutation = MutationType {
-            schema: Rc::new(self.clone()),
+            schema: Arc::new(self.clone()),
         };
 
         match mutation.fields(true).unwrap_or_default().len() {

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -136,7 +136,7 @@ where
     use crate::graphql::*;
 
     let query_type = schema_type.query_type();
-    let map = query_type.field_map();
+    let map = field_map(&query_type);
 
     let selections = match normalize_selection_set(
         &selection_set,
@@ -321,7 +321,7 @@ where
         }
     };
 
-    let map = mutation_type.field_map();
+    let map = field_map(&mutation_type);
 
     let selections = match normalize_selection_set(
         &selection_set,

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -218,14 +218,12 @@ where
                             }
                         }
                         __Type::__Type(_) => {
-                            let type_map = schema_type.type_map();
                             let __type_builder = schema_type.to_type_builder(
                                 field_def,
                                 selection,
                                 &fragment_definitions,
                                 None,
                                 variables,
-                                &type_map,
                             );
 
                             match __type_builder {

--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -36,17 +36,17 @@ pub struct Column {
     pub directives: ColumnDirectives,
 }
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct FunctionDirectives {
     pub name: Option<String>,
 }
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct FunctionPermissions {
     pub is_executable: bool,
 }
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Function {
     pub oid: u32,
     pub name: String,
@@ -59,7 +59,7 @@ pub struct Function {
     pub permissions: FunctionPermissions,
 }
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct TablePermissions {
     pub is_insertable: bool,
     pub is_selectable: bool,
@@ -67,12 +67,12 @@ pub struct TablePermissions {
     pub is_deletable: bool,
 }
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct TypePermissions {
     pub is_usable: bool,
 }
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum TypeCategory {
     Enum,
     Composite,
@@ -80,7 +80,7 @@ pub enum TypeCategory {
     Other,
 }
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Type {
     pub oid: u32,
     pub schema_oid: u32,
@@ -92,14 +92,14 @@ pub struct Type {
     pub directives: EnumDirectives,
 }
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct EnumValue {
     pub oid: u32,
     pub name: String,
     pub sort_order: i32,
 }
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Enum {
     pub oid: u32,
     pub schema_oid: u32,
@@ -111,18 +111,18 @@ pub struct Enum {
     pub directives: EnumDirectives,
 }
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct EnumDirectives {
     pub name: Option<String>,
 }
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Composite {
     pub oid: u32,
     pub schema_oid: u32,
 }
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Index {
     pub table_oid: u32,
     pub column_names: Vec<String>,
@@ -130,7 +130,7 @@ pub struct Index {
     pub is_primary_key: bool,
 }
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ForeignKeyTableInfo {
     pub oid: u32,
     // The table's actual name
@@ -139,25 +139,25 @@ pub struct ForeignKeyTableInfo {
     pub column_names: Vec<String>,
 }
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ForeignKeyDirectives {
     pub local_name: Option<String>,
     pub foreign_name: Option<String>,
 }
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ForeignKey {
     pub directives: ForeignKeyDirectives,
     pub local_table_meta: ForeignKeyTableInfo,
     pub referenced_table_meta: ForeignKeyTableInfo,
 }
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct TableDirectiveTotalCount {
     pub enabled: bool,
 }
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct TableDirectiveForeignKey {
     // Equivalent to ForeignKeyDirectives.local_name
     pub local_name: Option<String>,
@@ -170,7 +170,7 @@ pub struct TableDirectiveForeignKey {
     pub foreign_columns: Vec<String>,
 }
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct TableDirectives {
     // @graphql({"name": "Foo" })
     pub name: Option<String>,
@@ -203,7 +203,7 @@ pub struct TableDirectives {
     pub foreign_keys: Option<Vec<TableDirectiveForeignKey>>,
 }
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Table {
     pub oid: u32,
     pub name: String,
@@ -281,7 +281,7 @@ impl Table {
     }
 }
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct SchemaDirectives {
     // @graphql({"inflect_names": true})
     pub inflect_names: bool,
@@ -289,7 +289,7 @@ pub struct SchemaDirectives {
     pub max_rows: i64,
 }
 
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Schema {
     pub oid: u32,
     pub name: String,
@@ -297,7 +297,7 @@ pub struct Schema {
     pub directives: SchemaDirectives,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Config {
     pub search_path: Vec<String>,
     pub role: String,
@@ -313,6 +313,13 @@ pub struct Context {
     pub types: HashMap<u32, Arc<Type>>,
     pub enums: HashMap<u32, Arc<Enum>>,
     pub composites: Vec<Arc<Composite>>,
+}
+
+impl Hash for Context {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Only the config is needed to has ha Context
+        self.config.hash(state);
+    }
 }
 
 impl Context {
@@ -477,10 +484,19 @@ pub fn load_sql_config() -> Config {
     config
 }
 
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+pub fn calculate_hash<T: Hash>(t: &T) -> u64 {
+    let mut s = DefaultHasher::new();
+    t.hash(&mut s);
+    s.finish()
+}
+
 #[cached(
-    type = "SizedCache<String, Result<Arc<Context>, String>>",
+    type = "SizedCache<u64, Result<Arc<Context>, String>>",
     create = "{ SizedCache::with_size(250) }",
-    convert = r#"{ serde_json::ser::to_string(_config).unwrap() }"#,
+    convert = r#"{ calculate_hash(_config) }"#,
     sync_writes = true
 )]
 pub fn load_sql_context(_config: &Config) -> Result<Arc<Context>, String> {

--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -17,7 +17,6 @@ pub struct ColumnPermissions {
 
 #[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ColumnDirectives {
-    pub inflect_names: bool,
     pub name: Option<String>,
 }
 
@@ -26,6 +25,7 @@ pub struct Column {
     pub name: String,
     pub type_oid: u32,
     pub type_name: String,
+    pub schema_oid: u32,
     pub is_not_null: bool,
     pub is_serial: bool,
     pub is_generated: bool,
@@ -38,7 +38,6 @@ pub struct Column {
 
 #[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct FunctionDirectives {
-    pub inflect_names: bool,
     pub name: Option<String>,
 }
 
@@ -51,6 +50,7 @@ pub struct FunctionPermissions {
 pub struct Function {
     pub oid: u32,
     pub name: String,
+    pub schema_oid: u32,
     pub schema_name: String,
     pub type_oid: u32,
     pub type_name: String,
@@ -151,8 +151,6 @@ pub struct TableDirectiveForeignKey {
 
 #[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct TableDirectives {
-    pub inflect_names: bool,
-
     // @graphql({"name": "Foo" })
     pub name: Option<String>,
 

--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -2,7 +2,7 @@ use cached::proc_macro::cached;
 use cached::SizedCache;
 use pgx::*;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::*;
 
@@ -68,8 +68,28 @@ pub struct TablePermissions {
 }
 
 #[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
-pub struct EnumPermissions {
+pub struct TypePermissions {
     pub is_usable: bool,
+}
+
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+pub enum TypeCategory {
+    Enum,
+    Composite,
+    Array,
+    Other,
+}
+
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct Type {
+    pub oid: u32,
+    pub schema_oid: u32,
+    pub name: String,
+    pub category: TypeCategory,
+    pub array_element_type_oid: Option<u32>,
+    pub comment: Option<String>,
+    pub permissions: TypePermissions,
+    pub directives: EnumDirectives,
 }
 
 #[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
@@ -85,8 +105,9 @@ pub struct Enum {
     pub schema_oid: u32,
     pub name: String,
     pub values: Vec<EnumValue>,
+    pub array_element_type_oid: Option<u32>,
     pub comment: Option<String>,
-    pub permissions: EnumPermissions,
+    pub permissions: TypePermissions,
     pub directives: EnumDirectives,
 }
 
@@ -289,7 +310,8 @@ pub struct Context {
     pub config: Config,
     pub schemas: Vec<Schema>,
     foreign_keys: Vec<Arc<ForeignKey>>,
-    pub enums: Vec<Arc<Enum>>,
+    pub types: HashMap<u32, Arc<Type>>,
+    pub enums: HashMap<u32, Arc<Enum>>,
     pub composites: Vec<Arc<Composite>>,
 }
 


### PR DESCRIPTION
Refactorings to the SQL Entities:

- [x] separate schema level comment directives from tables/columns/functions/etc (no duplication of schema comment directive)
- [x] make SQL types dumb data store with the `Context` handling name inflections since it has enough info for that operation and the lower level entities do not
- [x] move name inflection from context up to `__Schema` so a GraphQL object is responsible for a GraphQL operation
- [x] add `Types` to the top level of the SQL Context
- [x] (performance) load all SQL types as a hash map from the most relevant SQL `old` type -> the entity to remove all "search by iteration". This change will make performance identical on large and small schemas
- [x] (performance) cache type map to improve scalability on large schemas
- [x] (performance) cache field/input field maps for frequently used types

Performance Comparison:
```sql
-- Minimum Setup
create table account(
	id int primary key
);

-- Expand the schema to make sure size doesn't have a significant impact
create table abc1(
	id int primary key,
	a1 text,
	a2 text,
	a3 text,
	a4 text,
	a5 text
);

...

create table abc15(
	id int primary key,
	a1 text,
	a2 text,
	a3 text,
	a4 text,
	a5 text
);


-- Populate caches (if exist)
select graphql.resolve($$ {accountCollection(first: 1) { edges {node {id}}}} $$)

-- Benchmark sequential requests
explain analyze
select graphql.resolve($$ {accountCollection(first: 1) { edges {node {id}}}} $$)
from generate_series(1,10000)

-- Before: Execution Time: 7431.168 ms
-- After: Execution Time: 4846.272 ms
```
~35% increase in throughput on single connection for moderately size (16 table) schema. Large schemas see a larger benefit.