### PR TITLE
If a Function returns a table type, the table must be selectable

### DIFF
--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1284,8 +1284,18 @@ fn function_fields(schema: &Arc<__Schema>, volatilities: &[FunctionVolatility]) 
                                 return None;
                             }
                         }
-
                         gql_args.extend(connection_args);
+                    }
+
+                    // If the return type is a table type, it must be selectable
+                    if !match &return_type {
+                        __Type::Node(table_type) => table_type.table.permissions.is_selectable,
+                        __Type::Connection(table_type) => {
+                            table_type.table.permissions.is_selectable
+                        }
+                        _ => true,
+                    } {
+                        return None;
                     }
 
                     Some(__Field {

--- a/test/expected/function_return_row_is_selectable.out
+++ b/test/expected/function_return_row_is_selectable.out
@@ -1,0 +1,131 @@
+begin;
+    create table account(
+        id serial primary key,
+        email varchar(255) not null
+    );
+    create function returns_account()
+        returns account language sql stable
+    as $$ select id, email from account; $$;
+    insert into account(email)
+    values
+        ('aardvark@x.com');
+    create role anon;
+    grant usage on schema graphql to anon;
+    grant select on account to anon;
+    savepoint a;
+    set local role anon;
+    -- Should be visible
+    select jsonb_pretty(
+        graphql.resolve($$
+        {
+          __type(name: "Account") {
+            __typename
+          }
+        }
+        $$)
+    );
+            jsonb_pretty             
+-------------------------------------
+ {                                  +
+     "data": {                      +
+         "__type": {                +
+             "__typename": "Account"+
+         }                          +
+     }                              +
+ }
+(1 row)
+
+    -- Should show an entrypoint on Query for returnAccount
+    select jsonb_pretty(
+        graphql.resolve($$
+            query IntrospectionQuery {
+              __schema {
+                queryType {
+                  fields {
+                    name
+                  }
+                }
+              }
+            }
+        $$)
+    );
+                    jsonb_pretty                     
+-----------------------------------------------------
+ {                                                  +
+     "data": {                                      +
+         "__schema": {                              +
+             "queryType": {                         +
+                 "fields": [                        +
+                     {                              +
+                         "name": "accountCollection"+
+                     },                             +
+                     {                              +
+                         "name": "node"             +
+                     },                             +
+                     {                              +
+                         "name": "returnsAccount"   +
+                     }                              +
+                 ]                                  +
+             }                                      +
+         }                                          +
+     }                                              +
+ }
+(1 row)
+
+    rollback to a;
+    revoke select on account from anon;
+    set local role anon;
+    -- We should no longer see "Account" types after revoking access
+    select jsonb_pretty(
+        graphql.resolve($$
+        {
+          __type(name: "Account") {
+            __typename
+          }
+        }
+        $$)
+    );
+      jsonb_pretty      
+------------------------
+ {                     +
+     "data": {         +
+         "__type": null+
+     }                 +
+ }
+(1 row)
+
+    -- We should no longer see returnAccount since it references an unknown return type "Account"
+    select jsonb_pretty(
+        graphql.resolve($$
+            query IntrospectionQuery {
+              __schema {
+                queryType {
+                  fields {
+                    name
+                  }
+                }
+              }
+            }
+        $$)
+    );
+                   jsonb_pretty                   
+--------------------------------------------------
+ {                                               +
+     "data": {                                   +
+         "__schema": {                           +
+             "queryType": {                      +
+                 "fields": [                     +
+                     {                           +
+                         "name": "node"          +
+                     },                          +
+                     {                           +
+                         "name": "returnsAccount"+
+                     }                           +
+                 ]                               +
+             }                                   +
+         }                                       +
+     }                                           +
+ }
+(1 row)
+
+rollback;

--- a/test/expected/function_return_row_is_selectable.out
+++ b/test/expected/function_return_row_is_selectable.out
@@ -108,23 +108,20 @@ begin;
             }
         $$)
     );
-                   jsonb_pretty                   
---------------------------------------------------
- {                                               +
-     "data": {                                   +
-         "__schema": {                           +
-             "queryType": {                      +
-                 "fields": [                     +
-                     {                           +
-                         "name": "node"          +
-                     },                          +
-                     {                           +
-                         "name": "returnsAccount"+
-                     }                           +
-                 ]                               +
-             }                                   +
-         }                                       +
-     }                                           +
+              jsonb_pretty              
+----------------------------------------
+ {                                     +
+     "data": {                         +
+         "__schema": {                 +
+             "queryType": {            +
+                 "fields": [           +
+                     {                 +
+                         "name": "node"+
+                     }                 +
+                 ]                     +
+             }                         +
+         }                             +
+     }                                 +
  }
 (1 row)
 

--- a/test/sql/function_return_row_is_selectable.sql
+++ b/test/sql/function_return_row_is_selectable.sql
@@ -1,0 +1,82 @@
+begin;
+
+    create table account(
+        id serial primary key,
+        email varchar(255) not null
+    );
+
+    create function returns_account()
+        returns account language sql stable
+    as $$ select id, email from account; $$;
+
+    insert into account(email)
+    values
+        ('aardvark@x.com');
+
+
+    create role anon;
+    grant usage on schema graphql to anon;
+    grant select on account to anon;
+
+    savepoint a;
+
+    set local role anon;
+
+    -- Should be visible
+    select jsonb_pretty(
+        graphql.resolve($$
+        {
+          __type(name: "Account") {
+            __typename
+          }
+        }
+        $$)
+    );
+
+    -- Should show an entrypoint on Query for returnAccount
+    select jsonb_pretty(
+        graphql.resolve($$
+            query IntrospectionQuery {
+              __schema {
+                queryType {
+                  fields {
+                    name
+                  }
+                }
+              }
+            }
+        $$)
+    );
+
+    rollback to a;
+
+    revoke select on account from anon;
+    set local role anon;
+
+    -- We should no longer see "Account" types after revoking access
+    select jsonb_pretty(
+        graphql.resolve($$
+        {
+          __type(name: "Account") {
+            __typename
+          }
+        }
+        $$)
+    );
+
+    -- We should no longer see returnAccount since it references an unknown return type "Account"
+    select jsonb_pretty(
+        graphql.resolve($$
+            query IntrospectionQuery {
+              __schema {
+                queryType {
+                  fields {
+                    name
+                  }
+                }
+              }
+            }
+        $$)
+    );
+
+rollback;


### PR DESCRIPTION
## What kind of change does this PR introduce?
If a function returns a table type (single row or set of) the querying user must have select access to the table in order for the function to be visible in the GraphQL schema.

Otherwise, a function can make an invalid reference in the GraphQL type system to a Type that isn't present on the schema resulting in an error during introspection
```
Invalid or incomplete schema, unknown type: <ReferencedType>. Ensure that a full introspection query is used in order to build a client schema
```

This PR adds that check and tests the behavior.