### PR TITLE
Respect user defined defaults for variables

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -48,6 +48,7 @@ fn read_argument<'a, T>(
     field: &__Field,
     query_field: &graphql_parser::query::Field<'a, T>,
     variables: &serde_json::Value,
+    variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> Result<gson::Value, String>
 where
     T: Text<'a> + Eq + AsRef<str>,
@@ -77,12 +78,19 @@ fn read_argument_at_most<'a, T>(
     field: &__Field,
     query_field: &graphql_parser::query::Field<'a, T>,
     variables: &serde_json::Value,
+    variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> Result<i64, String>
 where
     T: Text<'a> + Eq + AsRef<str>,
 {
-    let at_most: gson::Value = read_argument("atMost", field, query_field, variables)
-        .unwrap_or(gson::Value::Number(gson::Number::Integer(1)));
+    let at_most: gson::Value = read_argument(
+        "atMost",
+        field,
+        query_field,
+        variables,
+        variable_definitions,
+    )
+    .unwrap_or(gson::Value::Number(gson::Number::Integer(1)));
     match at_most {
         gson::Value::Number(gson::Number::Integer(x)) => Ok(x),
         _ => Err("Internal Error: failed to parse validated atFirst".to_string()),
@@ -144,13 +152,19 @@ fn read_argument_node_id<'a, T>(
     field: &__Field,
     query_field: &graphql_parser::query::Field<'a, T>,
     variables: &serde_json::Value,
+    variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> Result<NodeIdInstance, String>
 where
     T: Text<'a> + Eq + AsRef<str>,
 {
     // nodeId is a base64 encoded string of [schema, table, pkey_val1, pkey_val2, ...]
-    let node_id_base64_encoded_json_string: gson::Value =
-        read_argument("nodeId", field, query_field, variables)?;
+    let node_id_base64_encoded_json_string: gson::Value = read_argument(
+        "nodeId",
+        field,
+        query_field,
+        variables,
+        variable_definitions,
+    )?;
 
     parse_node_id(node_id_base64_encoded_json_string)
 }
@@ -159,12 +173,19 @@ fn read_argument_objects<'a, T>(
     field: &__Field,
     query_field: &graphql_parser::query::Field<'a, T>,
     variables: &serde_json::Value,
+    variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> Result<Vec<InsertRowBuilder>, String>
 where
     T: Text<'a> + Eq + AsRef<str>,
 {
     // [{"name": "bob", "email": "a@b.com"}, {..}]
-    let validated: gson::Value = read_argument("objects", field, query_field, variables)?;
+    let validated: gson::Value = read_argument(
+        "objects",
+        field,
+        query_field,
+        variables,
+        variable_definitions,
+    )?;
 
     // [<Table>OrderBy!]
     let insert_type: InsertInputType =
@@ -229,6 +250,7 @@ pub fn to_insert_builder<'a, T>(
     query_field: &graphql_parser::query::Field<'a, T>,
     fragment_definitions: &Vec<FragmentDefinition<'a, T>>,
     variables: &serde_json::Value,
+    variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> Result<InsertBuilder, String>
 where
     T: Text<'a> + Eq + AsRef<str>,
@@ -246,7 +268,7 @@ where
             restrict_allowed_arguments(&["objects"], query_field)?;
 
             let objects: Vec<InsertRowBuilder> =
-                read_argument_objects(field, query_field, variables)?;
+                read_argument_objects(field, query_field, variables, variable_definitions)?;
 
             let mut builder_fields: Vec<InsertSelection> = vec![];
 
@@ -271,6 +293,7 @@ where
                                 fragment_definitions,
                                 variables,
                                 &[],
+                                variable_definitions,
                             );
                             InsertSelection::Records(node_builder?)
                         }
@@ -330,11 +353,13 @@ fn read_argument_set<'a, T>(
     field: &__Field,
     query_field: &graphql_parser::query::Field<'a, T>,
     variables: &serde_json::Value,
+    variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> Result<SetBuilder, String>
 where
     T: Text<'a> + Eq + AsRef<str>,
 {
-    let validated: gson::Value = read_argument("set", field, query_field, variables)?;
+    let validated: gson::Value =
+        read_argument("set", field, query_field, variables, variable_definitions)?;
 
     let update_type: UpdateInputType = match field.get_arg("set").unwrap().type_().unmodified_type()
     {
@@ -384,6 +409,7 @@ pub fn to_update_builder<'a, T>(
     query_field: &graphql_parser::query::Field<'a, T>,
     fragment_definitions: &Vec<FragmentDefinition<'a, T>>,
     variables: &serde_json::Value,
+    variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> Result<UpdateBuilder, String>
 where
     T: Text<'a> + Eq + AsRef<str>,
@@ -400,9 +426,12 @@ where
             // Raise for disallowed arguments
             restrict_allowed_arguments(&["set", "filter", "atMost"], query_field)?;
 
-            let set: SetBuilder = read_argument_set(field, query_field, variables)?;
-            let filter: FilterBuilder = read_argument_filter(field, query_field, variables)?;
-            let at_most: i64 = read_argument_at_most(field, query_field, variables)?;
+            let set: SetBuilder =
+                read_argument_set(field, query_field, variables, variable_definitions)?;
+            let filter: FilterBuilder =
+                read_argument_filter(field, query_field, variables, variable_definitions)?;
+            let at_most: i64 =
+                read_argument_at_most(field, query_field, variables, variable_definitions)?;
 
             let mut builder_fields: Vec<UpdateSelection> = vec![];
 
@@ -427,6 +456,7 @@ where
                                 fragment_definitions,
                                 variables,
                                 &[],
+                                variable_definitions,
                             );
                             UpdateSelection::Records(node_builder?)
                         }
@@ -482,6 +512,7 @@ pub fn to_delete_builder<'a, T>(
     query_field: &graphql_parser::query::Field<'a, T>,
     fragment_definitions: &Vec<FragmentDefinition<'a, T>>,
     variables: &serde_json::Value,
+    variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> Result<DeleteBuilder, String>
 where
     T: Text<'a> + Eq + AsRef<str>,
@@ -498,8 +529,10 @@ where
             // Raise for disallowed arguments
             restrict_allowed_arguments(&["filter", "atMost"], query_field)?;
 
-            let filter: FilterBuilder = read_argument_filter(field, query_field, variables)?;
-            let at_most: i64 = read_argument_at_most(field, query_field, variables)?;
+            let filter: FilterBuilder =
+                read_argument_filter(field, query_field, variables, variable_definitions)?;
+            let at_most: i64 =
+                read_argument_at_most(field, query_field, variables, variable_definitions)?;
 
             let mut builder_fields: Vec<DeleteSelection> = vec![];
 
@@ -524,6 +557,7 @@ where
                                 fragment_definitions,
                                 variables,
                                 &[],
+                                variable_definitions,
                             );
                             DeleteSelection::Records(node_builder?)
                         }
