### PR TITLE
Bump versions for 1.2.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_graphql"
-version = "1.1.1"
+version = "1.2.0"
 edition = "2021"
 
 [lib]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,15 +1,23 @@
-## [1.0.0]
+## 1.0.0
 - Initial release
 
-## [1.0.1]
+## 1.0.1
 - feature: Add support for Postgres 15
 
-## [1.0.2]
+## 1.0.2
 - bugfix: Correct inconsistent treatment of null literals
 
-## [1.1.0]
+## 1.1.0
 - feature: Add support for Views, Materialized Views, and Foreign Tables
 - feature: Add support for filtering on `is null` and `is not null`
 - feature: User configurable page size
 - bugfix: Remove requirement for `insert` permission on every column for inserts to succeed
 - bugfix: `hasNextPage` and `hasPreviousPage` during reverse pagination were backwards
+
+## 1.2.0
+- feature: `String` type filters support `ilike`, `like`, `startsWith`
+- feature: Support for `@skip` and `@include` directives
+- feature: Custom descriptions via comment directive `@graphql({"description": ...})`
+- bugfix: Unknown types are represented in GraphQL schema as `Opaque` rather than `String`
+- bugfix: PostgreSQL type modifiers, e.g. char(n), no longer truncate excess text
+- bugfix: Creating a new enum variant between existing variants no longer errors


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bumps versions and adds changelog entries for version 1.2.0