### PR TITLE
fixes #406

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -40,5 +40,6 @@
 - bugfix: query with more than 50 fields fails
 - bugfix: @skip and @include directives missing from introspection schema
 - feature: Support for `and`, `or` and `not` operators in filters
+- bugfix: queries failed to run if the database was in read-only replica mode
 
 ## master

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -2,6 +2,7 @@ use crate::builder::*;
 use crate::graphql::*;
 use crate::omit::*;
 use crate::parser_util::*;
+use crate::sql_types::get_one_readonly;
 use crate::transpile::{MutationEntrypoint, QueryEntrypoint};
 use graphql_parser::query::{
     Definition, Document, FragmentDefinition, Mutation, OperationDefinition, Query, SelectionSet,
@@ -256,7 +257,7 @@ where
                             }
                             "heartbeat" => {
                                 let now_jsonb: pgrx::JsonB =
-                                    pgrx::Spi::get_one("select to_jsonb(now())")
+                                    get_one_readonly("select to_jsonb(now())")
                                         .expect("Internal error: queries should not fail")
                                         .expect("Internal Error: queries should not return null");
                                 let now_json = now_jsonb.0;

--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -504,9 +504,20 @@ impl Context {
     }
 }
 
+/// This method is similar to `Spi::get_one` with the only difference
+/// being that it calls `client.select` instead of `client.update`.
+/// The `client.update` method generates a new transaction id so
+/// calling `Spi::get_one` is not possible when postgres is in
+/// recovery mode.
+pub(crate) fn get_one_readonly<A: FromDatum + IntoDatum>(
+    query: &str,
+) -> std::result::Result<Option<A>, pgrx::spi::Error> {
+    Spi::connect(|client| client.select(query, Some(1), None)?.first().get_one())
+}
+
 pub fn load_sql_config() -> Config {
     let query = include_str!("../sql/load_sql_config.sql");
-    let sql_result: serde_json::Value = Spi::get_one::<JsonB>(query).unwrap().unwrap().0;
+    let sql_result: serde_json::Value = get_one_readonly::<JsonB>(query).unwrap().unwrap().0;
     let config: Config = serde_json::from_value(sql_result).unwrap();
     config
 }
@@ -526,7 +537,7 @@ pub fn calculate_hash<T: Hash>(t: &T) -> u64 {
 pub fn load_sql_context(_config: &Config) -> Result<Arc<Context>, String> {
     // cache value for next query
     let query = include_str!("../sql/load_sql_context.sql");
-    let sql_result: serde_json::Value = Spi::get_one::<JsonB>(query).unwrap().unwrap().0;
+    let sql_result: serde_json::Value = get_one_readonly::<JsonB>(query).unwrap().unwrap().0;
     let context: Result<Context, serde_json::Error> = serde_json::from_value(sql_result);
 
     /// This pass cross-reference types with its details


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Graphql query fails if postgres is in recovery mode.

## What is the new behavior?

Read-only queries will work even when postgres is in recovery mode. Note that mutations will still not work.

## Additional context

See [this comment](https://github.com/supabase/pg_graphql/issues/406#issuecomment-1689578797) for details about this fix.

Fixes #406 
