### PR TITLE
Add note and example about quotes in JSON string fields

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1983,6 +1983,23 @@ The returns the following data. Note that `config` is serialized as a string
 
 Use serialized JSON strings when updating or inserting `JSON` fields via the GraphQL API.
 
+Note: You have to escape the escape character to insert double-quotes in `JSON` fields :
+```json
+{
+  "data": {
+    "userCollection": {
+      "edges": [
+        {
+          "node": {
+            "caracteristics": "{\"description\": \"A \\\"valid\\\" string with double-quotes\"}"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
 JSON does not currently support filtering.
 
 ### BigInt


### PR DESCRIPTION
Double-quotes are not intuitive to insert in jsonb string fields

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

No hint to insert quotes in strings

## What is the new behavior?

Note and example about it