@@ -585,6 +619,7 @@ pub fn to_function_call_builder<'a, T>(
     query_field: &graphql_parser::query::Field<'a, T>,
     fragment_definitions: &Vec<FragmentDefinition<'a, T>>,
     variables: &serde_json::Value,
+    variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> Result<FunctionCallBuilder, String>
 where
     T: Text<'a> + Eq + AsRef<str>,
@@ -597,7 +632,13 @@ where
             let args = field.args();
             let allowed_args: Vec<&str> = args.iter().map(|a| a.name_.as_str()).collect();
             restrict_allowed_arguments(&allowed_args, query_field)?;
-            let args = read_func_call_args(field, query_field, variables, func_call_resp_type)?;
+            let args = read_func_call_args(
+                field,
+                query_field,
+                variables,
+                func_call_resp_type,
+                variable_definitions,
+            )?;
 
             let return_type_builder = match func_call_resp_type.return_type.deref() {
                 __Type::Scalar(_) => FuncCallReturnTypeBuilder::Scalar,
@@ -609,6 +650,7 @@ where
                         fragment_definitions,
                         variables,
                         &allowed_args,
+                        variable_definitions,
                     )?;
                     FuncCallReturnTypeBuilder::Node(node_builder)
                 }
@@ -619,6 +661,7 @@ where
                         fragment_definitions,
                         variables,
                         &allowed_args,
