### PR TITLE
Add support for type modifiers char(n), varchar(n), bpchar(n)

### DIFF
--- a/sql/load_sql_context.sql
+++ b/sql/load_sql_context.sql
@@ -294,7 +294,11 @@ select
                                         jsonb_build_object(
                                             'name', pa.attname::text,
                                             'type_oid', pa.atttypid::int,
-                                            'type_name', pa.atttypid::regtype::text,
+                                            -- includes type mod info like char(4)
+                                            'type_name', pg_catalog.format_type(pa.atttypid, pa.atttypmod),
+                                            -- char, bpchar, varchar, char[], bpchar[], carchar[]
+                                            -- the -4 removes the byte for the null terminated str
+                                            'max_characters', nullif(pa.atttypmod, -1) - 4,
                                             'schema_oid', schemas_.oid::int,
                                             'is_not_null', pa.attnotnull,
                                             'attribute_num', pa.attnum,

--- a/src/parser_util.rs
+++ b/src/parser_util.rs
@@ -183,7 +183,6 @@ pub fn validate_arg_from_type(type_: &__Type, value: &gson::Value) -> Result<gso
                     }
                     _ => return Err(format!("Invalid input for {:?} type", scalar)),
                 },
-                // TODO(or): add max length validation check
                 Scalar::Int => match value {
                     GsonValue::Absent => value.clone(),
                     GsonValue::Null => value.clone(),

--- a/src/parser_util.rs
+++ b/src/parser_util.rs
@@ -163,10 +163,27 @@ pub fn validate_arg_from_type(type_: &__Type, value: &gson::Value) -> Result<gso
     let res: GsonValue = match type_ {
         __Type::Scalar(scalar) => {
             match scalar {
-                Scalar::String => match value {
+                Scalar::String(None) => match value {
                     GsonValue::Absent | GsonValue::Null | GsonValue::String(_) => value.clone(),
                     _ => return Err(format!("Invalid input for {:?} type", scalar)),
                 },
+                Scalar::String(Some(max_length)) => match value {
+                    GsonValue::Absent | GsonValue::Null => value.clone(),
+                    GsonValue::String(string_content) => {
+                        match string_content.len() as i32 > *max_length {
+                            false => value.clone(),
+                            true => {
+                                return Err(format!(
+                                    "Invalid input for {} type. Maximum character length {}",
+                                    scalar.name().unwrap_or("String".to_string()),
+                                    max_length
+                                ))
+                            }
+                        }
+                    }
+                    _ => return Err(format!("Invalid input for {:?} type", scalar)),
+                },
+                // TODO(or): add max length validation check
                 Scalar::Int => match value {
                     GsonValue::Absent => value.clone(),
                     GsonValue::Null => value.clone(),

--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -25,6 +25,7 @@ pub struct Column {
     pub name: String,
     pub type_oid: u32,
     pub type_name: String,
+    pub max_characters: Option<i32>,
     pub schema_oid: u32,
     pub is_not_null: bool,
     pub is_serial: bool,

--- a/test/expected/roundtrip_types.out
+++ b/test/expected/roundtrip_types.out
@@ -36,7 +36,7 @@ begin;
                     typeText: "1a"
                     typeVarchar: "1a"
                     typeVarchar_n: "1a"
-                    typeChar: "1a"
+                    typeChar: "1"
                     typeUuid: "d4f47ef5-fb25-4d2a-83b2-d5fab114a2e6"
                     typeDate: "1900-01-01"
                     typeTime: "18:23"

--- a/test/expected/type_modifier_max_length.out
+++ b/test/expected/type_modifier_max_length.out
@@ -1,0 +1,95 @@
+begin;
+    create table memo(
+        id serial primary key,
+        vc8 varchar(8),
+        c2 char(2)
+    );
+    insert into memo(vc8, c2)
+    values ('foo bar', 'aa');
+    -- Expect success
+    select graphql.resolve($$
+    mutation {
+      insertIntoMemoCollection(objects: [
+        { vc8: "baz", c2: "bb" }
+      ]) {
+        records {
+          id
+          vc8
+          c2
+        }
+      }
+    }
+    $$);
+                                          resolve                                           
+--------------------------------------------------------------------------------------------
+ {"data": {"insertIntoMemoCollection": {"records": [{"c2": "bb", "id": 2, "vc8": "baz"}]}}}
+(1 row)
+
+    -- Expect fail, vc8 too long
+    select graphql.resolve($$
+    mutation {
+      insertIntoMemoCollection(objects: [
+        { vc8: "123456789", c2: "bb" }
+      ]) {
+        records {
+          id
+          vc8
+          c2
+        }
+      }
+    }
+    $$);
+                                               resolve                                                
+------------------------------------------------------------------------------------------------------
+ {"data": null, "errors": [{"message": "Invalid input for String type. Maximum character length 8"}]}
+(1 row)
+
+    -- Expect fail, c2 too long
+    select graphql.resolve($$
+    mutation {
+      insertIntoMemoCollection(objects: [
+        { vc8: "12345", c2: "123" }
+      ]) {
+        records {
+          id
+          vc8
+          c2
+        }
+      }
+    }
+    $$);
+                                               resolve                                                
+------------------------------------------------------------------------------------------------------
+ {"data": null, "errors": [{"message": "Invalid input for String type. Maximum character length 2"}]}
+(1 row)
+
+    -- Expect fail, filter value too long
+    select graphql.resolve($$
+    {
+      memoCollection(filter: {c2: {eq: "too long"}}){
+        edges { node { id } }
+
+      }
+    }
+    $$);
+                                               resolve                                                
+------------------------------------------------------------------------------------------------------
+ {"data": null, "errors": [{"message": "Invalid input for String type. Maximum character length 2"}]}
+(1 row)
+
+    -- Expect success
+    select graphql.resolve($$
+    {
+      memoCollection(filter: {c2: {eq: "aa"}}){
+        edges { node { id } }
+
+      }
+    }
+    $$);
+                            resolve                             
+----------------------------------------------------------------
+ {"data": {"memoCollection": {"edges": [{"node": {"id": 1}}]}}}
+(1 row)
+
+    
+rollback;

--- a/test/expected/type_modifier_max_length.out
+++ b/test/expected/type_modifier_max_length.out
@@ -91,5 +91,4 @@ begin;
  {"data": {"memoCollection": {"edges": [{"node": {"id": 1}}]}}}
 (1 row)
 
-    
 rollback;

--- a/test/sql/roundtrip_types.sql
+++ b/test/sql/roundtrip_types.sql
@@ -39,7 +39,7 @@ begin;
                     typeText: "1a"
                     typeVarchar: "1a"
                     typeVarchar_n: "1a"
-                    typeChar: "1a"
+                    typeChar: "1"
                     typeUuid: "d4f47ef5-fb25-4d2a-83b2-d5fab114a2e6"
                     typeDate: "1900-01-01"
                     typeTime: "18:23"

--- a/test/sql/type_modifier_max_length.sql
+++ b/test/sql/type_modifier_max_length.sql
@@ -1,0 +1,77 @@
+begin;
+    create table memo(
+        id serial primary key,
+        vc8 varchar(8),
+        c2 char(2)
+    );
+
+    insert into memo(vc8, c2)
+    values ('foo bar', 'aa');
+
+    -- Expect success
+    select graphql.resolve($$
+    mutation {
+      insertIntoMemoCollection(objects: [
+        { vc8: "baz", c2: "bb" }
+      ]) {
+        records {
+          id
+          vc8
+          c2
+        }
+      }
+    }
+    $$);
+
+    -- Expect fail, vc8 too long
+    select graphql.resolve($$
+    mutation {
+      insertIntoMemoCollection(objects: [
+        { vc8: "123456789", c2: "bb" }
+      ]) {
+        records {
+          id
+          vc8
+          c2
+        }
+      }
+    }
+    $$);
+
+    -- Expect fail, c2 too long
+    select graphql.resolve($$
+    mutation {
+      insertIntoMemoCollection(objects: [
+        { vc8: "12345", c2: "123" }
+      ]) {
+        records {
+          id
+          vc8
+          c2
+        }
+      }
+    }
+    $$);
+
+    -- Expect fail, filter value too long
+    select graphql.resolve($$
+    {
+      memoCollection(filter: {c2: {eq: "too long"}}){
+        edges { node { id } }
+
+      }
+    }
+    $$);
+
+    -- Expect success
+    select graphql.resolve($$
+    {
+      memoCollection(filter: {c2: {eq: "aa"}}){
+        edges { node { id } }
+
+      }
+    }
+    $$);
+
+
+rollback;


### PR DESCRIPTION
## What kind of change does this PR introduce?
Adds support for builtin type modifiers on `char(n)` `varchar(n)` and `bpchar(n)` such that input value strings that are too long are rejected during parsing with a better error message and no values are coerced to shorter strings

resolves #192