### PR TITLE
fix sql in "add a schema to api" example

### DIFF
--- a/docs/supabase.md
+++ b/docs/supabase.md
@@ -145,10 +145,10 @@ First, we need to add the new schema to the API search path. In the example belo
 Next, make sure the schema and entities (tables/views/functions) that you intend to expose are accessible by the relevant roles. For example, to match permissions from the public schema:
 
 ```sql
-grant usage on app to anon, authenticated, service_role;
-grant all on all tables in schema app to anon, authenticated, service_role;
-grant all on all routines in schema app to anon, authenticated, service_role;
-grant all on all sequences in schema app to anon, authenticated, service_role;
+grant usage on schema app to anon, authenticated, service_role;
+grant all privileges on all tables in schema app to anon, authenticated, service_role;
+grant all privileges on all routines in schema app to anon, authenticated, service_role;
+grant all privileges on all sequences in schema app to anon, authenticated, service_role;
 alter default privileges for role postgres in schema app grant all on tables to anon, authenticated, service_role;
 alter default privileges for role postgres in schema app grant all on routines to anon, authenticated, service_role;
 alter default privileges for role postgres in schema app grant all on sequences to anon, authenticated, service_role;


### PR DESCRIPTION
The SQL was invalid when i tried to run it. The tweaks in this PR make the statements work.

## What kind of change does this PR introduce?

Docs SQL fix

## What is the current behavior?

SQL invalid so example doesn't work

## What is the new behavior?

SQL runs

## Additional context