+                        variable_definitions,
                     )?;
                     FuncCallReturnTypeBuilder::Connection(connection_builder)
                 }
@@ -653,6 +696,7 @@ fn read_func_call_args<'a, T>(
     query_field: &graphql_parser::query::Field<'a, T>,
     variables: &serde_json::Value,
     func_call_resp_type: &FuncCallResponseType,
+    variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> Result<FuncCallArgsBuilder, String>
 where
     T: Text<'a> + Eq + AsRef<str>,
@@ -660,7 +704,13 @@ where
     let inflected_to_sql_args = func_call_resp_type.inflected_to_sql_args();
     let mut args = vec![];
     for arg in field.args() {
-        let arg_value = read_argument(&arg.name(), field, query_field, variables)?;
+        let arg_value = read_argument(
+            &arg.name(),
+            field,
+            query_field,
+            variables,
+            variable_definitions,
+        )?;
         if !arg_value.is_absent() {
             let func_call_sql_arg_name =
                 inflected_to_sql_args
@@ -970,11 +1020,18 @@ fn read_argument_filter<'a, T>(
     field: &__Field,
     query_field: &graphql_parser::query::Field<'a, T>,
     variables: &serde_json::Value,
+    variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> Result<FilterBuilder, String>
 where
     T: Text<'a> + Eq + AsRef<str>,
 {
-    let validated: gson::Value = read_argument("filter", field, query_field, variables)?;
+    let validated: gson::Value = read_argument(
+        "filter",
+        field,
+        query_field,
+        variables,
+        variable_definitions,
+    )?;
 
     let filter_type = field.get_arg("filter").unwrap().type_().unmodified_type();
     if !matches!(filter_type, __Type::FilterEntity(_)) {
@@ -1113,12 +1170,19 @@ fn read_argument_order_by<'a, T>(
     field: &__Field,
     query_field: &graphql_parser::query::Field<'a, T>,
     variables: &serde_json::Value,
+    variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> Result<OrderByBuilder, String>
 where
     T: Text<'a> + Eq + AsRef<str>,
 {
     // [{"id": "DescNullsLast"}]
-    let validated: gson::Value = read_argument("orderBy", field, query_field, variables)?;
+    let validated: gson::Value = read_argument(
+        "orderBy",
+        field,
+        query_field,
+        variables,
+        variable_definitions,
+    )?;
 
     // [<Table>OrderBy!]
     let order_type: OrderByEntityType =
@@ -1198,11 +1262,18 @@ fn read_argument_cursor<'a, T>(
     field: &__Field,
     query_field: &graphql_parser::query::Field<'a, T>,
     variables: &serde_json::Value,
+    variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> Result<Option<Cursor>, String>
 where
     T: Text<'a> + Eq + AsRef<str>,
 {
-    let validated: gson::Value = read_argument(arg_name, field, query_field, variables)?;
+    let validated: gson::Value = read_argument(
+        arg_name,
+        field,
+        query_field,
+        variables,
+        variable_definitions,
+    )?;
     let _: Scalar = match field.get_arg(arg_name).unwrap().type_().unmodified_type() {
         __Type::Scalar(x) => x,
         _ => return Err(format!("Could not argument {}", arg_name)),
@@ -1227,6 +1298,7 @@ pub fn to_connection_builder<'a, T>(
     fragment_definitions: &Vec<FragmentDefinition<'a, T>>,
     variables: &serde_json::Value,
     extra_allowed_args: &[&str],
+    variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> Result<ConnectionBuilder, String>
 where
     T: Text<'a> + Eq + AsRef<str>,
@@ -1247,7 +1319,8 @@ where
             restrict_allowed_arguments(&allowed_args, query_field)?;
 
             // TODO: only one of first/last, before/after provided
-            let first: gson::Value = read_argument("first", field, query_field, variables)?;
+            let first: gson::Value =
+                read_argument("first", field, query_field, variables, variable_definitions)?;
             let first: Option<u64> = match first {
                 gson::Value::Absent | gson::Value::Null => None,
                 gson::Value::Number(gson::Number::Integer(n)) if n < 0 => {
@@ -1259,7 +1332,8 @@ where
                 }
             };
 
-            let last: gson::Value = read_argument("last", field, query_field, variables)?;
+            let last: gson::Value =
+                read_argument("last", field, query_field, variables, variable_definitions)?;
             let last: Option<u64> = match last {
                 gson::Value::Absent | gson::Value::Null => None,
                 gson::Value::Number(gson::Number::Integer(n)) if n < 0 => {
@@ -1280,10 +1354,15 @@ where
                 .map(|x| x.directives.max_rows)
                 .unwrap_or(30);
 
-            let before: Option<Cursor> =
-                read_argument_cursor("before", field, query_field, variables)?;
+            let before: Option<Cursor> = read_argument_cursor(
+                "before",
+                field,
+                query_field,
+                variables,
+                variable_definitions,
+            )?;
             let after: Option<Cursor> =
-                read_argument_cursor("after", field, query_field, variables)?;
+                read_argument_cursor("after", field, query_field, variables, variable_definitions)?;
 
             // Validate compatible input arguments
             if first.is_some() && last.is_some() {
@@ -1296,8 +1375,10 @@ where
                 return Err("\"last\" may only be used with \"before\"".to_string());
             }
 
-            let filter: FilterBuilder = read_argument_filter(field, query_field, variables)?;
-            let order_by: OrderByBuilder = read_argument_order_by(field, query_field, variables)?;
+            let filter: FilterBuilder =
+                read_argument_filter(field, query_field, variables, variable_definitions)?;
+            let order_by: OrderByBuilder =
+                read_argument_order_by(field, query_field, variables, variable_definitions)?;
 
             let mut builder_fields: Vec<ConnectionSelection> = vec![];
 
@@ -1317,6 +1398,7 @@ where
                             selection_field,
                             fragment_definitions,
                             variables,
+                            variable_definitions,
                         )?),
                         __Type::PageInfo(_) => ConnectionSelection::PageInfo(to_page_info_builder(
                             f,
@@ -1427,6 +1509,7 @@ fn to_edge_builder<'a, T>(
     query_field: &graphql_parser::query::Field<'a, T>,
     fragment_definitions: &Vec<FragmentDefinition<'a, T>>,
     variables: &serde_json::Value,
+    variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> Result<EdgeBuilder, String>
 where
     T: Text<'a> + Eq + AsRef<str>,
@@ -1461,6 +1544,7 @@ where
                                 fragment_definitions,
                                 variables,
                                 &[],
+                                variable_definitions,
                             )?;
                             EdgeSelection::Node(node_builder)
                         }
@@ -1492,6 +1576,7 @@ pub fn to_node_builder<'a, T>(
     fragment_definitions: &Vec<FragmentDefinition<'a, T>>,
     variables: &serde_json::Value,
     extra_allowed_args: &[&str],
+    variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> Result<NodeBuilder, String>
 where
     T: Text<'a> + Eq + AsRef<str>,
@@ -1509,7 +1594,8 @@ where
             restrict_allowed_arguments(&["nodeId"], query_field)?;
             // The nodeId argument is only valid on the entrypoint field for Node
             // relationships to "node" e.g. within edges, do not have any arguments
-            let node_id: NodeIdInstance = read_argument_node_id(field, query_field, variables)?;
+            let node_id: NodeIdInstance =
+                read_argument_node_id(field, query_field, variables, variable_definitions)?;
 
             let possible_types: Vec<__Type> = node_interface.possible_types().unwrap_or(vec![]);
             let xtype = possible_types.iter().find_map(|x| match x {
@@ -1551,7 +1637,12 @@ where
     // The nodeId argument is only valid on the entrypoint field for Node
     // relationships to "node" e.g. within edges, do not have any arguments
     let node_id: Option<NodeIdInstance> = match field.get_arg("nodeId").is_some() {
-        true => Some(read_argument_node_id(field, query_field, variables)?),
+        true => Some(read_argument_node_id(
+            field,
+            query_field,
+            variables,
+            variable_definitions,
+        )?),
         false => None,
     };
 
@@ -1590,6 +1681,7 @@ where
                                         fragment_definitions,
                                         variables,
                                         &[],
+                                        variable_definitions,
                                         // TODO need ref to fkey here
                                     )?;
                                     FunctionSelection::Node(node_builder)
@@ -1601,6 +1693,7 @@ where
                                         fragment_definitions,
                                         variables,
                                         &[], // TODO need ref to fkey here
+                                        variable_definitions,
                                     )?;
                                     FunctionSelection::Connection(connection_builder)
                                 }
@@ -1635,6 +1728,7 @@ where
                                     fragment_definitions,
                                     variables,
                                     &[],
+                                    variable_definitions,
                                 );
                                 NodeSelection::Connection(con_builder?)
                             }
@@ -1645,6 +1739,7 @@ where
                                     fragment_definitions,
                                     variables,
                                     &[],
+                                    variable_definitions,
                                 );
                                 NodeSelection::Node(node_builder?)
                             }
@@ -1875,6 +1970,7 @@ impl __Schema {
         query_field: &graphql_parser::query::Field<'a, T>,
         fragment_definitions: &Vec<FragmentDefinition<'a, T>>,
         variables: &serde_json::Value,
+        variable_definitions: &Vec<VariableDefinition<'a, T>>,
     ) -> Result<__InputValueBuilder, String>
     where
         T: Text<'a> + Eq + AsRef<str>,
@@ -1902,6 +1998,7 @@ impl __Schema {
                         selection_field,
                         fragment_definitions,
                         variables,
+                        variable_definitions,
                     )?;
                     __InputValueField::Type(t_builder)
                 }
@@ -1938,6 +2035,7 @@ impl __Schema {
         query_field: &graphql_parser::query::Field<'a, T>,
         fragment_definitions: &Vec<FragmentDefinition<'a, T>>,
         variables: &serde_json::Value,
+        variable_definitions: &Vec<VariableDefinition<'a, T>>,
     ) -> Result<__FieldBuilder, String>
     where
         T: Text<'a> + Eq + AsRef<str>,
@@ -1967,6 +2065,7 @@ impl __Schema {
                             selection_field,
                             fragment_definitions,
                             variables,
+                            variable_definitions,
                         )?;
                         f_builders.push(f_builder)
                     }
