### PR TITLE
fix: performance issue when database contains a lot of schemas

### DIFF
--- a/sql/load_sql_context.sql
+++ b/sql/load_sql_context.sql
@@ -95,6 +95,8 @@ select
                     pg_type pt
                     left join pg_class tabs
                         on pt.typrelid = tabs.oid
+                    join search_path_oids spo
+                        on pt.typnamespace = spo.schema_oid or pt.typnamespace = 'pg_catalog'::regnamespace::oid
             ),
             jsonb_build_object()
         ),
@@ -111,6 +113,8 @@ select
                     pg_type pt
                     join pg_class tabs
                         on pt.typrelid = tabs.oid
+                    join search_path_oids spo
+                        on pt.typnamespace = spo.schema_oid or pt.typnamespace = 'pg_catalog'::regnamespace::oid
                 where
                     pt.typcategory = 'C'
                     and tabs.relkind = 'c'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Performance issue

## What is the current behavior?

Currently, the query time increases linearly with the number of schemas in our system.

## What is the new behavior?

With the proposed changes, the query time remains constant, regardless of the number of schemas.

## Additional context

At [Twenty](https://github.com/twentyhq/twenty/pull/3204), we've identified a performance bottleneck in `pg_graphql` related to our multi-tenancy approach, which involves creating a separate schema for each workspace. In our production environment, which includes hundreds of schemas, we've noticed a significant slowdown in query performance.

Upon investigation, we found that the `types` and `composites` in `load_sql_context.sql` are being loaded for all schemas, rather than just the relevant schema. This seems to be the root cause of the performance issue.

We have identified a potential fix but are seeking additional insights and suggestions to refine our approach.