### PR TITLE
docs: add primary key requirement in the API section in docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -6,6 +6,26 @@ By default, PostgreSQL table and column names are not inflected when reflecting 
 
 Individual table, column, and relationship names may also be [manually overridden](configuration.md#tables-type).
 
+## Primary Keys (Required)
+
+Every table must have a primary key for it to be exposed in the GraphQL schema. For example, the following `Blog` table will be available in the GraphQL schema as `blogCollection` since it has a primary key named `id`:
+
+```sql
+create table "Blog"(
+  id serial primary key,
+  name varchar(255) not null,
+);
+```
+
+But the following table will not be exposed because it doesn't have a primary key:
+
+```sql
+create table "Blog"(
+  id int,
+  name varchar(255) not null,
+);
+```
+
 
 ## QueryType
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

API section in docs did not mention the requirement for tables to have a primary key for them to be exposed in the GraphQL schema.

## What is the new behavior?

The requirement to have a primary key is mentioned in the beginning of the API section.

## Additional context

Fixes #445 
