### PR TITLE
Bugfix: Apply special case casting rules to computed fields, disallow set returning

### DIFF
--- a/sql/load_sql_context.sql
+++ b/sql/load_sql_context.sql
@@ -272,6 +272,7 @@ select
                                         pp.pronargs = 1 -- one argument
                                         and pp.proargtypes[0] = pc.reltype -- first argument is table type
                                         and pp.proname like '\_%' -- starts with underscore
+                                        and not pp.proretset -- disallow set returning functions (for now)
                                 ),
                                 jsonb_build_array()
                             ),

--- a/test/expected/issue_339_function_return_json.out
+++ b/test/expected/issue_339_function_return_json.out
@@ -1,0 +1,46 @@
+begin;
+    create table public.account(
+        id int primary key
+    );
+    create function public._computed(rec public.account)
+        returns json
+        immutable
+        strict
+        language sql
+    as $$
+        select jsonb_build_object('hello', 'world');
+    $$;
+    insert into account(id) values (1);
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              accountCollection {
+                edges {
+                  node {
+                    id
+                    computed
+                  }
+                }
+              }
+            }
+        $$)
+    );
+                         jsonb_pretty                         
+--------------------------------------------------------------
+ {                                                           +
+     "data": {                                               +
+         "accountCollection": {                              +
+             "edges": [                                      +
+                 {                                           +
+                     "node": {                               +
+                         "id": 1,                            +
+                         "computed": "{\"hello\": \"world\"}"+
+                     }                                       +
+                 }                                           +
+             ]                                               +
+         }                                                   +
+     }                                                       +
+ }
+(1 row)
+
+rollback;

--- a/test/expected/issue_339_function_return_table.out
+++ b/test/expected/issue_339_function_return_table.out
@@ -1,0 +1,71 @@
+begin;
+    create table public.account(
+        id int primary key
+    );
+    create function public._computed(rec public.account)
+        returns table ( id int )
+        immutable
+        strict
+        language sql
+    as $$
+        select 2 as id;
+    $$;
+    insert into account(id) values (1);
+    select jsonb_pretty(
+        graphql.resolve($$
+        {
+          __type(name: "Account") {
+            kind
+            fields {
+                name
+            }
+          }
+        }
+        $$)
+    );
+             jsonb_pretty             
+--------------------------------------
+ {                                   +
+     "data": {                       +
+         "__type": {                 +
+             "kind": "OBJECT",       +
+             "fields": [             +
+                 {                   +
+                     "name": "nodeId"+
+                 },                  +
+                 {                   +
+                     "name": "id"    +
+                 }                   +
+             ]                       +
+         }                           +
+     }                               +
+ }
+(1 row)
+
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              accountCollection {
+                edges {
+                  node {
+                    id
+                    computed
+                  }
+                }
+              }
+            }
+        $$)
+    );
+                            jsonb_pretty                             
+---------------------------------------------------------------------
+ {                                                                  +
+     "data": null,                                                  +
+     "errors": [                                                    +
+         {                                                          +
+             "message": "Unknown field 'computed' on type 'Account'"+
+         }                                                          +
+     ]                                                              +
+ }
+(1 row)
+
+rollback;

--- a/test/sql/issue_339_function_return_json.sql
+++ b/test/sql/issue_339_function_return_json.sql
@@ -1,0 +1,32 @@
+begin;
+    create table public.account(
+        id int primary key
+    );
+
+    create function public._computed(rec public.account)
+        returns json
+        immutable
+        strict
+        language sql
+    as $$
+        select jsonb_build_object('hello', 'world');
+    $$;
+
+    insert into account(id) values (1);
+
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              accountCollection {
+                edges {
+                  node {
+                    id
+                    computed
+                  }
+                }
+              }
+            }
+        $$)
+    );
+
+rollback;

--- a/test/sql/issue_339_function_return_table.sql
+++ b/test/sql/issue_339_function_return_table.sql
@@ -1,0 +1,45 @@
+begin;
+    create table public.account(
+        id int primary key
+    );
+
+    create function public._computed(rec public.account)
+        returns table ( id int )
+        immutable
+        strict
+        language sql
+    as $$
+        select 2 as id;
+    $$;
+
+    insert into account(id) values (1);
+
+    select jsonb_pretty(
+        graphql.resolve($$
+        {
+          __type(name: "Account") {
+            kind
+            fields {
+                name
+            }
+          }
+        }
+        $$)
+    );
+
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              accountCollection {
+                edges {
+                  node {
+                    id
+                    computed
+                  }
+                }
+              }
+            }
+        $$)
+    );
+
+rollback;


### PR DESCRIPTION
Bug:
- Special casting rules (json as serialized string, bigint as string, numeric as string) are not applied to computed fields
- (Unsupported) set returning computed fields are not filtered out of the GraphQL schema

Fix:
- Apply casting rules to computed fields
- Filter out set returning computed fields