### PR TITLE
replace regex with std alternative

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,7 +1105,6 @@ dependencies = [
  "pgrx",
  "pgrx-tests",
  "rand",
- "regex",
  "serde",
  "serde_json",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ itertools = "0.10.3"
 cached = "0.34.0"
 rand = "0.8"
 uuid = "1"
-regex = "1"
 base64 = "0.13"
 lazy_static = "1"
 bimap = { version = "0.6.3", features = ["serde"] }

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -2,19 +2,15 @@ use crate::sql_types::*;
 use cached::proc_macro::cached;
 use cached::SizedCache;
 use itertools::Itertools;
-use lazy_static::lazy_static;
-use regex::Regex;
 use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
 use std::sync::Arc;
 
-lazy_static! {
-    static ref GRAPHQL_NAME_RE: Regex = Regex::new("^[_A-Za-z][_0-9A-Za-z]*$").unwrap();
-}
-
 fn is_valid_graphql_name(name: &str) -> bool {
-    GRAPHQL_NAME_RE.is_match(name)
+    !name.is_empty()
+        && name.starts_with(|c: char| c == '_' || c.is_ascii_alphabetic())
+        && name.chars().all(|c| c == '_' || c.is_ascii_alphanumeric())
 }
 
 fn to_base_type_name(name: &str, name_override: &Option<String>, inflect_names: bool) -> String {


### PR DESCRIPTION
regex is a big dependency (adds over 1 MiB to the binary size) and it's completely unnecessary for such a simple check.