### PR TITLE
Add citext support as String vs Opaque

### DIFF
--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1656,7 +1656,13 @@ impl Type {
                     25 => __Type::Scalar(Scalar::String(None)), // text
                     // char, bpchar, varchar
                     18 | 1042 | 1043 => __Type::Scalar(Scalar::String(max_characters)),
-                    _ => __Type::Scalar(Scalar::Opaque),
+                    _ => match self.name.as_str() {
+                        // would be nice to do something better here like confirm the type came
+                        // from an extension but until types from extensions become a bigger issue
+                        // this avoids slowing down the sql context query
+                        "citext" => __Type::Scalar(Scalar::String(None)),
+                        _ => __Type::Scalar(Scalar::Opaque),
+                    },
                 })
             }
             TypeCategory::Array => match self.array_element_type_oid {

--- a/test/expected/issue_370_citext_as_string.out
+++ b/test/expected/issue_370_citext_as_string.out
@@ -1,0 +1,97 @@
+begin;
+    -- https://github.com/supabase/pg_graphql/issues/370
+    -- citext is common enough that we should handle treating it as a string
+    create extension citext;
+    create table account(
+        id int primary key,
+        email citext
+    );
+    insert into public.account(id, email)
+    values (1, 'aBc'), (2, 'def');
+    select jsonb_pretty(
+        graphql.resolve($$
+        {
+          __type(name: "Account") {
+            kind
+            fields {
+                name type { kind name ofType { name }  }
+            }
+          }
+        }
+        $$)
+    );
+                jsonb_pretty                 
+---------------------------------------------
+ {                                          +
+     "data": {                              +
+         "__type": {                        +
+             "kind": "OBJECT",              +
+             "fields": [                    +
+                 {                          +
+                     "name": "nodeId",      +
+                     "type": {              +
+                         "kind": "NON_NULL",+
+                         "name": null,      +
+                         "ofType": {        +
+                             "name": "ID"   +
+                         }                  +
+                     }                      +
+                 },                         +
+                 {                          +
+                     "name": "id",          +
+                     "type": {              +
+                         "kind": "NON_NULL",+
+                         "name": null,      +
+                         "ofType": {        +
+                             "name": "Int"  +
+                         }                  +
+                     }                      +
+                 },                         +
+                 {                          +
+                     "name": "email",       +
+                     "type": {              +
+                         "kind": "SCALAR",  +
+                         "name": "String",  +
+                         "ofType": null     +
+                     }                      +
+                 }                          +
+             ]                              +
+         }                                  +
+     }                                      +
+ }
+(1 row)
+
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              accountCollection( filter: {email: {in: ["abc"]}}) {
+                edges {
+                  node {
+                    id
+                    email 
+                  }
+                }
+              }
+            }
+        $$)
+    );
+              jsonb_pretty              
+----------------------------------------
+ {                                     +
+     "data": {                         +
+         "accountCollection": {        +
+             "edges": [                +
+                 {                     +
+                     "node": {         +
+                         "id": 1,      +
+                         "email": "aBc"+
+                     }                 +
+                 }                     +
+             ]                         +
+         }                             +
+     }                                 +
+ }
+(1 row)
+
+    
+rollback;

--- a/test/expected/issue_370_citext_as_string.out
+++ b/test/expected/issue_370_citext_as_string.out
@@ -68,7 +68,7 @@ begin;
                 edges {
                   node {
                     id
-                    email 
+                    email
                   }
                 }
               }
@@ -93,5 +93,4 @@ begin;
  }
 (1 row)
 
-    
 rollback;

--- a/test/expected/resolve_graphiql_schema.out
+++ b/test/expected/resolve_graphiql_schema.out
@@ -1,7 +1,8 @@
 begin;
+    create extension citext;
     create table account(
         id serial primary key,
-        email varchar(255) not null,
+        email citext not null,
         encrypted_password varchar(255) not null,
         created_at timestamp not null,
         updated_at timestamp not null

--- a/test/sql/issue_370_citext_as_string.sql
+++ b/test/sql/issue_370_citext_as_string.sql
@@ -1,0 +1,43 @@
+begin;
+    -- https://github.com/supabase/pg_graphql/issues/370
+    -- citext is common enough that we should handle treating it as a string
+    create extension citext;
+
+    create table account(
+        id int primary key,
+        email citext
+    );
+
+    insert into public.account(id, email)
+    values (1, 'aBc'), (2, 'def');
+
+    select jsonb_pretty(
+        graphql.resolve($$
+        {
+          __type(name: "Account") {
+            kind
+            fields {
+                name type { kind name ofType { name }  }
+            }
+          }
+        }
+        $$)
+    );
+
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              accountCollection( filter: {email: {in: ["abc"]}}) {
+                edges {
+                  node {
+                    id
+                    email
+                  }
+                }
+              }
+            }
+        $$)
+    );
+
+
+rollback;

--- a/test/sql/resolve_graphiql_schema.sql
+++ b/test/sql/resolve_graphiql_schema.sql
@@ -1,7 +1,9 @@
 begin;
+    create extension citext;
+
     create table account(
         id serial primary key,
-        email varchar(255) not null,
+        email citext not null,
         encrypted_password varchar(255) not null,
         created_at timestamp not null,
         updated_at timestamp not null


### PR DESCRIPTION
## What kind of change does this PR introduce?
Renders the `citext` type as a `String` rather than `Opaque`, the default for unknown types

This enables the full suite of `String` filter ops like `in`, `like` etc, instead of just `eq`

resolves #370 