@@ -1980,6 +2079,7 @@ impl __Schema {
                         selection_field,
                         fragment_definitions,
                         variables,
+                        variable_definitions,
                     )?;
                     __FieldField::Type(t_builder)
                 }
@@ -2011,6 +2111,7 @@ impl __Schema {
         fragment_definitions: &Vec<FragmentDefinition<'a, T>>,
         mut type_name: Option<String>,
         variables: &serde_json::Value,
+        variable_definitions: &Vec<VariableDefinition<'a, T>>,
     ) -> Result<Option<__TypeBuilder>, String>
     where
         T: Text<'a> + Eq + AsRef<str>,
@@ -2020,7 +2121,7 @@ impl __Schema {
         }
 
         let name_arg_result: Result<gson::Value, String> =
-            read_argument("name", field, query_field, variables);
+            read_argument("name", field, query_field, variables, variable_definitions);
         let name_arg: Option<String> = match name_arg_result {
             // This builder (too) is overloaded and the arg is not present in all uses
             Err(_) => None,
@@ -2051,6 +2152,7 @@ impl __Schema {
                     query_field,
                     fragment_definitions,
                     variables,
+                    variable_definitions,
                 )
                 .map(Some)
             }
@@ -2064,6 +2166,7 @@ impl __Schema {
         query_field: &graphql_parser::query::Field<'a, T>,
         fragment_definitions: &Vec<FragmentDefinition<'a, T>>,
         variables: &serde_json::Value,
+        variable_definitions: &Vec<VariableDefinition<'a, T>>,
     ) -> Result<__TypeBuilder, String>
     where
         T: Text<'a> + Eq + AsRef<str>,
