### PR TITLE
fix a clippy warning

### DIFF
--- a/src/parser_util.rs
+++ b/src/parser_util.rs
@@ -259,8 +259,7 @@ where
                         variable_definitions
                             .iter()
                             .find(|var_def| var_def.name.as_ref() == var_name.as_ref())
-                            .map(|x| x.default_value.as_ref())
-                            .flatten();
+                            .and_then(|x| x.default_value.as_ref());
 
                     match variable_default {
                         Some(x) => to_gson(x, variables, variable_definitions)?,


### PR DESCRIPTION
Fixed a clippy warning about calling `map(...).flatten()`. Replaced the call with a call to `and_then(...)`.