### PR TITLE
fix potential panic due to indexing in string

### DIFF
--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -48,7 +48,25 @@ fn to_base_type_name(
 }
 
 fn lowercase_first_letter(token: &str) -> String {
-    token[0..1].to_lowercase() + &token[1..]
+    let first_char = token.chars().nth(0);
+    match first_char {
+        Some(c) => format!("{}{}", c.to_lowercase(), &token[c.len_utf8()..]),
+        None => token.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_lowercase_first_letter() {
+        fn run_test(token: &str, expected: &str) {
+            let actual = super::lowercase_first_letter(token);
+            assert_eq!(expected, actual);
+        }
+
+        run_test("Hello", "hello");
+        run_test("用户", "用户");
+    }
 }
 
 impl __Schema {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes a potential panic if the first character in the `token` string is not a single byte.

## What is the current behavior?

The `lowercase_first_letter` function might panic if he `token` input string's first character is represented in more than one byte in utf-8 encoding. This is because indices for a string in Rust are bytes. In the general case an index operation can panic if the byte index is not on a char boundary. It's almost always safer to work on chars.

## What is the new behavior?

The `lowercase_first_letter` is now guaranteed to never panic for any input string.

## Additional context

N/A