@@ -2110,6 +2213,7 @@ impl __Schema {
                                             selection_field,
                                             fragment_definitions,
                                             variables,
+                                            variable_definitions,
                                         )?;
                                         f_builders.push(f_builder)
                                     }
@@ -2130,6 +2234,7 @@ impl __Schema {
                                             selection_field,
                                             fragment_definitions,
                                             variables,
+                                            variable_definitions,
                                         )?;
                                         f_builders.push(f_builder)
                                     }
@@ -2147,6 +2252,7 @@ impl __Schema {
                                             selection_field,
                                             fragment_definitions,
                                             variables,
+                                            variable_definitions,
                                         )?;
                                         interface_builders.push(interface_builder);
                                     }
@@ -2186,6 +2292,7 @@ impl __Schema {
                                         selection_field,
                                         fragment_definitions,
                                         variables,
+                                        variable_definitions,
                                     )?;
 
                                     type_builders.push(type_builder);
@@ -2208,6 +2315,7 @@ impl __Schema {
                                         selection_field,
                                         fragment_definitions,
                                         variables,
+                                        variable_definitions,
                                     )?)
                                 }
                                 __Type::NonNull(non_null_type) => {
@@ -2217,6 +2325,7 @@ impl __Schema {
                                         selection_field,
                                         fragment_definitions,
                                         variables,
+                                        variable_definitions,
                                     )?)
                                 }
                                 _ => None,
