### PR TITLE
Bump version to 1.4.1 for release to prod

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_graphql"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 
 [lib]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -47,5 +47,8 @@
 - feature: Support for Postgres 16
 - feature: Support for user defined functions
 
-## master
+## 1.4.1
 - feature: Support for user defined functions with default arguments
+- bugfix: Trigger functions excluded from API
+
+## master


### PR DESCRIPTION
## What kind of change does this PR introduce?
bumps version to include latest bugfix before deploying to Supabase prod