### PR TITLE
remove single quotes from `defaultValue` of a `String` type

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -56,3 +56,4 @@
 
 ## master
 - bugfix: make non-default args non-null in UDFs
+- bugfix: default value of a string type argument in a UDF was wrapped in single quotes

--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -232,7 +232,7 @@ impl<'a> ArgsIterator<'a> {
             25 => trimmed
                 .strip_suffix("::text")
                 .to_owned()
-                .map(|i| i.trim_matches(',').to_string()),
+                .map(|i| i.trim_matches(',').trim_matches('\'').to_string()),
             _ => None,
         }
     }

--- a/test/expected/function_calls.out
+++ b/test/expected/function_calls.out
@@ -2436,7 +2436,7 @@ begin;
                                      "name": "String",    +
                                      "ofType": null       +
                                  },                       +
-                                 "defaultValue": "'hello'"+
+                                 "defaultValue": "hello"  +
                              }                            +
                          ],                               +
                          "name": "funcWithDefaults"       +


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

GraphiQL failed to fetch functions with default String arguments because `pg_graphql` returned default values wrapped in single quotes.

## What is the new behavior?

Single quotes have been stripped from default values of string types.

## Additional context

Fixes #456 