### PR TITLE
filter out functions in `graphql` & `graphql_public` schemas

### DIFF
--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -117,6 +117,7 @@ impl Function {
             && !self.has_a_nameless_arg()
             && !self.has_a_default_arg()
             && self.permissions.is_executable
+            && !self.is_in_a_system_schema()
     }
 
     fn arg_types_are_supported(&self, types: &HashMap<u32, Arc<Type>>) -> bool {
@@ -153,6 +154,10 @@ impl Function {
 
     fn has_a_default_arg(&self) -> bool {
         self.num_default_args > 0
+    }
+
+    fn is_in_a_system_schema(&self) -> bool {
+        self.schema_name == "graphql" || self.schema_name == "graphql_public"
     }
 }
 

--- a/test/expected/function_calls.out
+++ b/test/expected/function_calls.out
@@ -1866,4 +1866,47 @@ begin;
  }
 (1 row)
 
+    set search_path = public, graphql, graphql_public;
+    create function graphql.function_in_graphql()
+        returns smallint language sql immutable
+    as $$ select 10; $$;
+    select jsonb_pretty(graphql.resolve($$
+        query {
+            function_in_graphql
+        }
+    $$));
+                                 jsonb_pretty                                 
+------------------------------------------------------------------------------
+ {                                                                           +
+     "data": null,                                                           +
+     "errors": [                                                             +
+         {                                                                   +
+             "message": "Unknown field \"function_in_graphql\" on type Query"+
+         }                                                                   +
+     ]                                                                       +
+ }
+(1 row)
+
+    create schema if not exists graphql_public;
+    create function graphql_public.function_in_graphql_public()
+        returns smallint language sql immutable
+    as $$ select 10; $$;
+    select jsonb_pretty(graphql.resolve($$
+        query {
+            function_in_graphql_public
+        }
+    $$));
+                                    jsonb_pretty                                     
+-------------------------------------------------------------------------------------
+ {                                                                                  +
+     "data": null,                                                                  +
+     "errors": [                                                                    +
+         {                                                                          +
+             "message": "Unknown field \"function_in_graphql_public\" on type Query"+
+         }                                                                          +
+     ]                                                                              +
+ }
+(1 row)
+
+    set search_path to default;
 rollback;

--- a/test/sql/function_calls.sql
+++ b/test/sql/function_calls.sql
@@ -622,4 +622,30 @@ begin;
         }
     } $$));
 
+    set search_path = public, graphql, graphql_public;
+
+    create function graphql.function_in_graphql()
+        returns smallint language sql immutable
+    as $$ select 10; $$;
+
+    select jsonb_pretty(graphql.resolve($$
+        query {
+            function_in_graphql
+        }
+    $$));
+
+    create schema if not exists graphql_public;
+
+    create function graphql_public.function_in_graphql_public()
+        returns smallint language sql immutable
+    as $$ select 10; $$;
+
+    select jsonb_pretty(graphql.resolve($$
+        query {
+            function_in_graphql_public
+        }
+    $$));
+
+    set search_path to default;
+
 rollback;


### PR DESCRIPTION
Functions in `graphql` and `graphql_public` schemas are no longer exposed because these are system schemas.