### PR TITLE
Problem: Postgres enum value validity rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,9 +1025,10 @@ dependencies = [
 
 [[package]]
 name = "pg_graphql"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "base64 0.13.1",
+ "bimap",
  "cached",
  "graphql-parser",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ uuid = "1"
 regex = "1"
 base64 = "0.13"
 lazy_static = "1"
+bimap = { version = "0.6.3", features = ["serde"] }
 
 [dev-dependencies]
 pgrx-tests = "=0.9.7"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,3 +36,4 @@
 - bugfix: foreign keys on non-null columns produce non-null GraphQL relationships
 
 ## master
+- rename enum variants with comment directive `@graphql({"mappings": "sql-value": "graphql_value""})`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -246,3 +246,43 @@ type Account implements Node {
   id: Int!
 }
 ```
+
+#### Enum Variant
+
+If a variant of a Postgres enum does not conform to GraphQL naming conventions, introspection returns an error:
+
+For example:
+```sql
+create type "Algorithm" as enum ('aead-ietf');
+```
+
+causes the error:
+
+```json
+{
+  "errors": [
+    {
+      "message": "Names must only contain [_a-zA-Z0-9] but \"aead-ietf\" does not.",
+    }
+  ]
+}
+```
+
+To resolve this problem, rename the invalid SQL enum variant to a GraphQL compatible name:
+
+```sql
+alter type "Algorithm" rename value 'aead-ietf' to 'AEAD_IETF';
+```
+
+or, add a comment directive to remap the enum variant in the GraphQL API
+
+```sql
+comment on type "Algorithm" is '@graphql({"mappings": {"aead-ietf": "AEAD_IETF"}})';
+```
+
+Which both result in the GraphQL enum:
+```graphql
+enum Algorithm {
+  AEAD_IETF
+}
+```

--- a/sql/load_sql_context.sql
+++ b/sql/load_sql_context.sql
@@ -35,6 +35,7 @@ select
                             'name', min(pt.typname),
                             'comment', pg_catalog.obj_description(pt.oid, 'pg_type'),
                             'directives', jsonb_build_object(
+                                'mappings', graphql.comment_directive(pg_catalog.obj_description(pt.oid, 'pg_type')) -> 'mappings',
                                 'name', graphql.comment_directive(pg_catalog.obj_description(pt.oid, 'pg_type')) ->> 'name'
                             ),
                             'values', jsonb_agg(
@@ -359,7 +360,8 @@ select
                                                 select
                                                     jsonb_build_object(
                                                         'name', d.directive ->> 'name',
-                                                        'description', d.directive -> 'description'
+                                                        'description', d.directive -> 'description',
+                                                        'mappings', (graphql.comment_directive(pg_catalog.obj_description(pa.atttypid, 'pg_type'))) -> 'mappings'
                                                     )
                                                 from
                                                     directives d

--- a/sql/load_sql_context.sql
+++ b/sql/load_sql_context.sql
@@ -361,6 +361,7 @@ select
                                                     jsonb_build_object(
                                                         'name', d.directive ->> 'name',
                                                         'description', d.directive -> 'description',
+                                                        -- TODO: this duplication is to be refactored as per https://github.com/supabase/pg_graphql/pull/376#discussion_r1259865044
                                                         'mappings', (graphql.comment_directive(pg_catalog.obj_description(pa.atttypid, 'pg_type'))) -> 'mappings'
                                                     )
                                                 from

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1363,7 +1363,13 @@ impl ___Type for EnumType {
                 .values
                 .iter()
                 .map(|x| __EnumValue {
-                    name: x.name.clone(),
+                    name: enum_
+                        .directives
+                        .mappings
+                        .as_ref()
+                        // Use mappings if available and mapped
+                        .and_then(|mappings| mappings.get_by_left(&x.name).cloned())
+                        .unwrap_or_else(|| x.name.clone()),
                     description: None,
                     deprecation_reason: None,
                 })

--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -22,6 +22,7 @@ pub struct ColumnPermissions {
 pub struct ColumnDirectives {
     pub name: Option<String>,
     pub description: Option<String>,
+    // TODO: this duplication is to be refactored as per https://github.com/supabase/pg_graphql/pull/376#discussion_r1259865044
     pub mappings: Option<BiBTreeMap<String, String>>,
 }
 

--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -1,3 +1,4 @@
+use bimap::BiBTreeMap;
 use cached::proc_macro::cached;
 use cached::SizedCache;
 use pgrx::*;
@@ -21,6 +22,7 @@ pub struct ColumnPermissions {
 pub struct ColumnDirectives {
     pub name: Option<String>,
     pub description: Option<String>,
+    pub mappings: Option<BiBTreeMap<String, String>>,
 }
 
 #[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
@@ -124,6 +126,7 @@ pub struct Enum {
 #[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct EnumDirectives {
     pub name: Option<String>,
+    pub mappings: Option<BiBTreeMap<String, String>>,
 }
 
 #[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]

--- a/test/expected/enum_mappings.out
+++ b/test/expected/enum_mappings.out
@@ -1,87 +1,124 @@
 begin;
-create type my_enum as enum ('test', 'valid value', 'another value');
-comment on type my_enum is E'@graphql({"mappings": {"valid value": "valid_value", "another value": "another_value"}})';
-create table enums (
-   id serial primary key,
-   value my_enum
-);
--- Seed with value that's valid in both Postgres and GraphQL
-insert into enums (value) values ('test');
--- Mutation to insert
-select graphql.resolve($$
-mutation {
-  insertIntoEnumsCollection(objects: [ { value: "valid_value" } ]) {
-      affectedCount
-  }
-}
-$$);
+    create type my_enum as enum ('test', 'valid value', 'another value');
+    comment on type my_enum is E'@graphql({"mappings": {"valid value": "valid_value", "another value": "another_value"}})';
+    create table enums (
+       id serial primary key,
+       value my_enum
+    );
+    -- Seed with value that's valid in both Postgres and GraphQL
+    insert into enums (value) values ('test');
+    -- Mutation to insert
+    select graphql.resolve($$
+    mutation {
+      insertIntoEnumsCollection(objects: [ { value: "valid_value" } ]) {
+          affectedCount
+      }
+    }
+    $$);
                             resolve                            
 ---------------------------------------------------------------
  {"data": {"insertIntoEnumsCollection": {"affectedCount": 1}}}
 (1 row)
 
--- Mutation to update
-select graphql.resolve($$
-mutation {
-  updateEnumsCollection(set: { value: "another_value" }, filter: { value: {eq: "test"} } ) {
-    records { value }
-  }
-}
-$$);
+    -- Mutation to update
+    select graphql.resolve($$
+    mutation {
+      updateEnumsCollection(set: { value: "another_value" }, filter: { value: {eq: "test"} } ) {
+        records { value }
+      }
+    }
+    $$);
                                     resolve                                     
 --------------------------------------------------------------------------------
  {"data": {"updateEnumsCollection": {"records": [{"value": "another_value"}]}}}
 (1 row)
 
---- Query
-select graphql.resolve($$
-    {
-      enumsCollection {
-        edges {
-            node {
-             value
+    --- Query
+    select graphql.resolve($$
+        {
+          enumsCollection {
+            edges {
+                node {
+                 value
+                }
             }
+          }
         }
-      }
-    }
-$$);
+    $$);
                                                        resolve                                                        
 ----------------------------------------------------------------------------------------------------------------------
  {"data": {"enumsCollection": {"edges": [{"node": {"value": "another_value"}}, {"node": {"value": "valid_value"}}]}}}
 (1 row)
 
---- Query with filter
-select graphql.resolve($$
-    {
-      enumsCollection(filter: {value: {eq: "another_value"}}) {
-        edges {
-            node {
-             value
+    --- Query with filter
+    select graphql.resolve($$
+        {
+          enumsCollection(filter: {value: {eq: "another_value"}}) {
+            edges {
+                node {
+                 value
+                }
             }
+          }
         }
-      }
-    }
-$$);
+    $$);
                                      resolve                                      
 ----------------------------------------------------------------------------------
  {"data": {"enumsCollection": {"edges": [{"node": {"value": "another_value"}}]}}}
 (1 row)
 
---- Query with `in` filter
-select graphql.resolve($$
-    {
-      enumsCollection(filter: {value: {in: ["another_value"]}}) {
-        edges {
-            node {
-             value
+    --- Query with `in` filter
+    select graphql.resolve($$
+        {
+          enumsCollection(filter: {value: {in: ["another_value"]}}) {
+            edges {
+                node {
+                 value
+                }
             }
+          }
         }
-      }
-    }
-$$);
+    $$);
                                      resolve                                      
 ----------------------------------------------------------------------------------
  {"data": {"enumsCollection": {"edges": [{"node": {"value": "another_value"}}]}}}
+(1 row)
+
+    -- Display type via introspection
+    select jsonb_pretty(
+        graphql.resolve($$
+        {
+          __type(name: "MyEnum") {
+            kind
+            name
+            enumValues {
+              name
+            }
+          }
+        }
+        $$)
+    );
+                jsonb_pretty                 
+---------------------------------------------
+ {                                          +
+     "data": {                              +
+         "__type": {                        +
+             "kind": "ENUM",                +
+             "name": "MyEnum",              +
+             "enumValues": [                +
+                 {                          +
+                     "name": "test"         +
+                 },                         +
+                 {                          +
+                     "name": "valid_value"  +
+                 },                         +
+                 {                          +
+                     "name": "another_value"+
+                 }                          +
+             ]                              +
+         }                                  +
+     }                                      +
+ }
 (1 row)
 
 rollback;

--- a/test/expected/enum_mappings.out
+++ b/test/expected/enum_mappings.out
@@ -67,4 +67,21 @@ $$);
  {"data": {"enumsCollection": {"edges": [{"node": {"value": "another_value"}}]}}}
 (1 row)
 
+--- Query with `in` filter
+select graphql.resolve($$
+    {
+      enumsCollection(filter: {value: {in: ["another_value"]}}) {
+        edges {
+            node {
+             value
+            }
+        }
+      }
+    }
+$$);
+                                     resolve                                      
+----------------------------------------------------------------------------------
+ {"data": {"enumsCollection": {"edges": [{"node": {"value": "another_value"}}]}}}
+(1 row)
+
 rollback;

--- a/test/expected/enum_mappings.out
+++ b/test/expected/enum_mappings.out
@@ -1,0 +1,25 @@
+begin;
+create type my_enum as enum ('test', 'valid value');
+comment on type my_enum is E'@graphql({"mappings": {"valid value": "valid_value"}})';
+create table enums (
+   id serial primary key,
+   value my_enum
+);
+insert into enums (value) values ('test'), ('valid value');
+select graphql.resolve($$
+    {
+      enumsCollection {
+        edges {
+            node {
+             value
+            }
+        }
+      }
+    }
+$$);
+                                                   resolve                                                   
+-------------------------------------------------------------------------------------------------------------
+ {"data": {"enumsCollection": {"edges": [{"node": {"value": "test"}}, {"node": {"value": "valid_value"}}]}}}
+(1 row)
+
+rollback;

--- a/test/expected/enum_mappings.out
+++ b/test/expected/enum_mappings.out
@@ -50,4 +50,21 @@ $$);
  {"data": {"enumsCollection": {"edges": [{"node": {"value": "another_value"}}, {"node": {"value": "valid_value"}}]}}}
 (1 row)
 
+--- Query with filter
+select graphql.resolve($$
+    {
+      enumsCollection(filter: {value: {eq: "another_value"}}) {
+        edges {
+            node {
+             value
+            }
+        }
+      }
+    }
+$$);
+                                     resolve                                      
+----------------------------------------------------------------------------------
+ {"data": {"enumsCollection": {"edges": [{"node": {"value": "another_value"}}]}}}
+(1 row)
+
 rollback;

--- a/test/expected/enum_mappings.out
+++ b/test/expected/enum_mappings.out
@@ -1,11 +1,39 @@
 begin;
-create type my_enum as enum ('test', 'valid value');
-comment on type my_enum is E'@graphql({"mappings": {"valid value": "valid_value"}})';
+create type my_enum as enum ('test', 'valid value', 'another value');
+comment on type my_enum is E'@graphql({"mappings": {"valid value": "valid_value", "another value": "another_value"}})';
 create table enums (
    id serial primary key,
    value my_enum
 );
-insert into enums (value) values ('test'), ('valid value');
+-- Seed with value that's valid in both Postgres and GraphQL
+insert into enums (value) values ('test');
+-- Mutation to insert
+select graphql.resolve($$
+mutation {
+  insertIntoEnumsCollection(objects: [ { value: "valid_value" } ]) {
+      affectedCount
+  }
+}
+$$);
+                            resolve                            
+---------------------------------------------------------------
+ {"data": {"insertIntoEnumsCollection": {"affectedCount": 1}}}
+(1 row)
+
+-- Mutation to update
+select graphql.resolve($$
+mutation {
+  updateEnumsCollection(set: { value: "another_value" }, filter: { value: {eq: "test"} } ) {
+    records { value }
+  }
+}
+$$);
+                                    resolve                                     
+--------------------------------------------------------------------------------
+ {"data": {"updateEnumsCollection": {"records": [{"value": "another_value"}]}}}
+(1 row)
+
+--- Query
 select graphql.resolve($$
     {
       enumsCollection {
@@ -17,9 +45,9 @@ select graphql.resolve($$
       }
     }
 $$);
-                                                   resolve                                                   
--------------------------------------------------------------------------------------------------------------
- {"data": {"enumsCollection": {"edges": [{"node": {"value": "test"}}, {"node": {"value": "valid_value"}}]}}}
+                                                       resolve                                                        
+----------------------------------------------------------------------------------------------------------------------
+ {"data": {"enumsCollection": {"edges": [{"node": {"value": "another_value"}}, {"node": {"value": "valid_value"}}]}}}
 (1 row)
 
 rollback;

--- a/test/sql/enum_mappings.sql
+++ b/test/sql/enum_mappings.sql
@@ -40,4 +40,18 @@ select graphql.resolve($$
     }
 $$);
 
+--- Query with filter
+select graphql.resolve($$
+    {
+      enumsCollection(filter: {value: {eq: "another_value"}}) {
+        edges {
+            node {
+             value
+            }
+        }
+      }
+    }
+$$);
+
+
 rollback;

--- a/test/sql/enum_mappings.sql
+++ b/test/sql/enum_mappings.sql
@@ -1,0 +1,20 @@
+begin;
+create type my_enum as enum ('test', 'valid value');
+comment on type my_enum is E'@graphql({"mappings": {"valid value": "valid_value"}})';
+create table enums (
+   id serial primary key,
+   value my_enum
+);
+insert into enums (value) values ('test'), ('valid value');
+select graphql.resolve($$
+    {
+      enumsCollection {
+        edges {
+            node {
+             value
+            }
+        }
+      }
+    }
+$$);
+rollback;

--- a/test/sql/enum_mappings.sql
+++ b/test/sql/enum_mappings.sql
@@ -1,69 +1,87 @@
 begin;
-create type my_enum as enum ('test', 'valid value', 'another value');
-comment on type my_enum is E'@graphql({"mappings": {"valid value": "valid_value", "another value": "another_value"}})';
-create table enums (
-   id serial primary key,
-   value my_enum
-);
 
--- Seed with value that's valid in both Postgres and GraphQL
-insert into enums (value) values ('test');
+    create type my_enum as enum ('test', 'valid value', 'another value');
 
--- Mutation to insert
-select graphql.resolve($$
-mutation {
-  insertIntoEnumsCollection(objects: [ { value: "valid_value" } ]) {
-      affectedCount
-  }
-}
-$$);
+    comment on type my_enum is E'@graphql({"mappings": {"valid value": "valid_value", "another value": "another_value"}})';
 
--- Mutation to update
-select graphql.resolve($$
-mutation {
-  updateEnumsCollection(set: { value: "another_value" }, filter: { value: {eq: "test"} } ) {
-    records { value }
-  }
-}
-$$);
+    create table enums (
+       id serial primary key,
+       value my_enum
+    );
 
---- Query
-select graphql.resolve($$
-    {
-      enumsCollection {
-        edges {
-            node {
-             value
-            }
-        }
+    -- Seed with value that's valid in both Postgres and GraphQL
+    insert into enums (value) values ('test');
+
+    -- Mutation to insert
+    select graphql.resolve($$
+    mutation {
+      insertIntoEnumsCollection(objects: [ { value: "valid_value" } ]) {
+          affectedCount
       }
     }
-$$);
+    $$);
 
---- Query with filter
-select graphql.resolve($$
-    {
-      enumsCollection(filter: {value: {eq: "another_value"}}) {
-        edges {
-            node {
-             value
-            }
-        }
+    -- Mutation to update
+    select graphql.resolve($$
+    mutation {
+      updateEnumsCollection(set: { value: "another_value" }, filter: { value: {eq: "test"} } ) {
+        records { value }
       }
     }
-$$);
+    $$);
 
---- Query with `in` filter
-select graphql.resolve($$
-    {
-      enumsCollection(filter: {value: {in: ["another_value"]}}) {
-        edges {
-            node {
-             value
+    --- Query
+    select graphql.resolve($$
+        {
+          enumsCollection {
+            edges {
+                node {
+                 value
+                }
             }
+          }
         }
-      }
-    }
-$$);
+    $$);
+
+    --- Query with filter
+    select graphql.resolve($$
+        {
+          enumsCollection(filter: {value: {eq: "another_value"}}) {
+            edges {
+                node {
+                 value
+                }
+            }
+          }
+        }
+    $$);
+
+    --- Query with `in` filter
+    select graphql.resolve($$
+        {
+          enumsCollection(filter: {value: {in: ["another_value"]}}) {
+            edges {
+                node {
+                 value
+                }
+            }
+          }
+        }
+    $$);
+
+    -- Display type via introspection
+    select jsonb_pretty(
+        graphql.resolve($$
+        {
+          __type(name: "MyEnum") {
+            kind
+            name
+            enumValues {
+              name
+            }
+          }
+        }
+        $$)
+    );
 
 rollback;

--- a/test/sql/enum_mappings.sql
+++ b/test/sql/enum_mappings.sql
@@ -53,5 +53,17 @@ select graphql.resolve($$
     }
 $$);
 
+--- Query with `in` filter
+select graphql.resolve($$
+    {
+      enumsCollection(filter: {value: {in: ["another_value"]}}) {
+        edges {
+            node {
+             value
+            }
+        }
+      }
+    }
+$$);
 
 rollback;


### PR DESCRIPTION
They are wider than those for GraphQL as mentioned in #172.

Solution: allow specifying name mapping for enums via comments

Creating a comment like:

```sql
comment on type my_enum is E'@graphql({"mappings": {"valid value": "valid_value"}})';
```

Allows to override Postgres enum value to have a different value.

Please note that this is the first go at the problem, and it doesn't handle the following (and probably more):

* [ ] verification of new value's validity
* [x] mutations
* [ ] more exhaustive testing

Also, it is important to mention that while this approach does not implement a dynamic mapping technique proposed in #172 for the sake of conformity to the current approach used throughout pg_graphsql, it does not mean this will not or should happen in the future. A breaking release may indeed consider such a change for a variety of reasons:

* performance optimizations (mapping functions can be declared immutable)
* cases where comments aren't feasible or too onerous

Of particular note is an idea to dispatch conversions back to Postgres using an `inout` parameter to help us type on the return type.

---

## What kind of change does this PR introduce?

Workaround for specification compliance.

## What is the current behavior?

Using Postgres enum values as is. GraphQL has stricter rules for these. See #172 

## What is the new behavior?

Allowing overriding Postgres enum values.

## Additional context

resolves #172 