@@ -2250,6 +2359,7 @@ impl __Schema {
         query_field: &graphql_parser::query::Field<'a, T>,
         fragment_definitions: &Vec<FragmentDefinition<'a, T>>,
         variables: &serde_json::Value,
+        variable_definitions: &Vec<VariableDefinition<'a, T>>,
     ) -> Result<__DirectiveBuilder, String>
     where
         T: Text<'a> + Eq + AsRef<str>,
@@ -2280,6 +2390,7 @@ impl __Schema {
                             selection_field,
                             fragment_definitions,
                             variables,
+                            variable_definitions,
                         )?;
                         builders.push(builder)
                     }
@@ -2317,6 +2428,7 @@ impl __Schema {
         query_field: &graphql_parser::query::Field<'a, T>,
         fragment_definitions: &Vec<FragmentDefinition<'a, T>>,
         variables: &serde_json::Value,
+        variable_definitions: &Vec<VariableDefinition<'a, T>>,
     ) -> Result<__SchemaBuilder, String>
     where
         T: Text<'a> + Eq + AsRef<str>,
@@ -2361,6 +2473,7 @@ impl __Schema {
                                                 fragment_definitions,
                                                 t.name(),
                                                 variables,
+                                                variable_definitions,
                                             )
                                             .map(|x| x.unwrap())
                                         })
@@ -2375,6 +2488,7 @@ impl __Schema {
                                         fragment_definitions,
                                         Some("Query".to_string()),
                                         variables,
+                                        variable_definitions,
                                     )?;
                                     __SchemaField::QueryType(builder.unwrap())
                                 }
@@ -2385,6 +2499,7 @@ impl __Schema {
                                         fragment_definitions,
                                         Some("Mutation".to_string()),
                                         variables,
+                                        variable_definitions,
                                     )?;
                                     __SchemaField::MutationType(builder)
                                 }
@@ -2399,6 +2514,7 @@ impl __Schema {
                                                 selection_field,
                                                 fragment_definitions,
                                                 variables,
+                                                variable_definitions,
                                             )
                                         })
                                         .collect::<Result<Vec<_>, _>>()?;

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -6,7 +6,7 @@ use crate::sql_types::get_one_readonly;
 use crate::transpile::{MutationEntrypoint, QueryEntrypoint};
 use graphql_parser::query::{
     Definition, Document, FragmentDefinition, Mutation, OperationDefinition, Query, SelectionSet,
-    Text,
+    Text, VariableDefinition,
 };
 use itertools::Itertools;
 use serde_json::{json, Value};
