### PR TITLE
Specify cargo-pgx version to avoid compatibility error

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,11 +1,11 @@
-First, install [pgx](https://github.com/tcdi/pgx)
+First, install [pgx](https://github.com/tcdi/pgx) by running `cargo install --locked cargo-pgx@version`, where version should be compatible with the [pgx version used by pg_graphl](https://github.com/supabase/pg_graphql/blob/master/Cargo.toml#L16)
 
 Then clone the repo and install using
 
 ```bash
 git clone https://github.com/supabase/pg_graphql.git
 cd pg_graphql
-cargo pgx install pg14 --release
+cargo pgx install --release
 ```
 
 To enable the extension in PostgreSQL we must execute a `create extension` statement. The extension creates its own schema/namespace named `graphql` to avoid naming conflicts.


### PR DESCRIPTION
Without this, users would face an error whenever pg_graphql doesn't use the newest version of pgx:
```bash
cargo pgx install --release                                                                                      ✔  02:36:09 pm
Error:
   0: `pgx-0.7.1` shouldn't be used with `cargo-pgx-0.7.2`, please use `pgx = "~0.7.2"` in your `Cargo.toml`.

Location:
   /Users/zen/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-pgx-0.7.2/src/metadata.rs:42

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ SPANTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

   0: cargo_pgx::metadata::validate
      at /Users/zen/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-pgx-0.7.2/src/metadata.rs:27
   1: cargo_pgx::command::install::execute
      at /Users/zen/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-pgx-0.7.2/src/command/install.rs:51

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

I also removed `pg14` from the `cargo pgx install` command, because it is invalid.

## What kind of change does this PR introduce?

Docs

## What is the current behavior?

error shown above

## What is the new behavior?

no error

## Additional context
NA

Add any other context or screenshots.
