### PR TITLE
Adds matrix pg_version for ci test command

### DIFF
--- a/.ci/docker-compose.yml
+++ b/.ci/docker-compose.yml
@@ -6,5 +6,7 @@ services:
     build:
         context: ..
         dockerfile: ./dockerfiles/db/Dockerfile
+        args:
+          PG_VERSION: ${PG_VERSION:-15}
     command:
       - ./bin/installcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,14 +6,16 @@ on:
 jobs:
   test:
     name: Run tests
+    strategy:
+      matrix:
+        postgres: [14, 15]
     runs-on: ubuntu-latest
-
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-    - name: Build docker images
-      run: docker-compose -f .ci/docker-compose.yml build
+      - name: Build docker images
+        run: PG_VERSION=${{ matrix.postgres }} docker-compose -f .ci/docker-compose.yml build
 
-    - name: Run tests
-      run: docker-compose -f .ci/docker-compose.yml run test
+      - name: Run tests
+        run: PG_VERSION=${{ matrix.postgres }} docker-compose -f .ci/docker-compose.yml run test

--- a/dockerfiles/db/Dockerfile
+++ b/dockerfiles/db/Dockerfile
@@ -1,11 +1,12 @@
-FROM postgres:15
+ARG PG_VERSION=15
+FROM postgres:${PG_VERSION}
 RUN apt-get update
 
 ENV build_deps ca-certificates \
   git \
   build-essential \
   libpq-dev \
-  postgresql-server-dev-15 \
+  postgresql-server-dev-${PG_MAJOR} \
   curl \
   libreadline6-dev \
   zlib1g-dev
@@ -29,7 +30,7 @@ RUN \
 # PGRX
 RUN cargo install cargo-pgrx --version 0.9.7 --locked
 
-RUN cargo pgrx init --pg15 $(which pg_config)
+RUN cargo pgrx init --pg${PG_MAJOR} $(which pg_config)
 
 USER root
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Ci

## What is the current behavior?

Runs only postgres 15 for the ci test action.

Closes #281 

## What is the new behavior?

Runs postgres 14 and 15 for the ci test action

## Additional context

Nope

---

resolves #281 