@@ -93,7 +93,7 @@ where
                 resolve_query(query, schema, variables, fragment_defs)
             }
             OperationDefinition::SelectionSet(selection_set) => {
-                resolve_selection_set(selection_set, schema, variables, fragment_defs)
+                resolve_selection_set(selection_set, schema, variables, fragment_defs, &vec![])
             }
             OperationDefinition::Mutation(mutation) => {
                 resolve_mutation(mutation, schema, variables, fragment_defs)
@@ -117,11 +117,13 @@ fn resolve_query<'a, 'b, T>(
 where
     T: Text<'a> + Eq + AsRef<str>,
 {
+    let variable_definitions = &query.variable_definitions;
     resolve_selection_set(
         query.selection_set,
         schema_type,
         variables,
         fragment_definitions,
+        variable_definitions,
     )
 }
 
@@ -130,6 +132,7 @@ fn resolve_selection_set<'a, 'b, T>(
     schema_type: &__Schema,
     variables: &Value,
     fragment_definitions: Vec<FragmentDefinition<'a, T>>,
+    variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> GraphQLResponse
 where
     T: Text<'a> + Eq + AsRef<str>,
@@ -190,6 +193,7 @@ where
                                 &fragment_definitions,
                                 variables,
                                 &[],
+                                variable_definitions,
                             );
 
                             match connection_builder {
@@ -209,6 +213,7 @@ where
                                 &fragment_definitions,
                                 variables,
                                 &[],
+                                variable_definitions,
                             );
 
                             match node_builder {
@@ -228,6 +233,7 @@ where
                                 &fragment_definitions,
                                 None,
                                 variables,
+                                variable_definitions,
                             );
 
                             match __type_builder {
@@ -243,6 +249,7 @@ where
                                 selection,
                                 &fragment_definitions,
                                 variables,
+                                variable_definitions,
                             );
 
                             match __schema_builder {
@@ -271,6 +278,7 @@ where
                                     selection,
                                     &fragment_definitions,
                                     variables,
+                                    variable_definitions,
                                 );
 
                                 match function_call_builder {
@@ -316,11 +324,13 @@ fn resolve_mutation<'a, 'b, T>(
 where
     T: Text<'a> + Eq + AsRef<str>,
 {
+    let variable_definitions = &query.variable_definitions;
     resolve_mutation_selection_set(
         query.selection_set,
         schema_type,
         variables,
         fragment_definitions,
+        variable_definitions,
     )
 }
 
@@ -329,6 +339,7 @@ fn resolve_mutation_selection_set<'a, 'b, T>(
     schema_type: &__Schema,
     variables: &Value,
     fragment_definitions: Vec<FragmentDefinition<'a, T>>,
+    variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> GraphQLResponse
 where
     T: Text<'a> + Eq + AsRef<str>,
@@ -391,6 +402,7 @@ where
                                     selection,
                                     &fragment_definitions,
                                     variables,
+                                    variable_definitions,
                                 ) {
                                     Ok(builder) => builder,
                                     Err(err) => {
@@ -409,6 +421,7 @@ where
                                     selection,
                                     &fragment_definitions,
                                     variables,
+                                    variable_definitions,
                                 ) {
                                     Ok(builder) => builder,
                                     Err(err) => {
@@ -426,6 +439,7 @@ where
                                     selection,
                                     &fragment_definitions,
                                     variables,
+                                    variable_definitions,
                                 ) {
                                     Ok(builder) => builder,
                                     Err(err) => {
@@ -449,6 +463,7 @@ where
                                         selection,
                                         &fragment_definitions,
                                         variables,
+                                        variable_definitions,
                                     ) {
                                         Ok(builder) => builder,
                                         Err(err) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?
When a user's query defines a default value, that value is currently ignored.

```graphql
  query Units($first: Int = 3) {
    unitsCollection(first: $first) { 
      edges {
        node {
          id
          name
          desc
        }}}}
```

This PR changes the behavior so that the user defined default is respected when no value is explicitly passed.

Order of precedence is:
- User provided value in a variable
- User provided default in operation definition
- Server side default value