### PR TITLE
default string values should be encoded as a GraphQL value

### DIFF
--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -232,7 +232,7 @@ impl<'a> ArgsIterator<'a> {
             25 => trimmed
                 .strip_suffix("::text")
                 .to_owned()
-                .map(|i| i.trim_matches(',').trim_matches('\'').to_string()),
+                .map(|i| format!("\"{}\"", i.trim_matches(',').trim_matches('\''))),
             _ => None,
         }
     }

--- a/test/expected/function_calls.out
+++ b/test/expected/function_calls.out
@@ -2351,117 +2351,117 @@ begin;
             }
         $$)
     );
-                       jsonb_pretty                        
------------------------------------------------------------
- {                                                        +
-     "data": {                                            +
-         "__schema": {                                    +
-             "queryType": {                               +
-                 "name": "Query",                         +
-                 "fields": [                              +
-                     {                                    +
-                         "args": [                        +
-                             {                            +
-                                 "name": "a",             +
-                                 "type": {                +
-                                     "kind": "SCALAR",    +
-                                     "name": "Int",       +
-                                     "ofType": null       +
-                                 },                       +
-                                 "defaultValue": "1"      +
-                             },                           +
-                             {                            +
-                                 "name": "b",             +
-                                 "type": {                +
-                                     "kind": "SCALAR",    +
-                                     "name": "Int",       +
-                                     "ofType": null       +
-                                 },                       +
-                                 "defaultValue": "2"      +
-                             }                            +
-                         ],                               +
-                         "name": "addSmallints"           +
-                     },                                   +
-                     {                                    +
-                         "args": [                        +
-                             {                            +
-                                 "name": "a",             +
-                                 "type": {                +
-                                     "kind": "SCALAR",    +
-                                     "name": "Int",       +
-                                     "ofType": null       +
-                                 },                       +
-                                 "defaultValue": "1"      +
-                             },                           +
-                             {                            +
-                                 "name": "b",             +
-                                 "type": {                +
-                                     "kind": "SCALAR",    +
-                                     "name": "Int",       +
-                                     "ofType": null       +
-                                 },                       +
-                                 "defaultValue": "2"      +
-                             },                           +
-                             {                            +
-                                 "name": "c",             +
-                                 "type": {                +
-                                     "kind": "SCALAR",    +
-                                     "name": "Boolean",   +
-                                     "ofType": null       +
-                                 },                       +
-                                 "defaultValue": "false"  +
-                             },                           +
-                             {                            +
-                                 "name": "d",             +
-                                 "type": {                +
-                                     "kind": "SCALAR",    +
-                                     "name": "Float",     +
-                                     "ofType": null       +
-                                 },                       +
-                                 "defaultValue": "3.14"   +
-                             },                           +
-                             {                            +
-                                 "name": "e",             +
-                                 "type": {                +
-                                     "kind": "SCALAR",    +
-                                     "name": "Float",     +
-                                     "ofType": null       +
-                                 },                       +
-                                 "defaultValue": "2.718"  +
-                             },                           +
-                             {                            +
-                                 "name": "f",             +
-                                 "type": {                +
-                                     "kind": "SCALAR",    +
-                                     "name": "String",    +
-                                     "ofType": null       +
-                                 },                       +
-                                 "defaultValue": "hello"  +
-                             }                            +
-                         ],                               +
-                         "name": "funcWithDefaults"       +
-                     },                                   +
-                     {                                    +
-                         "args": [                        +
-                             {                            +
-                                 "name": "nodeId",        +
-                                 "type": {                +
-                                     "kind": "NON_NULL",  +
-                                     "name": null,        +
-                                     "ofType": {          +
-                                         "kind": "SCALAR",+
-                                         "name": "ID"     +
-                                     }                    +
-                                 },                       +
-                                 "defaultValue": null     +
-                             }                            +
-                         ],                               +
-                         "name": "node"                   +
-                     }                                    +
-                 ]                                        +
-             }                                            +
-         }                                                +
-     }                                                    +
+                        jsonb_pretty                         
+-------------------------------------------------------------
+ {                                                          +
+     "data": {                                              +
+         "__schema": {                                      +
+             "queryType": {                                 +
+                 "name": "Query",                           +
+                 "fields": [                                +
+                     {                                      +
+                         "args": [                          +
+                             {                              +
+                                 "name": "a",               +
+                                 "type": {                  +
+                                     "kind": "SCALAR",      +
+                                     "name": "Int",         +
+                                     "ofType": null         +
+                                 },                         +
+                                 "defaultValue": "1"        +
+                             },                             +
+                             {                              +
+                                 "name": "b",               +
+                                 "type": {                  +
+                                     "kind": "SCALAR",      +
+                                     "name": "Int",         +
+                                     "ofType": null         +
+                                 },                         +
+                                 "defaultValue": "2"        +
+                             }                              +
+                         ],                                 +
+                         "name": "addSmallints"             +
+                     },                                     +
+                     {                                      +
+                         "args": [                          +
+                             {                              +
+                                 "name": "a",               +
+                                 "type": {                  +
+                                     "kind": "SCALAR",      +
+                                     "name": "Int",         +
+                                     "ofType": null         +
+                                 },                         +
+                                 "defaultValue": "1"        +
+                             },                             +
+                             {                              +
+                                 "name": "b",               +
+                                 "type": {                  +
+                                     "kind": "SCALAR",      +
+                                     "name": "Int",         +
+                                     "ofType": null         +
+                                 },                         +
+                                 "defaultValue": "2"        +
+                             },                             +
+                             {                              +
+                                 "name": "c",               +
+                                 "type": {                  +
+                                     "kind": "SCALAR",      +
+                                     "name": "Boolean",     +
+                                     "ofType": null         +
+                                 },                         +
+                                 "defaultValue": "false"    +
+                             },                             +
+                             {                              +
+                                 "name": "d",               +
+                                 "type": {                  +
+                                     "kind": "SCALAR",      +
+                                     "name": "Float",       +
+                                     "ofType": null         +
+                                 },                         +
+                                 "defaultValue": "3.14"     +
+                             },                             +
+                             {                              +
+                                 "name": "e",               +
+                                 "type": {                  +
+                                     "kind": "SCALAR",      +
+                                     "name": "Float",       +
+                                     "ofType": null         +
+                                 },                         +
+                                 "defaultValue": "2.718"    +
+                             },                             +
+                             {                              +
+                                 "name": "f",               +
+                                 "type": {                  +
+                                     "kind": "SCALAR",      +
+                                     "name": "String",      +
+                                     "ofType": null         +
+                                 },                         +
+                                 "defaultValue": "\"hello\""+
+                             }                              +
+                         ],                                 +
+                         "name": "funcWithDefaults"         +
+                     },                                     +
+                     {                                      +
+                         "args": [                          +
+                             {                              +
+                                 "name": "nodeId",          +
+                                 "type": {                  +
+                                     "kind": "NON_NULL",    +
+                                     "name": null,          +
+                                     "ofType": {            +
+                                         "kind": "SCALAR",  +
+                                         "name": "ID"       +
+                                     }                      +
+                                 },                         +
+                                 "defaultValue": null       +
+                             }                              +
+                         ],                                 +
+                         "name": "node"                     +
+                     }                                      +
+                 ]                                          +
+             }                                              +
+         }                                                  +
+     }                                                      +
  }
 (1 row)
 


### PR DESCRIPTION
The last attempt to fix #456 in #457 did not work because a default string value needs to be wrapped in double quotes. As per [the spec](https://spec.graphql.org/October2021/#sec-The-__InputValue-Type):

> defaultValue may return a String encoding (using the GraphQL language) of the default value used by this input value in the condition a value is not provided at runtime