### PR TITLE
do not expose trigger functions in GQL

### DIFF
--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -135,6 +135,8 @@ impl Function {
         if let Some(return_type) = types.get(&self.type_oid) {
             return_type.category != TypeCategory::Pseudo
                 && return_type.name != "record"
+                && return_type.name != "trigger"
+                && return_type.name != "event_trigger"
                 && !self.type_name.ends_with("[]")
         } else {
             false

--- a/test/expected/function_calls.out
+++ b/test/expected/function_calls.out
@@ -2161,4 +2161,38 @@ begin;
  }
 (1 row)
 
+    select jsonb_pretty(graphql.resolve($$
+        query {
+            returnsTrigger
+        }
+    $$));
+                              jsonb_pretty                               
+-------------------------------------------------------------------------
+ {                                                                      +
+     "data": null,                                                      +
+     "errors": [                                                        +
+         {                                                              +
+             "message": "Unknown field \"returnsTrigger\" on type Query"+
+         }                                                              +
+     ]                                                                  +
+ }
+(1 row)
+
+    select jsonb_pretty(graphql.resolve($$
+        query {
+            returnsEventTrigger
+        }
+    $$));
+                                 jsonb_pretty                                 
+------------------------------------------------------------------------------
+ {                                                                           +
+     "data": null,                                                           +
+     "errors": [                                                             +
+         {                                                                   +
+             "message": "Unknown field \"returnsEventTrigger\" on type Query"+
+         }                                                                   +
+     ]                                                                       +
+ }
+(1 row)
+
 rollback;

--- a/test/expected/function_calls.out
+++ b/test/expected/function_calls.out
@@ -1954,6 +1954,12 @@ begin;
     )
         returns smallint language sql immutable
     as $$ select 0; $$;
+    create function returns_trigger()
+        returns trigger language plpgsql immutable
+    as $$ begin return null; end; $$;
+    create function returns_event_trigger()
+        returns event_trigger language plpgsql immutable
+    as $$ begin end; $$;
     select jsonb_pretty(
         graphql.resolve($$
             query IntrospectionQuery {

--- a/test/sql/function_calls.sql
+++ b/test/sql/function_calls.sql
@@ -701,6 +701,14 @@ begin;
         returns smallint language sql immutable
     as $$ select 0; $$;
 
+    create function returns_trigger()
+        returns trigger language plpgsql immutable
+    as $$ begin return null; end; $$;
+
+    create function returns_event_trigger()
+        returns event_trigger language plpgsql immutable
+    as $$ begin end; $$;
+
     select jsonb_pretty(
         graphql.resolve($$
             query IntrospectionQuery {

--- a/test/sql/function_calls.sql
+++ b/test/sql/function_calls.sql
@@ -770,4 +770,16 @@ begin;
             concatText(a: "hello ")
         }
     $$));
+
+    select jsonb_pretty(graphql.resolve($$
+        query {
+            returnsTrigger
+        }
+    $$));
+
+    select jsonb_pretty(graphql.resolve($$
+        query {
+            returnsEventTrigger
+        }
+    $$));
 rollback;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Trigger functions were exposed in the GraphQL schema.

## What is the new behavior?

Trigger functions will not be callable from GraphQL.

## Additional context

N/A
