### PR TITLE
Bugfix: Disambiguate functions for computed columns

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -793,6 +793,7 @@ pub struct ColumnBuilder {
 pub struct FunctionBuilder {
     pub alias: String,
     pub function: Arc<Function>,
+    pub table: Arc<Table>,
 }
 
 fn restrict_allowed_arguments<'a, T>(
@@ -1384,6 +1385,7 @@ where
                                     NodeSelection::Function(FunctionBuilder {
                                         alias,
                                         function: Arc::clone(func),
+                                        table: Arc::clone(&xtype.table),
                                     })
                                 }
                                 NodeSQLType::NodeId(pkey_columns) => {

--- a/src/transpile.rs
+++ b/src/transpile.rs
@@ -1290,7 +1290,11 @@ impl FunctionBuilder {
     pub fn to_sql(&self, block_name: &str) -> Result<String, String> {
         let schema_name = &self.function.schema_name;
         let function_name = &self.function.name;
-        Ok(format!("{schema_name}.{function_name}({block_name})"))
+        Ok(format!(
+            "{schema_name}.{function_name}({block_name}::{}.{})",
+            quote_ident(&self.table.schema),
+            quote_ident(&self.table.name)
+        ))
     }
 }
 

--- a/test/expected/issue_334_ambiguous_function.out
+++ b/test/expected/issue_334_ambiguous_function.out
@@ -1,0 +1,55 @@
+begin;
+    create table public.recipe_ingredient(
+        id int primary key
+    );
+    create table public.recipe(
+        id int primary key
+    );
+    insert into public.recipe(id) values (1);
+    create or replace function _calories(rec public.recipe_ingredient)
+        returns smallint
+        stable
+        language sql
+    as $$
+        select 1;
+    $$;
+    create or replace function _calories(rec public.recipe)
+        returns smallint
+        stable
+        language sql
+    as $$
+        select 1;
+    $$;
+    select jsonb_pretty(
+        graphql.resolve($$
+        {
+          recipeCollection {
+            edges {
+              node {
+                id
+                calories
+              }
+            }
+          }
+        }
+        $$)
+    );
+             jsonb_pretty              
+---------------------------------------
+ {                                    +
+     "data": {                        +
+         "recipeCollection": {        +
+             "edges": [               +
+                 {                    +
+                     "node": {        +
+                         "id": 1,     +
+                         "calories": 1+
+                     }                +
+                 }                    +
+             ]                        +
+         }                            +
+     }                                +
+ }
+(1 row)
+
+rollback;

--- a/test/sql/issue_334_ambiguous_function.sql
+++ b/test/sql/issue_334_ambiguous_function.sql
@@ -1,0 +1,48 @@
+begin;
+
+    create table public.recipe_ingredient(
+        id int primary key
+    );
+
+    create table public.recipe(
+        id int primary key
+    );
+
+    insert into public.recipe(id) values (1);
+
+    create or replace function _calories(rec public.recipe_ingredient)
+        returns smallint
+        stable
+        language sql
+    as $$
+        select 1;
+    $$;
+
+    create or replace function _calories(rec public.recipe)
+        returns smallint
+        stable
+        language sql
+    as $$
+        select 1;
+    $$;
+
+    select jsonb_pretty(
+        graphql.resolve($$
+        {
+          recipeCollection {
+            edges {
+              node {
+                id
+                calories
+              }
+            }
+          }
+        }
+        $$)
+    );
+
+
+
+
+
+rollback;


### PR DESCRIPTION
## What kind of change does this PR introduce?
When multiple table-extending functions exist

e.g.
```sql
    create or replace function _calories(rec public.recipe_ingredient)
        returns smallint
        stable
        language sql
    as $$
        select 1;
    $$;

    create or replace function _calories(rec public.recipe)
        returns smallint
        stable
        language sql
    as $$
        select 1;
    $$;
```

the query compiler did not explicitly cast the row type, which leads to postgres raising an error about not knowing which function to use during any GraphQL query referencing either function-based computed column.

This PR adds that explicit cast and a regression test


Resolves #334