### PR TITLE
Type referenced column enum value

### DIFF
--- a/sql/load_sql_context.sql
+++ b/sql/load_sql_context.sql
@@ -86,9 +86,6 @@ select
                             -- if category is 'Table' points to the table oid
                             'table_oid', tabs.oid::int,
                             'comment', pg_catalog.obj_description(pt.oid, 'pg_type'),
-                            'directives', jsonb_build_object(
-                                'name', graphql.comment_directive(pg_catalog.obj_description(pt.oid, 'pg_type')) ->> 'name'
-                            ),
                             'permissions', jsonb_build_object(
                                 'is_usable', pg_catalog.has_type_privilege(current_user, pt.oid, 'USAGE')
                             )

--- a/sql/load_sql_context.sql
+++ b/sql/load_sql_context.sql
@@ -360,9 +360,7 @@ select
                                                 select
                                                     jsonb_build_object(
                                                         'name', d.directive ->> 'name',
-                                                        'description', d.directive -> 'description',
-                                                        -- TODO: this duplication is to be refactored as per https://github.com/supabase/pg_graphql/pull/376#discussion_r1259865044
-                                                        'mappings', (graphql.comment_directive(pg_catalog.obj_description(pa.atttypid, 'pg_type'))) -> 'mappings'
+                                                        'description', d.directive -> 'description'
                                                     )
                                                 from
                                                     directives d

--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -101,7 +101,6 @@ pub struct Type {
     pub table_oid: Option<u32>,
     pub comment: Option<String>,
     pub permissions: TypePermissions,
-    pub directives: EnumDirectives,
     pub details: Option<TypeDetails>,
 }
 

--- a/src/transpile.rs
+++ b/src/transpile.rs
@@ -1,6 +1,6 @@
 use crate::builder::*;
 use crate::graphql::*;
-use crate::sql_types::{Column, ForeignKey, ForeignKeyTableInfo, Function, Table};
+use crate::sql_types::{Column, ForeignKey, ForeignKeyTableInfo, Function, Table, TypeDetails};
 use itertools::Itertools;
 use pgrx::pg_sys::PgBuiltInOids;
 use pgrx::prelude::*;
@@ -1310,7 +1310,17 @@ impl NodeSelection {
 impl ColumnBuilder {
     pub fn to_sql(&self, block_name: &str) -> Result<String, String> {
         let col = format!("{}.{}", &block_name, quote_ident(&self.column.name));
-        if let Some(ref mappings) = self.column.directives.mappings {
+        if let Some(ref mappings) = self
+            .column
+            .type_
+            .as_ref()
+            .and_then(|t| match t.details {
+                Some(TypeDetails::Enum(ref enum_)) => Some(enum_.clone()),
+                _ => None,
+            })
+            // FIXME: this cloning is inefficient
+            .and_then(|e| e.directives.mappings.clone())
+        {
             let cases = mappings
                 .iter()
                 .map(|(k, v)| {

--- a/src/transpile.rs
+++ b/src/transpile.rs
@@ -1310,28 +1310,27 @@ impl NodeSelection {
 impl ColumnBuilder {
     pub fn to_sql(&self, block_name: &str) -> Result<String, String> {
         let col = format!("{}.{}", &block_name, quote_ident(&self.column.name));
-        if let Some(ref mappings) = self
-            .column
-            .type_
-            .as_ref()
-            .and_then(|t| match t.details {
-                Some(TypeDetails::Enum(ref enum_)) => Some(enum_.clone()),
-                _ => None,
-            })
-            // FIXME: this cloning is inefficient
-            .and_then(|e| e.directives.mappings.clone())
-        {
-            let cases = mappings
-                .iter()
-                .map(|(k, v)| {
-                    format!(
-                        "when {col} = {} then {}",
-                        quote_literal(k),
-                        quote_literal(v)
-                    )
-                })
-                .join(" ");
-            Ok(format!("case {cases} else {col}::text end"))
+        let maybe_enum = self.column.type_.as_ref().and_then(|t| match t.details {
+            Some(TypeDetails::Enum(ref enum_)) => Some(enum_),
+            _ => None,
+        });
+        if let Some(ref enum_) = maybe_enum {
+            match enum_.directives.mappings {
+                Some(ref mappings) => {
+                    let cases = mappings
+                        .iter()
+                        .map(|(k, v)| {
+                            format!(
+                                "when {col} = {} then {}",
+                                quote_literal(k),
+                                quote_literal(v)
+                            )
+                        })
+                        .join(" ");
+                    Ok(format!("case {cases} else {col}::text end"))
+                }
+                _ => Ok(col),
+            }
         } else {
             Ok(col)
         }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Internal improvement in preparing SQL context.

## What is the current behavior?

As per the discussion in https://github.com/supabase/pg_graphql/pull/376#discussion_r1259865044, we are duplicating information in the SQL context, which is not ideal.

## What is the new behavior?

We now introduce additional passes into SQL context loading. In the first pass, we prepare details for types; in the second one, we add references to types for columns (to improve the functionality implemented in #376 and eliminate duplication). More passes of the same type can be added where necessary.

## Additional context

This implementation relies on the fact that before Arc's are referenced, they can be mutated. Since we're loading the context and never modifying it after that, we can use this to our advantage without introducing more complex synchronization primitives that would make working with the context much more painful.
