### PR TITLE
Allow installation from non-root users 

### DIFF
--- a/pg_graphql.control
+++ b/pg_graphql.control
@@ -2,5 +2,5 @@ comment = 'pg_graphql: GraphQL support'
 default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/pg_graphql'
 relocatable = false
-superuser = false
+superuser = true
 schema = 'graphql'


### PR DESCRIPTION
## What kind of change does this PR introduce?

At this moment, it's impossible to install this extension under non-privileged user because "C" language is untrusted. 

## What is the current behavior?

```
create extension pg_graphql;

ERROR: permission denied for language c (SQLSTATE 42501)
```

## What is the new behavior?

```
create extension pg_graphql;
CREATE EXTENSION
```

## Additional context

Changes at `pgx` template

tcdi/pgx#1056

