### PR TITLE
fix mkdocs warnings about absolute links

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2,9 +2,9 @@
 In our API, each SQL table is reflected as a set of GraphQL types. At a high level, tables become types and columns/foreign keys become fields on those types.
 
 
-By default, PostgreSQL table and column names are not inflected when reflecting GraphQL  names. For example, an `account_holder` table has GraphQL type name `account_holder`. In cases where SQL entities are named using `snake_case`, [enable inflection](/pg_graphql/configuration/#inflection) to match GraphQL/Javascript conventions e.g. `account_holder` -> `AccountHolder`.
+By default, PostgreSQL table and column names are not inflected when reflecting GraphQL  names. For example, an `account_holder` table has GraphQL type name `account_holder`. In cases where SQL entities are named using `snake_case`, [enable inflection](configuration.md#inflection) to match GraphQL/Javascript conventions e.g. `account_holder` -> `AccountHolder`.
 
-Individual table, column, and relationship names may also be [manually overridden](/pg_graphql/configuration/#tables-type).
+Individual table, column, and relationship names may also be [manually overridden](configuration.md#tables-type).
 
 
 ## QueryType

--- a/docs/computed_fields.md
+++ b/docs/computed_fields.md
@@ -31,7 +31,7 @@ Computed relations can be helpful to express relationships:
 - between entities that don't support foreign keys
 - too complex to be expressed via a foreign key
 
-If the relationship is simple, but involves an entity that does not support foreign keys e.g. Foreign Data Wrappers / Views, defining a comment directive is the easiest solution. See the [view doc](/pg_graphql/views) for a complete example. Note that for entities that do not support a primary key, like views, you must define one using a [comment directive](/pg_graphql/configuration/#comment-directives) to use them in a computed relationship.
+If the relationship is simple, but involves an entity that does not support foreign keys e.g. Foreign Data Wrappers / Views, defining a comment directive is the easiest solution. See the [view doc](views.md) for a complete example. Note that for entities that do not support a primary key, like views, you must define one using a [comment directive](configuration.md#comment-directives) to use them in a computed relationship.
 
 Alternatively, if the relationship is complex, or you need compatibility with PostgREST, you can define a relationship using set returning functions.
 

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -88,7 +88,7 @@ Functions marked `immutable` or `stable` are available on the query type. Functi
 ## Supported Return Types
 
 
-Built-in GraphQL scalar types `Int`, `Float`, `String`, `Boolean` and [custom scalar types](/pg_graphql/api/#custom-scalars) are supported as function arguments and return types. Function types returning a table or view are supported as well:
+Built-in GraphQL scalar types `Int`, `Float`, `String`, `Boolean` and [custom scalar types](api.md#custom-scalars) are supported as function arguments and return types. Function types returning a table or view are supported as well:
 
 === "Function"
 
@@ -142,7 +142,7 @@ Built-in GraphQL scalar types `Int`, `Float`, `String`, `Boolean` and [custom sc
     }
     ```
 
-Functions returning multiple rows of a table or view are exposed as [collections](/pg_graphql/api/#collections).
+Functions returning multiple rows of a table or view are exposed as [collections](api.md#collections).
 
 === "Function"
 

--- a/docs/supabase.md
+++ b/docs/supabase.md
@@ -37,7 +37,7 @@ Head back to GraphiQL to see the new table reflected in your GraphQL API's Query
 
 ![graphiql](./assets/supabase_graphiql_query_table.png)
 
-If you'd like your type and field names to match the GraphQL convention of `PascalCase` for types and `camelCase` for fields, check out the [pg_graphql inflection guide](/pg_graphql/configuration/#inflection).
+If you'd like your type and field names to match the GraphQL convention of `PascalCase` for types and `camelCase` for fields, check out the [pg_graphql inflection guide](configuration.md#inflection).
 
 ### HTTP Request
 
@@ -77,7 +77,7 @@ and there are no `variables`
 
 The JS ecosystem supports multiple prominent GraphQL frameworks. [supabase-js](https://supabase.com/docs/reference/javascript/introduction) is unopinionated about your GraphQL tooling and can integrate with all of them.
 
-For an example integration, check out the [Relay guide](/pg_graphql/usage_with_relay), complete with Supabase Auth support.
+For an example integration, check out the [Relay guide](usage_with_relay.md), complete with Supabase Auth support.
 
 ### GraphiQL
 
@@ -181,7 +181,7 @@ create extension pg_graphql; -- install default version 1.2.0
 
 To upgrade your GraphQL API with 0 downtime.
 
-When making a decision to upgrade, you can review features of the upgraded version in the [changelog](/pg_graphql/changelog/).
+When making a decision to upgrade, you can review features of the upgraded version in the [changelog](changelog.md).
 
 Always test a new version of pg_graphql extensively on a development or staging instance before updating your production instance. pg_graphql follows SemVer, which makes API backwards compatibility relatively safe for minor and patch updates. Even so, it's critical to verify that changes do not negatively impact the specifics of your project's API in other ways, e.g. requests/sec or CPU load.
 

--- a/docs/views.md
+++ b/docs/views.md
@@ -4,7 +4,7 @@ Views, materialized views, and foreign tables can be exposed with pg_graphql.
 
 ## Primary Keys (Required)
 
-A primary key is required for an entity to be reflected in the GraphQL schema. Tables can define primary keys with SQL DDL, but primary keys are not available for views, materialized views, or foreign tables. For those entities, you can set a "fake" primary key with a [comment directive](/pg_graphql/configuration/#comment-directives).
+A primary key is required for an entity to be reflected in the GraphQL schema. Tables can define primary keys with SQL DDL, but primary keys are not available for views, materialized views, or foreign tables. For those entities, you can set a "fake" primary key with a [comment directive](configuration.md#comment-directives).
 ```json
 {"primary_key_columns": [<column_name_1>, ..., <column_name_n>]}
 ```
@@ -38,7 +38,7 @@ type Person {
 
 ## Relationships
 
-pg_graphql identifies relationships among entities by inspecting foreign keys. Views, materialized views, and foreign tables do not support foreign keys. For this reason, relationships can also be defined in [comment directive](/pg_graphql/configuration/#comment-directives) using the structure:
+pg_graphql identifies relationships among entities by inspecting foreign keys. Views, materialized views, and foreign tables do not support foreign keys. For this reason, relationships can also be defined in [comment directive](configuration.md#comment-directives) using the structure:
 
 
 


### PR DESCRIPTION
Change the way to link among pages to fix mkdocs warnings about using absolute links.