### PR TITLE
exclude auth and extensions supabase system schemas

### DIFF
--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -157,7 +157,9 @@ impl Function {
     }
 
     fn is_in_a_system_schema(&self) -> bool {
-        self.schema_name == "graphql" || self.schema_name == "graphql_public"
+        // These are default schemas in supabase configuration
+        let system_schemas = &["graphql", "graphql_public", "auth", "extensions"];
+        system_schemas.contains(&self.schema_name.as_str())
     }
 }
 

--- a/test/expected/function_calls.out
+++ b/test/expected/function_calls.out
@@ -1866,45 +1866,76 @@ begin;
  }
 (1 row)
 
-    set search_path = public, graphql, graphql_public;
-    create function graphql.function_in_graphql()
-        returns smallint language sql immutable
-    as $$ select 10; $$;
-    select jsonb_pretty(graphql.resolve($$
-        query {
-            function_in_graphql
-        }
-    $$));
-                                 jsonb_pretty                                 
-------------------------------------------------------------------------------
- {                                                                           +
-     "data": null,                                                           +
-     "errors": [                                                             +
-         {                                                                   +
-             "message": "Unknown field \"function_in_graphql\" on type Query"+
-         }                                                                   +
-     ]                                                                       +
- }
-(1 row)
-
+    rollback to savepoint a;
+    -- Confirm that internal functions on the supabase default search_path
+    -- are excluded from GraphQL API
+    create schema if not exists auth;
+    create schema if not exists extensions;
     create schema if not exists graphql_public;
-    create function graphql_public.function_in_graphql_public()
+    -- functions in the counter_example schema should be visible
+    create schema if not exists counter_example;
+    -- Create a function in each excluded schema to confirm it isn't visible
+    create function graphql.should_be_invisible_one()
         returns smallint language sql immutable
     as $$ select 10; $$;
-    select jsonb_pretty(graphql.resolve($$
-        query {
-            function_in_graphql_public
-        }
-    $$));
-                                    jsonb_pretty                                     
--------------------------------------------------------------------------------------
- {                                                                                  +
-     "data": null,                                                                  +
-     "errors": [                                                                    +
-         {                                                                          +
-             "message": "Unknown field \"function_in_graphql_public\" on type Query"+
-         }                                                                          +
-     ]                                                                              +
+    create function graphql_public.should_be_invisible_two()
+        returns smallint language sql immutable
+    as $$ select 10; $$;
+    create function auth.should_be_invisible_three()
+        returns smallint language sql immutable
+    as $$ select 10; $$;
+    create function extensions.should_be_invisible_four()
+        returns smallint language sql immutable
+    as $$ select 10; $$;
+    -- Create a function in counter_example which should be visible to
+    -- preclude the posibility of some other error preventing the above schemas
+    -- from being visible
+    create function counter_example.visible()
+        returns smallint language sql immutable
+    as $$ select 10; $$;
+    -- Set search path to include all supabase system schemas + the counter example
+    set search_path = public, graphql, graphql_public, auth, extensions, counter_example;
+    -- Show all fields available on the QueryType. Only the function "visible" should be seen
+    -- in the output
+    select jsonb_pretty(
+        graphql.resolve($$
+            query IntrospectionQuery {
+              __schema {
+                queryType {
+                  name
+                  fields {
+                    name
+                  }
+                }
+                mutationType {
+                  name
+                  fields {
+                    name
+                  }
+                }
+              }
+            }
+        $$)
+    );
+               jsonb_pretty                
+-------------------------------------------
+ {                                        +
+     "data": {                            +
+         "__schema": {                    +
+             "queryType": {               +
+                 "name": "Query",         +
+                 "fields": [              +
+                     {                    +
+                         "name": "node"   +
+                     },                   +
+                     {                    +
+                         "name": "visible"+
+                     }                    +
+                 ]                        +
+             },                           +
+             "mutationType": null         +
+         }                                +
+     }                                    +
  }
 (1 row)
 


### PR DESCRIPTION
Currently, functions in `auth` and `extensions` schemas on supabase are visible to the UDF feature

The requirements to show a function is pg_graphql are:
- is on search_path
- has execute permission

The default search path on supabase is: 
```
"$user", public, auth, extensions
```
`anon` and `authenticated` users need to be able to execute functions like `auth.email()` and `auth.jwt()` in RLS policies so
```sql
select has_function_privilege('anon', 'auth.email()', 'execute');
```
is true

therefore, all functions in the `auth` and `extensions` schemas are visible/accessible in the GraphQL API

This PR adds `auth` and `extensions` to the exclusion list (previously `graphql` and `graphql_public`)
```rust
    fn is_in_a_system_schema(&self) -> bool {
        // These are default schemas in supabase configuration
        let system_schemas = &["graphql", "graphql_public", "auth", "extensions"];
        system_schemas.contains(&self.schema_name.as_str())
    }
```

