### PR TITLE
User defined descriptions in schema via comment directive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         package_name:
           - pg-graphql
         pgx_version:
-          - 0.6.1
+          - 0.7.1
         postgres: [14, 15]
         box:
           - { runner: ubuntu-20.04, arch: amd64 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ pg15 = ["pgx/pg15", "pgx-tests/pg15"]
 pg_test = []
 
 [dependencies]
-pgx = "~0.7.1"
+pgx = "0.7.1"
 graphql-parser = "0.4"
 serde = { version = "1.0", features = ["rc"] }
 serde_json = "1.0"
@@ -27,7 +27,7 @@ lazy_static = "1"
 pgx-contrib-spiext = { git = "https://github.com/supabase/pgx-contrib-spiext", rev = "a346053" }
 
 [dev-dependencies]
-pgx-tests = "~0.7.1"
+pgx-tests = "0.7.1"
 
 [profile.dev]
 panic = "unwind"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ pg15 = ["pgx/pg15", "pgx-tests/pg15"]
 pg_test = []
 
 [dependencies]
-pgx = "0.7.1"
+pgx = "=0.7.1"
 graphql-parser = "0.4"
 serde = { version = "1.0", features = ["rc"] }
 serde_json = "1.0"
@@ -27,7 +27,7 @@ lazy_static = "1"
 pgx-contrib-spiext = { git = "https://github.com/supabase/pgx-contrib-spiext", rev = "a346053" }
 
 [dev-dependencies]
-pgx-tests = "0.7.1"
+pgx-tests = "=0.7.1"
 
 [profile.dev]
 panic = "unwind"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_graphql"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 
 [lib]

--- a/dockerfiles/db/Dockerfile
+++ b/dockerfiles/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:14
+FROM postgres:15
 RUN apt-get update
 
 ENV build_deps ca-certificates \

--- a/dockerfiles/db/Dockerfile
+++ b/dockerfiles/db/Dockerfile
@@ -5,7 +5,7 @@ ENV build_deps ca-certificates \
   git \
   build-essential \
   libpq-dev \
-  postgresql-server-dev-14 \
+  postgresql-server-dev-15 \
   curl \
   libreadline6-dev \
   zlib1g-dev

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,9 +67,6 @@ For example, to increase the max rows per page for each table in the `public` sc
 comment on schema public is e'@graphql({"max_rows": 100})';
 ```
 
-
-
-
 ### totalCount
 
 `totalCount` is an opt-in field that extends a table's Connection type. It provides a count of the rows that match the query's filters, and ignores pagination arguments.
@@ -97,6 +94,7 @@ create table "BlogPost"(
 );
 comment on table "BlogPost" is e'@graphql({"totalCount": {"enabled": true}})';
 ```
+
 
 ### Renaming
 
@@ -221,5 +219,30 @@ type Account {
     last: Int,
     orderBy: [PostOrderBy!]
   ): PostConnection
+}
+```
+
+### Description
+
+Tables, Columns, and Functions accept a `description` directive to populate user defined descriptions in the GraphQL schema.
+
+```sql
+create table "Account"(
+    id serial primary key
+);
+
+comment on table public.account
+is e'@graphql({"description": "A User Account"})';
+
+comment on column public.account.id
+is e'@graphql({"description": "The primary key identifier"})';
+```
+
+```graphql
+"""A User Account"""
+type Account implements Node {
+
+  """The primary key identifier"""
+  id: Int!
 }
 ```

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1682,6 +1682,10 @@ impl ___Type for NodeType {
         Some(self.schema.graphql_table_base_type_name(&self.table))
     }
 
+    fn description(&self) -> Option<String> {
+        self.table.directives.description.clone()
+    }
+
     fn interfaces(&self) -> Option<Vec<__Type>> {
         let mut interfaces = vec![];
 
@@ -1708,7 +1712,7 @@ impl ___Type for NodeType {
                 name_: self.schema.graphql_column_field_name(&col),
                 type_: sql_column_to_graphql_type(col, &self.schema),
                 args: vec![],
-                description: None,
+                description: col.directives.description.clone(),
                 deprecation_reason: None,
                 sql_type: Some(NodeSQLType::Column(Arc::clone(col))),
             })
@@ -1756,7 +1760,7 @@ impl ___Type for NodeType {
                         &self.schema,
                     ),
                     args: vec![],
-                    description: None,
+                    description: func.directives.description.clone(),
                     deprecation_reason: None,
                     sql_type: Some(NodeSQLType::Function(Arc::clone(func))),
                 })

--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -18,6 +18,7 @@ pub struct ColumnPermissions {
 #[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ColumnDirectives {
     pub name: Option<String>,
+    pub description: Option<String>,
 }
 
 #[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
@@ -40,6 +41,8 @@ pub struct Column {
 #[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct FunctionDirectives {
     pub name: Option<String>,
+    // @graphql({"description": "the address of ..." })
+    pub description: Option<String>,
 }
 
 #[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
@@ -175,6 +178,9 @@ pub struct TableDirectiveForeignKey {
 pub struct TableDirectives {
     // @graphql({"name": "Foo" })
     pub name: Option<String>,
+
+    // @graphql({"description": "the address of ..." })
+    pub description: Option<String>,
 
     // @graphql({"totalCount": { "enabled": true } })
     pub total_count: Option<TableDirectiveTotalCount>,

--- a/test/expected/comment_directive_description.out
+++ b/test/expected/comment_directive_description.out
@@ -1,0 +1,59 @@
+begin;
+    create table public.account(
+        id int primary key
+    );
+    create function public._one(rec public.account)
+        returns int
+        immutable
+        strict
+        language sql
+    as $$
+        select 1
+    $$;
+    comment on table public.account
+    is e'@graphql({"description": "Some Description"})';
+    comment on column public.account.id
+    is e'@graphql({"description": "Some Other Description"})';
+    comment on function public._one
+    is e'@graphql({"description": "Func Description"})';
+    select jsonb_pretty(
+        graphql.resolve($$
+        {
+          __type(name: "Account") {
+            kind
+            description
+            fields {
+              name
+              description
+            }
+          }
+        }
+        $$)
+    );
+                              jsonb_pretty                              
+------------------------------------------------------------------------
+ {                                                                     +
+     "data": {                                                         +
+         "__type": {                                                   +
+             "kind": "OBJECT",                                         +
+             "fields": [                                               +
+                 {                                                     +
+                     "name": "nodeId",                                 +
+                     "description": "Globally Unique Record Identifier"+
+                 },                                                    +
+                 {                                                     +
+                     "name": "id",                                     +
+                     "description": "Some Other Description"           +
+                 },                                                    +
+                 {                                                     +
+                     "name": "one",                                    +
+                     "description": "Func Description"                 +
+                 }                                                     +
+             ],                                                        +
+             "description": "Some Description"                         +
+         }                                                             +
+     }                                                                 +
+ }
+(1 row)
+
+rollback;

--- a/test/sql/comment_directive_description.sql
+++ b/test/sql/comment_directive_description.sql
@@ -1,0 +1,39 @@
+begin;
+    create table public.account(
+        id int primary key
+    );
+
+    create function public._one(rec public.account)
+        returns int
+        immutable
+        strict
+        language sql
+    as $$
+        select 1
+    $$;
+
+    comment on table public.account
+    is e'@graphql({"description": "Some Description"})';
+
+    comment on column public.account.id
+    is e'@graphql({"description": "Some Other Description"})';
+
+    comment on function public._one
+    is e'@graphql({"description": "Func Description"})';
+
+    select jsonb_pretty(
+        graphql.resolve($$
+        {
+          __type(name: "Account") {
+            kind
+            description
+            fields {
+              name
+              description
+            }
+          }
+        }
+        $$)
+    );
+
+rollback;


### PR DESCRIPTION
## What kind of change does this PR introduce?
Users can set custom descriptions on tables/columns/functions using comment directive
```
@graphql({"description": "<some_description>"})
```