### PR TITLE
Reimplement field merging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,9 +751,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1040,6 +1040,7 @@ dependencies = [
  "bimap",
  "cached",
  "graphql-parser",
+ "indexmap",
  "itertools",
  "lazy_static",
  "pgrx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ uuid = "1"
 base64 = "0.13"
 lazy_static = "1"
 bimap = { version = "0.6.3", features = ["serde"] }
+indexmap = "2.2"
 
 [dev-dependencies]
 pgrx-tests = "=0.11.2"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -263,7 +263,7 @@ pub fn to_insert_builder<'a, T>(
     variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> Result<InsertBuilder, String>
 where
-    T: Text<'a> + Eq + AsRef<str>,
+    T: Text<'a> + Eq + AsRef<str> + Clone,
 {
     let type_ = field.type_().unmodified_type();
     let type_name = type_
@@ -294,12 +294,12 @@ where
                     None => return Err("unknown field in insert".to_string()),
                     Some(f) => builder_fields.push(match f.name().as_ref() {
                         "affectedCount" => InsertSelection::AffectedCount {
-                            alias: alias_or_name(selection_field),
+                            alias: alias_or_name(&selection_field),
                         },
                         "records" => {
                             let node_builder = to_node_builder(
                                 f,
-                                selection_field,
+                                &selection_field,
                                 fragment_definitions,
                                 variables,
                                 &[],
@@ -308,7 +308,7 @@ where
                             InsertSelection::Records(node_builder?)
                         }
                         "__typename" => InsertSelection::Typename {
-                            alias: alias_or_name(selection_field),
+                            alias: alias_or_name(&selection_field),
                             typename: xtype
                                 .name()
                                 .expect("insert response type should have a name"),
@@ -428,7 +428,7 @@ pub fn to_update_builder<'a, T>(
     variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> Result<UpdateBuilder, String>
 where
-    T: Text<'a> + Eq + AsRef<str>,
+    T: Text<'a> + Eq + AsRef<str> + Clone,
 {
     let type_ = field.type_().unmodified_type();
     let type_name = type_
@@ -463,12 +463,12 @@ where
                     None => return Err("unknown field in update".to_string()),
                     Some(f) => builder_fields.push(match f.name().as_ref() {
                         "affectedCount" => UpdateSelection::AffectedCount {
-                            alias: alias_or_name(selection_field),
+                            alias: alias_or_name(&selection_field),
                         },
                         "records" => {
                             let node_builder = to_node_builder(
                                 f,
-                                selection_field,
+                                &selection_field,
                                 fragment_definitions,
                                 variables,
                                 &[],
@@ -477,7 +477,7 @@ where
                             UpdateSelection::Records(node_builder?)
                         }
                         "__typename" => UpdateSelection::Typename {
-                            alias: alias_or_name(selection_field),
+                            alias: alias_or_name(&selection_field),
                             typename: xtype
                                 .name()
                                 .expect("update response type should have a name"),
@@ -533,7 +533,7 @@ pub fn to_delete_builder<'a, T>(
     variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> Result<DeleteBuilder, String>
 where
-    T: Text<'a> + Eq + AsRef<str>,
+    T: Text<'a> + Eq + AsRef<str> + Clone,
 {
     let type_ = field.type_().unmodified_type();
     let type_name = type_
@@ -566,12 +566,12 @@ where
                     None => return Err("unknown field in delete".to_string()),
                     Some(f) => builder_fields.push(match f.name().as_ref() {
                         "affectedCount" => DeleteSelection::AffectedCount {
-                            alias: alias_or_name(selection_field),
+                            alias: alias_or_name(&selection_field),
                         },
                         "records" => {
                             let node_builder = to_node_builder(
                                 f,
-                                selection_field,
+                                &selection_field,
                                 fragment_definitions,
                                 variables,
                                 &[],
@@ -580,7 +580,7 @@ where
                             DeleteSelection::Records(node_builder?)
                         }
                         "__typename" => DeleteSelection::Typename {
-                            alias: alias_or_name(selection_field),
+                            alias: alias_or_name(&selection_field),
                             typename: xtype
                                 .name()
                                 .expect("delete response type should have a name"),
@@ -642,7 +642,7 @@ pub fn to_function_call_builder<'a, T>(
     variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> Result<FunctionCallBuilder, String>
 where
-    T: Text<'a> + Eq + AsRef<str>,
+    T: Text<'a> + Eq + AsRef<str> + Clone,
 {
     let type_ = field.type_().unmodified_type();
     let alias = alias_or_name(query_field);
@@ -1336,7 +1336,7 @@ pub fn to_connection_builder<'a, T>(
     variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> Result<ConnectionBuilder, String>
 where
-    T: Text<'a> + Eq + AsRef<str>,
+    T: Text<'a> + Eq + AsRef<str> + Clone,
 {
     let type_ = field.type_().unmodified_type();
     let type_ = type_.return_type();
@@ -1453,24 +1453,24 @@ where
                     Some(f) => builder_fields.push(match &f.type_.unmodified_type() {
                         __Type::Edge(_) => ConnectionSelection::Edge(to_edge_builder(
                             f,
-                            selection_field,
+                            &selection_field,
                             fragment_definitions,
                             variables,
                             variable_definitions,
                         )?),
                         __Type::PageInfo(_) => ConnectionSelection::PageInfo(to_page_info_builder(
                             f,
-                            selection_field,
+                            &selection_field,
                             fragment_definitions,
                             variables,
                         )?),
 
                         _ => match f.name().as_ref() {
                             "totalCount" => ConnectionSelection::TotalCount {
-                                alias: alias_or_name(selection_field),
+                                alias: alias_or_name(&selection_field),
                             },
                             "__typename" => ConnectionSelection::Typename {
-                                alias: alias_or_name(selection_field),
+                                alias: alias_or_name(&selection_field),
                                 typename: xtype.name().expect("connection type should have a name"),
                             },
                             _ => return Err("unexpected field type on connection".to_string()),
@@ -1509,7 +1509,7 @@ fn to_page_info_builder<'a, T>(
     variables: &serde_json::Value,
 ) -> Result<PageInfoBuilder, String>
 where
-    T: Text<'a> + Eq + AsRef<str>,
+    T: Text<'a> + Eq + AsRef<str> + Clone,
 {
     let type_ = field.type_().unmodified_type();
     let type_name = type_.name().ok_or(format!(
@@ -1535,19 +1535,19 @@ where
                     None => return Err("unknown field in pageInfo".to_string()),
                     Some(f) => builder_fields.push(match f.name().as_ref() {
                         "startCursor" => PageInfoSelection::StartCursor {
-                            alias: alias_or_name(selection_field),
+                            alias: alias_or_name(&selection_field),
                         },
                         "endCursor" => PageInfoSelection::EndCursor {
-                            alias: alias_or_name(selection_field),
+                            alias: alias_or_name(&selection_field),
                         },
                         "hasPreviousPage" => PageInfoSelection::HasPreviousPage {
-                            alias: alias_or_name(selection_field),
+                            alias: alias_or_name(&selection_field),
                         },
                         "hasNextPage" => PageInfoSelection::HasNextPage {
-                            alias: alias_or_name(selection_field),
+                            alias: alias_or_name(&selection_field),
                         },
                         "__typename" => PageInfoSelection::Typename {
-                            alias: alias_or_name(selection_field),
+                            alias: alias_or_name(&selection_field),
                             typename: xtype.name().expect("page info type should have a name"),
                         },
                         _ => return Err("unexpected field type on pageInfo".to_string()),
@@ -1571,7 +1571,7 @@ fn to_edge_builder<'a, T>(
     variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> Result<EdgeBuilder, String>
 where
-    T: Text<'a> + Eq + AsRef<str>,
+    T: Text<'a> + Eq + AsRef<str> + Clone,
 {
     let type_ = field.type_().unmodified_type();
     let type_name = type_.name().ok_or(format!(
@@ -1599,7 +1599,7 @@ where
                         __Type::Node(_) => {
                             let node_builder = to_node_builder(
                                 f,
-                                selection_field,
+                                &selection_field,
                                 fragment_definitions,
                                 variables,
                                 &[],
@@ -1609,10 +1609,10 @@ where
                         }
                         _ => match f.name().as_ref() {
                             "cursor" => EdgeSelection::Cursor {
-                                alias: alias_or_name(selection_field),
+                                alias: alias_or_name(&selection_field),
                             },
                             "__typename" => EdgeSelection::Typename {
-                                alias: alias_or_name(selection_field),
+                                alias: alias_or_name(&selection_field),
                                 typename: xtype.name().expect("edge type should have a name"),
                             },
                             _ => return Err("unexpected field type on edge".to_string()),
@@ -1638,7 +1638,7 @@ pub fn to_node_builder<'a, T>(
     variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> Result<NodeBuilder, String>
 where
-    T: Text<'a> + Eq + AsRef<str>,
+    T: Text<'a> + Eq + AsRef<str> + Clone,
 {
     let type_ = field.type_().unmodified_type();
 
@@ -1722,7 +1722,7 @@ where
                 ))
             }
             Some(f) => {
-                let alias = alias_or_name(selection_field);
+                let alias = alias_or_name(&selection_field);
 
                 let node_selection = match &f.sql_type {
                     Some(node_sql_type) => match node_sql_type {
@@ -1737,7 +1737,7 @@ where
                                 __Type::Node(_) => {
                                     let node_builder = to_node_builder(
                                         f,
-                                        selection_field,
+                                        &selection_field,
                                         fragment_definitions,
                                         variables,
                                         &[],
@@ -1749,7 +1749,7 @@ where
                                 __Type::Connection(_) => {
                                     let connection_builder = to_connection_builder(
                                         f,
-                                        selection_field,
+                                        &selection_field,
                                         fragment_definitions,
                                         variables,
                                         &[], // TODO need ref to fkey here
@@ -1777,14 +1777,14 @@ where
                     },
                     _ => match f.name().as_ref() {
                         "__typename" => NodeSelection::Typename {
-                            alias: alias_or_name(selection_field),
+                            alias: alias_or_name(&selection_field),
                             typename: xtype.name().expect("node type should have a name"),
                         },
                         _ => match f.type_().unmodified_type() {
                             __Type::Connection(_) => {
                                 let con_builder = to_connection_builder(
                                     f,
-                                    selection_field,
+                                    &selection_field,
                                     fragment_definitions,
                                     variables,
                                     &[],
@@ -1795,7 +1795,7 @@ where
                             __Type::Node(_) => {
                                 let node_builder = to_node_builder(
                                     f,
-                                    selection_field,
+                                    &selection_field,
                                     fragment_definitions,
                                     variables,
                                     &[],
@@ -1981,7 +1981,7 @@ impl __Schema {
         variables: &serde_json::Value,
     ) -> Result<__EnumValueBuilder, String>
     where
-        T: Text<'a> + Eq + AsRef<str>,
+        T: Text<'a> + Eq + AsRef<str> + Clone,
     {
         let selection_fields = normalize_selection_set(
             &query_field.selection_set,
@@ -2001,7 +2001,7 @@ impl __Schema {
                 "isDeprecated" => __EnumValueField::IsDeprecated,
                 "deprecationReason" => __EnumValueField::DeprecationReason,
                 "__typename" => __EnumValueField::Typename {
-                    alias: alias_or_name(selection_field),
+                    alias: alias_or_name(&selection_field),
                     typename: enum_value.name(),
                 },
                 _ => {
@@ -2013,7 +2013,7 @@ impl __Schema {
             };
 
             builder_fields.push(__EnumValueSelection {
-                alias: alias_or_name(selection_field),
+                alias: alias_or_name(&selection_field),
                 selection: __enum_value_field,
             });
         }
@@ -2033,7 +2033,7 @@ impl __Schema {
         variable_definitions: &Vec<VariableDefinition<'a, T>>,
     ) -> Result<__InputValueBuilder, String>
     where
-        T: Text<'a> + Eq + AsRef<str>,
+        T: Text<'a> + Eq + AsRef<str> + Clone,
     {
         let selection_fields = normalize_selection_set(
             &query_field.selection_set,
@@ -2055,7 +2055,7 @@ impl __Schema {
 
                     let t_builder = self.to_type_builder_from_type(
                         &t,
-                        selection_field,
+                        &selection_field,
                         fragment_definitions,
                         variables,
                         variable_definitions,
@@ -2066,7 +2066,7 @@ impl __Schema {
                 "isDeprecated" => __InputValueField::IsDeprecated,
                 "deprecationReason" => __InputValueField::DeprecationReason,
                 "__typename" => __InputValueField::Typename {
-                    alias: alias_or_name(selection_field),
+                    alias: alias_or_name(&selection_field),
                     typename: input_value.name(),
                 },
                 _ => {
@@ -2078,7 +2078,7 @@ impl __Schema {
             };
 
             builder_fields.push(__InputValueSelection {
-                alias: alias_or_name(selection_field),
+                alias: alias_or_name(&selection_field),
                 selection: __input_value_field,
             });
         }
@@ -2098,7 +2098,7 @@ impl __Schema {
         variable_definitions: &Vec<VariableDefinition<'a, T>>,
     ) -> Result<__FieldBuilder, String>
     where
-        T: Text<'a> + Eq + AsRef<str>,
+        T: Text<'a> + Eq + AsRef<str> + Clone,
     {
         let selection_fields = normalize_selection_set(
             &query_field.selection_set,
@@ -2122,7 +2122,7 @@ impl __Schema {
                     for arg in args {
                         let f_builder = self.to_input_value_builder(
                             &arg,
-                            selection_field,
+                            &selection_field,
                             fragment_definitions,
                             variables,
                             variable_definitions,
@@ -2136,7 +2136,7 @@ impl __Schema {
 
                     let t_builder = self.to_type_builder_from_type(
                         &t,
-                        selection_field,
+                        &selection_field,
                         fragment_definitions,
                         variables,
                         variable_definitions,
@@ -2146,14 +2146,14 @@ impl __Schema {
                 "isDeprecated" => __FieldField::IsDeprecated,
                 "deprecationReason" => __FieldField::DeprecationReason,
                 "__typename" => __FieldField::Typename {
-                    alias: alias_or_name(selection_field),
+                    alias: alias_or_name(&selection_field),
                     typename: field.name(),
                 },
                 _ => return Err(format!("unknown field in __Field {}", type_field_name)),
             };
 
             builder_fields.push(__FieldSelection {
-                alias: alias_or_name(selection_field),
+                alias: alias_or_name(&selection_field),
                 selection: __field_field,
             });
         }
@@ -2174,7 +2174,7 @@ impl __Schema {
         variable_definitions: &Vec<VariableDefinition<'a, T>>,
     ) -> Result<Option<__TypeBuilder>, String>
     where
-        T: Text<'a> + Eq + AsRef<str>,
+        T: Text<'a> + Eq + AsRef<str> + Clone,
     {
         if field.type_.unmodified_type() != __Type::__Type(__TypeType {}) {
             return Err("can not build query for non-__type type".to_string());
@@ -2226,7 +2226,7 @@ impl __Schema {
         variable_definitions: &Vec<VariableDefinition<'a, T>>,
     ) -> Result<__TypeBuilder, String>
     where
-        T: Text<'a> + Eq + AsRef<str>,
+        T: Text<'a> + Eq + AsRef<str> + Clone,
     {
         let field_map = field_map(&__Type::__Type(__TypeType {}));
 
@@ -2245,7 +2245,7 @@ impl __Schema {
             match field_map.get(type_field_name) {
                 None => return Err(format!("unknown field on __Type: {}", type_field_name)),
                 Some(f) => builder_fields.push(__TypeSelection {
-                    alias: alias_or_name(selection_field),
+                    alias: alias_or_name(&selection_field),
                     selection: match f.name().as_str() {
                         "kind" => __TypeField::Kind,
                         "name" => __TypeField::Name,
@@ -2267,7 +2267,7 @@ impl __Schema {
 
                                         let f_builder = self.to_field_builder(
                                             &vec_field,
-                                            selection_field,
+                                            &selection_field,
                                             fragment_definitions,
                                             variables,
                                             variable_definitions,
@@ -2288,7 +2288,7 @@ impl __Schema {
                                     for vec_field in vec_fields {
                                         let f_builder = self.to_input_value_builder(
                                             &vec_field,
-                                            selection_field,
+                                            &selection_field,
                                             fragment_definitions,
                                             variables,
                                             variable_definitions,
@@ -2306,7 +2306,7 @@ impl __Schema {
                                     for interface in &interfaces {
                                         let interface_builder = self.to_type_builder_from_type(
                                             interface,
-                                            selection_field,
+                                            &selection_field,
                                             fragment_definitions,
                                             variables,
                                             variable_definitions,
@@ -2328,7 +2328,7 @@ impl __Schema {
                                     for enum_value in &enum_values {
                                         let f_builder = self.to_enum_value_builder(
                                             enum_value,
-                                            selection_field,
+                                            &selection_field,
                                             fragment_definitions,
                                             variables,
                                         )?;
@@ -2346,7 +2346,7 @@ impl __Schema {
                                 for ty in &types {
                                     let type_builder = self.to_type_builder_from_type(
                                         ty,
-                                        selection_field,
+                                        &selection_field,
                                         fragment_definitions,
                                         variables,
                                         variable_definitions,
@@ -2370,7 +2370,7 @@ impl __Schema {
                                     let inner_type: __Type = (*(list_type.type_)).clone();
                                     Some(self.to_type_builder_from_type(
                                         &inner_type,
-                                        selection_field,
+                                        &selection_field,
                                         fragment_definitions,
                                         variables,
                                         variable_definitions,
@@ -2380,7 +2380,7 @@ impl __Schema {
                                     let inner_type = (*(non_null_type.type_)).clone();
                                     Some(self.to_type_builder_from_type(
                                         &inner_type,
-                                        selection_field,
+                                        &selection_field,
                                         fragment_definitions,
                                         variables,
                                         variable_definitions,
@@ -2391,7 +2391,7 @@ impl __Schema {
                             __TypeField::OfType(unwrapped_type_builder)
                         }
                         "__typename" => __TypeField::Typename {
-                            alias: alias_or_name(selection_field),
+                            alias: alias_or_name(&selection_field),
                             typename: type_.name(),
                         },
                         _ => {
@@ -2420,7 +2420,7 @@ impl __Schema {
         variable_definitions: &Vec<VariableDefinition<'a, T>>,
     ) -> Result<__DirectiveBuilder, String>
     where
-        T: Text<'a> + Eq + AsRef<str>,
+        T: Text<'a> + Eq + AsRef<str> + Clone,
     {
         let selection_fields = normalize_selection_set(
             &query_field.selection_set,
@@ -2445,7 +2445,7 @@ impl __Schema {
                     for arg in args {
                         let builder = self.to_input_value_builder(
                             arg,
-                            selection_field,
+                            &selection_field,
                             fragment_definitions,
                             variables,
                             variable_definitions,
@@ -2456,7 +2456,7 @@ impl __Schema {
                 }
                 "isRepeatable" => __DirectiveField::IsRepeatable,
                 "__typename" => __DirectiveField::Typename {
-                    alias: alias_or_name(selection_field),
+                    alias: alias_or_name(&selection_field),
                     typename: __Directive::TYPE.to_string(),
                 },
                 _ => {
@@ -2469,7 +2469,7 @@ impl __Schema {
             };
 
             builder_fields.push(__DirectiveSelection {
-                alias: alias_or_name(selection_field),
+                alias: alias_or_name(&selection_field),
                 selection: directive_field,
             });
         }
@@ -2489,7 +2489,7 @@ impl __Schema {
         variable_definitions: &Vec<VariableDefinition<'a, T>>,
     ) -> Result<__SchemaBuilder, String>
     where
-        T: Text<'a> + Eq + AsRef<str>,
+        T: Text<'a> + Eq + AsRef<str> + Clone,
     {
         let type_ = field.type_.unmodified_type();
         let type_name = type_
@@ -2515,7 +2515,7 @@ impl __Schema {
                         None => return Err(format!("unknown field in __Schema: {}", field_name)),
                         Some(f) => {
                             builder_fields.push(__SchemaSelection {
-                                alias: alias_or_name(selection_field),
+                                alias: alias_or_name(&selection_field),
                                 selection: match f.name().as_str() {
                                     "types" => {
                                         let builders = self
@@ -2586,7 +2586,7 @@ impl __Schema {
                                         __SchemaField::Directives(builders)
                                     }
                                     "__typename" => __SchemaField::Typename {
-                                        alias: alias_or_name(selection_field),
+                                        alias: alias_or_name(&selection_field),
                                         typename: field.name(),
                                     },
                                     _ => {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5,6 +5,7 @@ use crate::sql_types::*;
 use graphql_parser::query::*;
 use serde::Serialize;
 use std::collections::HashMap;
+use std::hash::Hash;
 use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -264,6 +265,7 @@ pub fn to_insert_builder<'a, T>(
 ) -> Result<InsertBuilder, String>
 where
     T: Text<'a> + Eq + AsRef<str> + Clone,
+    T::Value: Hash,
 {
     let type_ = field.type_().unmodified_type();
     let type_name = type_
@@ -429,6 +431,7 @@ pub fn to_update_builder<'a, T>(
 ) -> Result<UpdateBuilder, String>
 where
     T: Text<'a> + Eq + AsRef<str> + Clone,
+    T::Value: Hash,
 {
     let type_ = field.type_().unmodified_type();
     let type_name = type_
@@ -534,6 +537,7 @@ pub fn to_delete_builder<'a, T>(
 ) -> Result<DeleteBuilder, String>
 where
     T: Text<'a> + Eq + AsRef<str> + Clone,
+    T::Value: Hash,
 {
     let type_ = field.type_().unmodified_type();
     let type_name = type_
@@ -643,6 +647,7 @@ pub fn to_function_call_builder<'a, T>(
 ) -> Result<FunctionCallBuilder, String>
 where
     T: Text<'a> + Eq + AsRef<str> + Clone,
+    T::Value: Hash,
 {
     let type_ = field.type_().unmodified_type();
     let alias = alias_or_name(query_field);
@@ -1337,6 +1342,7 @@ pub fn to_connection_builder<'a, T>(
 ) -> Result<ConnectionBuilder, String>
 where
     T: Text<'a> + Eq + AsRef<str> + Clone,
+    T::Value: Hash,
 {
     let type_ = field.type_().unmodified_type();
     let type_ = type_.return_type();
@@ -1510,6 +1516,7 @@ fn to_page_info_builder<'a, T>(
 ) -> Result<PageInfoBuilder, String>
 where
     T: Text<'a> + Eq + AsRef<str> + Clone,
+    T::Value: Hash,
 {
     let type_ = field.type_().unmodified_type();
     let type_name = type_.name().ok_or(format!(
@@ -1572,6 +1579,7 @@ fn to_edge_builder<'a, T>(
 ) -> Result<EdgeBuilder, String>
 where
     T: Text<'a> + Eq + AsRef<str> + Clone,
+    T::Value: Hash,
 {
     let type_ = field.type_().unmodified_type();
     let type_name = type_.name().ok_or(format!(
@@ -1639,6 +1647,7 @@ pub fn to_node_builder<'a, T>(
 ) -> Result<NodeBuilder, String>
 where
     T: Text<'a> + Eq + AsRef<str> + Clone,
+    T::Value: Hash,
 {
     let type_ = field.type_().unmodified_type();
 
@@ -1982,6 +1991,7 @@ impl __Schema {
     ) -> Result<__EnumValueBuilder, String>
     where
         T: Text<'a> + Eq + AsRef<str> + Clone,
+        T::Value: Hash,
     {
         let selection_fields = normalize_selection_set(
             &query_field.selection_set,
@@ -2034,6 +2044,7 @@ impl __Schema {
     ) -> Result<__InputValueBuilder, String>
     where
         T: Text<'a> + Eq + AsRef<str> + Clone,
+        T::Value: Hash,
     {
         let selection_fields = normalize_selection_set(
             &query_field.selection_set,
@@ -2099,6 +2110,7 @@ impl __Schema {
     ) -> Result<__FieldBuilder, String>
     where
         T: Text<'a> + Eq + AsRef<str> + Clone,
+        T::Value: Hash,
     {
         let selection_fields = normalize_selection_set(
             &query_field.selection_set,
@@ -2175,6 +2187,7 @@ impl __Schema {
     ) -> Result<Option<__TypeBuilder>, String>
     where
         T: Text<'a> + Eq + AsRef<str> + Clone,
+        T::Value: Hash,
     {
         if field.type_.unmodified_type() != __Type::__Type(__TypeType {}) {
             return Err("can not build query for non-__type type".to_string());
@@ -2227,6 +2240,7 @@ impl __Schema {
     ) -> Result<__TypeBuilder, String>
     where
         T: Text<'a> + Eq + AsRef<str> + Clone,
+        T::Value: Hash,
     {
         let field_map = field_map(&__Type::__Type(__TypeType {}));
 
@@ -2421,6 +2435,7 @@ impl __Schema {
     ) -> Result<__DirectiveBuilder, String>
     where
         T: Text<'a> + Eq + AsRef<str> + Clone,
+        T::Value: Hash,
     {
         let selection_fields = normalize_selection_set(
             &query_field.selection_set,
@@ -2490,6 +2505,7 @@ impl __Schema {
     ) -> Result<__SchemaBuilder, String>
     where
         T: Text<'a> + Eq + AsRef<str> + Clone,
+        T::Value: Hash,
     {
         let type_ = field.type_.unmodified_type();
         let type_name = type_

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use serde_json::json;
 mod builder;
 mod graphql;
 mod gson;
+pub mod merge;
 mod omit;
 mod parser_util;
 mod resolve;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use serde_json::json;
 mod builder;
 mod graphql;
 mod gson;
-pub mod merge;
+mod merge;
 mod omit;
 mod parser_util;
 mod resolve;

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -3,6 +3,13 @@ use indexmap::IndexMap;
 
 use crate::parser_util::alias_or_name;
 
+/// Merges duplicates in a vector of fields. The fields in the vector are added to a
+/// map from field name to field. If a field with the same name already exists in the
+/// map, the existing and new fields' children are combined into the existing field's
+/// children. These children will be merged later when they are normalized.
+///
+/// The map is an `IndexMap` to ensure iteration order of the fields is preserved.
+/// This prevents tests from being flaky due to field order changing between test runs.
 pub fn merge<'a, 'b, T>(fields: Vec<Field<'a, T>>) -> Result<Vec<Field<'a, T>>, String>
 where
     T: Text<'a> + Eq + AsRef<str>,

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1,3 +1,5 @@
+use std::{collections::HashMap, hash::Hash};
+
 use graphql_parser::query::{Field, Text, Value};
 use indexmap::IndexMap;
 
@@ -5,7 +7,7 @@ use crate::parser_util::alias_or_name;
 
 /// Merges duplicates in a vector of fields. The fields in the vector are added to a
 /// map from field name to field. If a field with the same name already exists in the
-/// map, the existing and new fields' children are combined into the existing field's
+/// map, the existing and new field's children are combined into the existing field's
 /// children. These children will be merged later when they are normalized.
 ///
 /// The map is an `IndexMap` to ensure iteration order of the fields is preserved.
@@ -13,6 +15,7 @@ use crate::parser_util::alias_or_name;
 pub fn merge<'a, 'b, T>(fields: Vec<Field<'a, T>>) -> Result<Vec<Field<'a, T>>, String>
 where
     T: Text<'a> + Eq + AsRef<str>,
+    T::Value: Hash,
 {
     let mut merged: IndexMap<String, Field<'a, T>> = IndexMap::new();
 
@@ -41,6 +44,7 @@ where
 fn can_merge<'a, T>(field_a: &Field<'a, T>, field_b: &Field<'a, T>) -> Result<bool, String>
 where
     T: Text<'a> + Eq + AsRef<str>,
+    T::Value: Hash,
 {
     if field_a.name != field_b.name {
         return Err(format!(
@@ -59,24 +63,81 @@ where
     Ok(true)
 }
 
+/// Compares two sets of arguments and returns true only if
+/// both are the same. `arguments_a` should not have two
+/// arguments with the same name. Similarly `arguments_b`
+/// should not have duplicates. It is assumed that [Argument
+/// Uniqueness] validation has already been run by the time
+/// this function is called.
+///
+/// [Argument Uniqueness]: https://spec.graphql.org/October2021/#sec-Argument-Uniqueness
 fn same_arguments<'a, 'b, T>(
     arguments_a: &[(T::Value, Value<'a, T>)],
     arguments_b: &[(T::Value, Value<'a, T>)],
 ) -> bool
 where
     T: Text<'a> + Eq + AsRef<str>,
+    T::Value: Hash,
 {
     if arguments_a.len() != arguments_b.len() {
         return false;
     }
 
+    let mut arguments_a_map = HashMap::new();
     for (arg_a_name, arg_a_val) in arguments_a {
-        for (arg_b_name, arg_b_val) in arguments_b {
-            if arg_a_name == arg_b_name && arg_a_val != arg_b_val {
-                return false;
+        arguments_a_map.insert(arg_a_name, arg_a_val);
+    }
+
+    for (arg_b_name, arg_b_val) in arguments_b {
+        match arguments_a_map.get(arg_b_name) {
+            Some(arg_a_val) => {
+                if *arg_a_val != arg_b_val {
+                    return false;
+                }
             }
+            None => return false,
         }
     }
 
     true
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::same_arguments;
+    use graphql_parser::query::Value;
+
+    #[test]
+    fn same_args_test() {
+        let arguments_a = vec![("a", Value::Int(1.into()))];
+        let arguments_b = vec![("a", Value::Int(1.into()))];
+        let result = same_arguments::<&str>(&arguments_a, &arguments_b);
+        assert!(result);
+
+        let arguments_a = vec![("a", Value::Int(1.into())), ("b", Value::Int(2.into()))];
+        let arguments_b = vec![("a", Value::Int(1.into())), ("b", Value::Int(2.into()))];
+        let result = same_arguments::<&str>(&arguments_a, &arguments_b);
+        assert!(result);
+
+        let arguments_a = vec![("a", Value::Int(1.into())), ("b", Value::Int(2.into()))];
+        let arguments_b = vec![("b", Value::Int(2.into())), ("a", Value::Int(1.into()))];
+        let result = same_arguments::<&str>(&arguments_a, &arguments_b);
+        assert!(result);
+
+        let arguments_a = vec![("a", Value::Int(1.into()))];
+        let arguments_b = vec![("a", Value::Int(2.into()))];
+        let result = same_arguments::<&str>(&arguments_a, &arguments_b);
+        assert!(!result);
+
+        let arguments_a = vec![("a", Value::Int(1.into())), ("b", Value::Int(1.into()))];
+        let arguments_b = vec![("a", Value::Int(1.into()))];
+        let result = same_arguments::<&str>(&arguments_a, &arguments_b);
+        assert!(!result);
+
+        let arguments_a = vec![("a", Value::Int(1.into()))];
+        let arguments_b = vec![("b", Value::Int(1.into()))];
+        let result = same_arguments::<&str>(&arguments_a, &arguments_b);
+        assert!(!result);
+    }
 }

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -22,9 +22,8 @@ where
                 }
                 if !same_arguments(&current_field.arguments, &existing_field.arguments) {
                     return Err(format!(
-                        "Fields `{}` and `{}` are have different arguments",
+                        "Two fields named `{}` have different arguments",
                         current_field.name.as_ref(),
-                        existing_field.name.as_ref(),
                     ));
                 }
                 existing_field

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -3,25 +3,25 @@ use indexmap::IndexMap;
 
 use crate::parser_util::alias_or_name;
 
-pub fn merge<'a, 'b, T>(fields: &[Field<'a, T>]) -> Result<Vec<Field<'a, T>>, String>
+pub fn merge<'a, 'b, T>(fields: Vec<Field<'a, T>>) -> Result<Vec<Field<'a, T>>, String>
 where
-    T: Text<'a> + Eq + AsRef<str> + Clone,
+    T: Text<'a> + Eq + AsRef<str>,
 {
     let mut merged: IndexMap<String, Field<'a, T>> = IndexMap::new();
 
     for current_field in fields {
-        let response_key = alias_or_name(current_field);
+        let response_key = alias_or_name(&current_field);
         match merged.get_mut(&response_key) {
             Some(existing_field) => {
-                if can_merge(current_field, existing_field)? {
+                if can_merge(&current_field, existing_field)? {
                     existing_field
                         .selection_set
                         .items
-                        .extend(current_field.selection_set.items.iter().cloned());
+                        .extend(current_field.selection_set.items);
                 }
             }
             None => {
-                merged.insert(response_key, (*current_field).clone());
+                merged.insert(response_key, current_field);
             }
         }
     }

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
-
 use graphql_parser::query::{Field, Text};
+use indexmap::IndexMap;
 
 use crate::parser_util::alias_or_name;
 
@@ -8,7 +7,7 @@ pub fn merge<'a, 'b, T>(fields: &[Field<'a, T>]) -> Result<Vec<Field<'a, T>>, St
 where
     T: Text<'a> + Eq + AsRef<str> + Clone,
 {
-    let mut merged: HashMap<String, Field<'a, T>> = HashMap::new();
+    let mut merged: IndexMap<String, Field<'a, T>> = IndexMap::new();
 
     for current_field in fields {
         let response_key = alias_or_name(current_field);

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1,0 +1,35 @@
+use std::collections::HashMap;
+
+use graphql_parser::query::{Field, Text};
+
+use crate::parser_util::alias_or_name;
+
+pub fn merge<'a, 'b, T>(fields: &[Field<'a, T>]) -> Result<Vec<Field<'a, T>>, String>
+where
+    T: Text<'a> + Eq + AsRef<str> + Clone,
+{
+    let mut merged: HashMap<String, Field<'a, T>> = HashMap::new();
+
+    for current_field in fields {
+        let response_key = alias_or_name(current_field);
+        match merged.get_mut(&response_key) {
+            Some(existing_field) => {
+                existing_field
+                    .selection_set
+                    .items
+                    .extend(current_field.selection_set.items.iter().cloned());
+            }
+            None => {
+                merged.insert(response_key, (*current_field).clone());
+            }
+        }
+    }
+
+    let mut fields = vec![];
+
+    for (_, field) in merged {
+        fields.push(field);
+    }
+
+    Ok(fields)
+}

--- a/src/parser_util.rs
+++ b/src/parser_util.rs
@@ -32,7 +32,7 @@ where
             Err(err) => return Err(err),
         }
     }
-    let selections = merge(&selections)?;
+    let selections = merge(selections)?;
     Ok(selections)
 }
 

--- a/src/parser_util.rs
+++ b/src/parser_util.rs
@@ -1,5 +1,5 @@
 use crate::graphql::{EnumSource, __InputValue, __Type, ___Type};
-use crate::gson;
+use crate::{gson, merge::merge};
 use graphql_parser::query::*;
 use std::collections::HashMap;
 
@@ -19,11 +19,11 @@ pub fn normalize_selection_set<'a, 'b, T>(
     fragment_definitions: &'b Vec<FragmentDefinition<'a, T>>,
     type_name: &String,            // for inline fragments
     variables: &serde_json::Value, // for directives
-) -> Result<Vec<&'b Field<'a, T>>, String>
+) -> Result<Vec<Field<'a, T>>, String>
 where
-    T: Text<'a> + Eq + AsRef<str>,
+    T: Text<'a> + Eq + AsRef<str> + Clone,
 {
-    let mut selections: Vec<&'b Field<'a, T>> = vec![];
+    let mut selections: Vec<Field<'a, T>> = vec![];
 
     for selection in &selection_set.items {
         let sel = selection;
@@ -32,6 +32,7 @@ where
             Err(err) => return Err(err),
         }
     }
+    let selections = merge(&selections)?;
     Ok(selections)
 }
 
@@ -135,11 +136,11 @@ pub fn normalize_selection<'a, 'b, T>(
     fragment_definitions: &'b Vec<FragmentDefinition<'a, T>>,
     type_name: &String,            // for inline fragments
     variables: &serde_json::Value, // for directives
-) -> Result<Vec<&'b Field<'a, T>>, String>
+) -> Result<Vec<Field<'a, T>>, String>
 where
-    T: Text<'a> + Eq + AsRef<str>,
+    T: Text<'a> + Eq + AsRef<str> + Clone,
 {
-    let mut selections: Vec<&Field<'a, T>> = vec![];
+    let mut selections: Vec<Field<'a, T>> = vec![];
 
     if selection_is_skipped(query_selection, variables)? {
         return Ok(selections);
@@ -147,7 +148,7 @@ where
 
     match query_selection {
         Selection::Field(field) => {
-            selections.push(field);
+            selections.push(field.clone());
         }
         Selection::FragmentSpread(fragment_spread) => {
             let frag_name = &fragment_spread.fragment_name;
@@ -180,7 +181,7 @@ where
                 variables,
             );
             match frag_selections {
-                Ok(sels) => selections.extend(sels.iter()),
+                Ok(sels) => selections.extend(sels),
                 Err(err) => return Err(err),
             };
         }
@@ -199,7 +200,7 @@ where
                     type_name,
                     variables,
                 )?;
-                selections.extend(infrag_selections.iter());
+                selections.extend(infrag_selections);
             }
         }
     }

--- a/src/parser_util.rs
+++ b/src/parser_util.rs
@@ -2,6 +2,7 @@ use crate::graphql::{EnumSource, __InputValue, __Type, ___Type};
 use crate::{gson, merge::merge};
 use graphql_parser::query::*;
 use std::collections::HashMap;
+use std::hash::Hash;
 
 pub fn alias_or_name<'a, T>(query_field: &graphql_parser::query::Field<'a, T>) -> String
 where
@@ -22,6 +23,7 @@ pub fn normalize_selection_set<'a, 'b, T>(
 ) -> Result<Vec<Field<'a, T>>, String>
 where
     T: Text<'a> + Eq + AsRef<str> + Clone,
+    T::Value: Hash,
 {
     let mut selections: Vec<Field<'a, T>> = vec![];
 
@@ -139,6 +141,7 @@ pub fn normalize_selection<'a, 'b, T>(
 ) -> Result<Vec<Field<'a, T>>, String>
 where
     T: Text<'a> + Eq + AsRef<str> + Clone,
+    T::Value: Hash,
 {
     let mut selections: Vec<Field<'a, T>> = vec![];
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -22,7 +22,7 @@ pub fn resolve_inner<'a, T>(
     schema: &__Schema,
 ) -> GraphQLResponse
 where
-    T: Text<'a> + Eq + AsRef<str>,
+    T: Text<'a> + Eq + AsRef<str> + Clone,
 {
     match variables {
         serde_json::Value::Object(_) => (),
@@ -130,7 +130,7 @@ fn resolve_query<'a, 'b, T>(
     fragment_definitions: Vec<FragmentDefinition<'a, T>>,
 ) -> GraphQLResponse
 where
-    T: Text<'a> + Eq + AsRef<str>,
+    T: Text<'a> + Eq + AsRef<str> + Clone,
 {
     let variable_definitions = &query.variable_definitions;
     resolve_selection_set(
@@ -150,7 +150,7 @@ fn resolve_selection_set<'a, 'b, T>(
     variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> GraphQLResponse
 where
-    T: Text<'a> + Eq + AsRef<str>,
+    T: Text<'a> + Eq + AsRef<str> + Clone,
 {
     use crate::graphql::*;
 
@@ -337,7 +337,7 @@ fn resolve_mutation<'a, 'b, T>(
     fragment_definitions: Vec<FragmentDefinition<'a, T>>,
 ) -> GraphQLResponse
 where
-    T: Text<'a> + Eq + AsRef<str>,
+    T: Text<'a> + Eq + AsRef<str> + Clone,
 {
     let variable_definitions = &query.variable_definitions;
     resolve_mutation_selection_set(
@@ -357,7 +357,7 @@ fn resolve_mutation_selection_set<'a, 'b, T>(
     variable_definitions: &Vec<VariableDefinition<'a, T>>,
 ) -> GraphQLResponse
 where
-    T: Text<'a> + Eq + AsRef<str>,
+    T: Text<'a> + Eq + AsRef<str> + Clone,
 {
     use crate::graphql::*;
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::hash::Hash;
 
 use crate::builder::*;
 use crate::graphql::*;
@@ -23,6 +24,7 @@ pub fn resolve_inner<'a, T>(
 ) -> GraphQLResponse
 where
     T: Text<'a> + Eq + AsRef<str> + Clone,
+    T::Value: Hash,
 {
     match variables {
         serde_json::Value::Object(_) => (),
@@ -131,6 +133,7 @@ fn resolve_query<'a, 'b, T>(
 ) -> GraphQLResponse
 where
     T: Text<'a> + Eq + AsRef<str> + Clone,
+    T::Value: Hash,
 {
     let variable_definitions = &query.variable_definitions;
     resolve_selection_set(
@@ -151,6 +154,7 @@ fn resolve_selection_set<'a, 'b, T>(
 ) -> GraphQLResponse
 where
     T: Text<'a> + Eq + AsRef<str> + Clone,
+    T::Value: Hash,
 {
     use crate::graphql::*;
 
@@ -338,6 +342,7 @@ fn resolve_mutation<'a, 'b, T>(
 ) -> GraphQLResponse
 where
     T: Text<'a> + Eq + AsRef<str> + Clone,
+    T::Value: Hash,
 {
     let variable_definitions = &query.variable_definitions;
     resolve_mutation_selection_set(
@@ -358,6 +363,7 @@ fn resolve_mutation_selection_set<'a, 'b, T>(
 ) -> GraphQLResponse
 where
     T: Text<'a> + Eq + AsRef<str> + Clone,
+    T::Value: Hash,
 {
     use crate::graphql::*;
 

--- a/test/expected/issue_237_field_merging.out
+++ b/test/expected/issue_237_field_merging.out
@@ -194,6 +194,72 @@ begin;
     select jsonb_pretty(graphql.resolve($$ {
         accountCollection {
             edges {
+                ... on AccountEdge {
+                    cursor
+                    cursor
+                    node {
+                        id
+                        email
+                    }
+                }
+                ... on AccountEdge {
+                    cursor
+                    cursor
+                    node {
+                        id
+                        email
+                    }
+                }
+                ... cursorsFragment
+                ... anotherCursorsFragment
+                cursor
+                cursor
+                node {
+                    id
+                    email
+                }
+            }
+        }
+    }
+    fragment cursorsFragment on AccountEdge {
+        cursor
+        cursor
+        node {
+            id
+            email
+        }
+    }
+    fragment anotherCursorsFragment on AccountEdge {
+        cursor
+        cursor
+        node {
+            id
+            email
+        }
+    }
+    $$));
+                   jsonb_pretty                    
+---------------------------------------------------
+ {                                                +
+     "data": {                                    +
+         "accountCollection": {                   +
+             "edges": [                           +
+                 {                                +
+                     "node": {                    +
+                         "id": 1,                 +
+                         "email": "aardvark@x.com"+
+                     },                           +
+                     "cursor": "WzFd"             +
+                 }                                +
+             ]                                    +
+         }                                        +
+     }                                            +
+ }
+(1 row)
+
+    select jsonb_pretty(graphql.resolve($$ {
+        accountCollection {
+            edges {
                 cursor
                 cursor
                 node {
@@ -219,7 +285,6 @@ begin;
             }
         }
     }
-
     $$));
                    jsonb_pretty                    
 ---------------------------------------------------

--- a/test/expected/issue_237_field_merging.out
+++ b/test/expected/issue_237_field_merging.out
@@ -1,5 +1,6 @@
 begin;
     -- https://github.com/supabase/pg_graphql/issues/237
+    savepoint a;
     create table blog_post(
         id int primary key,
         a text,
@@ -66,6 +67,176 @@ begin;
              ]                    +
          }                        +
      }                            +
+ }
+(1 row)
+
+    rollback to savepoint a;
+    create table account(
+        id serial primary key,
+        email varchar(255) not null
+    );
+    insert into public.account(email)
+    values
+        ('aardvark@x.com');
+    create table blog(
+        id serial primary key,
+        owner_id integer not null references account(id),
+        name varchar(255) not null
+    );
+    insert into blog(owner_id, name)
+    values
+        (1, 'A: Blog 1');
+    select jsonb_pretty(graphql.resolve($$ {
+        accountCollection {
+            edges {
+                node {
+                    email
+                    email
+                    id_alias: id
+                    id_alias: id
+                }
+            }
+        }
+    }$$));
+                    jsonb_pretty                    
+----------------------------------------------------
+ {                                                 +
+     "data": {                                     +
+         "accountCollection": {                    +
+             "edges": [                            +
+                 {                                 +
+                     "node": {                     +
+                         "email": "aardvark@x.com",+
+                         "id_alias": 1             +
+                     }                             +
+                 }                                 +
+             ]                                     +
+         }                                         +
+     }                                             +
+ }
+(1 row)
+
+    select jsonb_pretty(graphql.resolve($$ {
+        accountCollection(first: 1) {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+        accountCollection(first: 1) {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+    }$$));
+                   jsonb_pretty                    
+---------------------------------------------------
+ {                                                +
+     "data": {                                    +
+         "accountCollection": {                   +
+             "edges": [                           +
+                 {                                +
+                     "node": {                    +
+                         "id": 1,                 +
+                         "email": "aardvark@x.com"+
+                     }                            +
+                 }                                +
+             ]                                    +
+         }                                        +
+     }                                            +
+ }
+(1 row)
+
+    select jsonb_pretty(graphql.resolve($$ {
+        accountCollection(first: $count) {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+        accountCollection(first: $count) {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+    }$$,
+    jsonb_build_object(
+        'count', 1
+    )));
+                   jsonb_pretty                    
+---------------------------------------------------
+ {                                                +
+     "data": {                                    +
+         "accountCollection": {                   +
+             "edges": [                           +
+                 {                                +
+                     "node": {                    +
+                         "id": 1,                 +
+                         "email": "aardvark@x.com"+
+                     }                            +
+                 }                                +
+             ]                                    +
+         }                                        +
+     }                                            +
+ }
+(1 row)
+
+    select jsonb_pretty(graphql.resolve($$ {
+        accountCollection {
+            edges {
+                cursor
+                cursor
+                node {
+                    id
+                    email
+                }
+                node {
+                    id
+                    email
+                }
+            }
+            edges {
+                cursor
+                cursor
+                node {
+                    id
+                    email
+                }
+                node {
+                    id
+                    email
+                }
+            }
+        }
+    }
+
+    $$));
+                   jsonb_pretty                    
+---------------------------------------------------
+ {                                                +
+     "data": {                                    +
+         "accountCollection": {                   +
+             "edges": [                           +
+                 {                                +
+                     "node": {                    +
+                         "id": 1,                 +
+                         "email": "aardvark@x.com"+
+                     },                           +
+                     "cursor": "WzFd"             +
+                 }                                +
+             ]                                    +
+         }                                        +
+     }                                            +
  }
 (1 row)
 

--- a/test/expected/issue_237_field_merging.out
+++ b/test/expected/issue_237_field_merging.out
@@ -1,0 +1,72 @@
+begin;
+    -- https://github.com/supabase/pg_graphql/issues/237
+    create table blog_post(
+        id int primary key,
+        a text,
+        b text,
+        c text,
+        d text,
+        e text,
+        f text
+    );
+    insert into public.blog_post
+    values (1, 'a', 'b', 'c', 'd', 'e', 'f');
+    select jsonb_pretty(
+      graphql.resolve($$
+        query {
+          blogPostCollection {
+            edges {
+              node {
+                a
+                ...c_query
+                ... @include(if: true) {
+                  e
+                }
+              }
+            }
+          }
+          blogPostCollection {
+            edges {
+              node {
+                b
+                ...d_query
+                ... @include(if: true) {
+                  f
+                }
+              }
+            }
+          }
+        }
+
+        fragment c_query on BlogPost {
+          c
+        }
+
+        fragment d_query on BlogPost {
+          d
+        }
+      $$)
+    );
+           jsonb_pretty            
+-----------------------------------
+ {                                +
+     "data": {                    +
+         "blogPostCollection": {  +
+             "edges": [           +
+                 {                +
+                     "node": {    +
+                         "a": "a",+
+                         "b": "b",+
+                         "c": "c",+
+                         "d": "d",+
+                         "e": "e",+
+                         "f": "f" +
+                     }            +
+                 }                +
+             ]                    +
+         }                        +
+     }                            +
+ }
+(1 row)
+
+rollback;

--- a/test/expected/issue_237_field_merging.out
+++ b/test/expected/issue_237_field_merging.out
@@ -305,4 +305,70 @@ begin;
  }
 (1 row)
 
+    select graphql.encode('["public", "account", 1]'::jsonb);
+              encode              
+----------------------------------
+ WyJwdWJsaWMiLCAiYWNjb3VudCIsIDFd
+(1 row)
+
+    select graphql.encode('["public", "blog", 1]'::jsonb);
+            encode            
+------------------------------
+ WyJwdWJsaWMiLCAiYmxvZyIsIDFd
+(1 row)
+
+    select jsonb_pretty(graphql.resolve($$ {
+        node(nodeId: "WyJwdWJsaWMiLCAiYWNjb3VudCIsIDFd") {
+            nodeId
+            ... on Account {
+                id
+                str: email
+            }
+            ... on Blog {
+                id
+                str: name
+            }
+        }
+    }
+    $$));
+                       jsonb_pretty                       
+----------------------------------------------------------
+ {                                                       +
+     "data": {                                           +
+         "node": {                                       +
+             "id": 1,                                    +
+             "str": "aardvark@x.com",                    +
+             "nodeId": "WyJwdWJsaWMiLCAiYWNjb3VudCIsIDFd"+
+         }                                               +
+     }                                                   +
+ }
+(1 row)
+
+    select jsonb_pretty(graphql.resolve($$ {
+        node(nodeId: "WyJwdWJsaWMiLCAiYmxvZyIsIDFd") {
+            nodeId
+            ... on Account {
+                id
+                str: email
+            }
+            ... on Blog {
+                id
+                str: name
+            }
+        }
+    }
+    $$));
+                     jsonb_pretty                     
+------------------------------------------------------
+ {                                                   +
+     "data": {                                       +
+         "node": {                                   +
+             "id": 1,                                +
+             "str": "A: Blog 1",                     +
+             "nodeId": "WyJwdWJsaWMiLCAiYmxvZyIsIDFd"+
+         }                                           +
+     }                                               +
+ }
+(1 row)
+
 rollback;

--- a/test/expected/issue_237_field_merging_mismatched.out
+++ b/test/expected/issue_237_field_merging_mismatched.out
@@ -1,5 +1,6 @@
 begin;
     -- https://github.com/supabase/pg_graphql/issues/237
+    savepoint a;
     create table blog_post(
         id int primary key,
         a text,
@@ -104,6 +105,167 @@ begin;
              "message": "Fields `pageInfo` and `edges` are different"+
          }                                                           +
      ]                                                               +
+ }
+(1 row)
+
+    rollback to savepoint a;
+    create table account(
+        id serial primary key,
+        email varchar(255) not null
+    );
+    insert into public.account(email)
+    values
+        ('aardvark@x.com');
+    create table blog(
+        id serial primary key,
+        owner_id integer not null references account(id),
+        name varchar(255) not null
+    );
+    insert into blog(owner_id, name)
+    values
+        (1, 'A: Blog 1');
+    select jsonb_pretty(graphql.resolve($$ {
+        accountCollection {
+            edges {
+                node {
+                    email: id
+                    email
+                }
+            }
+        }
+    }$$));
+                          jsonb_pretty                          
+----------------------------------------------------------------
+ {                                                             +
+     "data": null,                                             +
+     "errors": [                                               +
+         {                                                     +
+             "message": "Fields `email` and `id` are different"+
+         }                                                     +
+     ]                                                         +
+ }
+(1 row)
+
+    select jsonb_pretty(graphql.resolve($$ {
+        accountCollection(first: 1) {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+        accountCollection(first: 2) {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+    }$$));
+                                      jsonb_pretty                                      
+----------------------------------------------------------------------------------------
+ {                                                                                     +
+     "errors": [                                                                       +
+         {                                                                             +
+             "message": "Two fields named `accountCollection` have different arguments"+
+         }                                                                             +
+     ]                                                                                 +
+ }
+(1 row)
+
+    select jsonb_pretty(graphql.resolve($$ {
+        accountCollection(first: $count) {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+        accountCollection(first: 1) {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+    }$$,
+    jsonb_build_object(
+        'count', 1
+    )));
+                                      jsonb_pretty                                      
+----------------------------------------------------------------------------------------
+ {                                                                                     +
+     "errors": [                                                                       +
+         {                                                                             +
+             "message": "Two fields named `accountCollection` have different arguments"+
+         }                                                                             +
+     ]                                                                                 +
+ }
+(1 row)
+
+    select jsonb_pretty(graphql.resolve($$ {
+        accountCollection(first: $count) {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+        accountCollection(first: $num) {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+    }$$,
+    jsonb_build_object(
+        'count', 1,
+        'num', 1
+    )));
+                                      jsonb_pretty                                      
+----------------------------------------------------------------------------------------
+ {                                                                                     +
+     "errors": [                                                                       +
+         {                                                                             +
+             "message": "Two fields named `accountCollection` have different arguments"+
+         }                                                                             +
+     ]                                                                                 +
+ }
+(1 row)
+
+    select jsonb_pretty(graphql.resolve($$ {
+        accountCollection(first: 1) {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+        accountCollection {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+    }$$));
+                                      jsonb_pretty                                      
+----------------------------------------------------------------------------------------
+ {                                                                                     +
+     "errors": [                                                                       +
+         {                                                                             +
+             "message": "Two fields named `accountCollection` have different arguments"+
+         }                                                                             +
+     ]                                                                                 +
  }
 (1 row)
 

--- a/test/expected/issue_237_field_merging_mismatched.out
+++ b/test/expected/issue_237_field_merging_mismatched.out
@@ -1,0 +1,110 @@
+begin;
+    -- https://github.com/supabase/pg_graphql/issues/237
+    create table blog_post(
+        id int primary key,
+        a text,
+        b text,
+        c text,
+        d text,
+        e text,
+        f text
+    );
+    insert into public.blog_post
+    values (1, 'a', 'b', 'c', 'd', 'e', 'f');
+    -- mismatched field names
+    select jsonb_pretty(
+      graphql.resolve($$
+        query {
+          blogPostCollection {
+            edges {
+              node {
+                a
+              }
+            }
+          }
+          blogPostCollection {
+            edges {
+              node {
+                a: b
+              }
+            }
+          }
+        }
+      $$)
+    );
+                       jsonb_pretty                        
+-----------------------------------------------------------
+ {                                                        +
+     "data": null,                                        +
+     "errors": [                                          +
+         {                                                +
+             "message": "Fields `b` and `a` are different"+
+         }                                                +
+     ]                                                    +
+ }
+(1 row)
+
+    -- mismatched arguments
+    select jsonb_pretty(
+      graphql.resolve($$
+        query {
+          blogPostCollection(filter: {
+            id: { eq: 1 }
+          }) {
+            edges {
+              node {
+                a
+              }
+            }
+          }
+          blogPostCollection {
+            edges {
+              node {
+                b
+              }
+            }
+          }
+        }
+      $$)
+    );
+                                      jsonb_pretty                                       
+-----------------------------------------------------------------------------------------
+ {                                                                                      +
+     "errors": [                                                                        +
+         {                                                                              +
+             "message": "Two fields named `blogPostCollection` have different arguments"+
+         }                                                                              +
+     ]                                                                                  +
+ }
+(1 row)
+
+    -- mismatched list to node
+    select jsonb_pretty(
+      graphql.resolve($$
+        query {
+          blogPostCollection {
+            a: edges {
+              cursor
+            }
+          }
+          blogPostCollection {
+            a: pageInfo {
+              cursor: endCursor
+            }
+          }
+        }
+      $$)
+    );
+                             jsonb_pretty                             
+----------------------------------------------------------------------
+ {                                                                   +
+     "data": null,                                                   +
+     "errors": [                                                     +
+         {                                                           +
+             "message": "Fields `pageInfo` and `edges` are different"+
+         }                                                           +
+     ]                                                               +
+ }
+(1 row)
+
+rollback;

--- a/test/sql/issue_237_field_merging.sql
+++ b/test/sql/issue_237_field_merging.sql
@@ -1,0 +1,50 @@
+begin;
+    -- https://github.com/supabase/pg_graphql/issues/237
+    create table blog_post(
+        id int primary key,
+        a text,
+        b text,
+        c text,
+        d text,
+        e text,
+        f text
+    );
+    insert into public.blog_post
+    values (1, 'a', 'b', 'c', 'd', 'e', 'f');
+    select jsonb_pretty(
+      graphql.resolve($$
+        query {
+          blogPostCollection {
+            edges {
+              node {
+                a
+                ...c_query
+                ... @include(if: true) {
+                  e
+                }
+              }
+            }
+          }
+          blogPostCollection {
+            edges {
+              node {
+                b
+                ...d_query
+                ... @include(if: true) {
+                  f
+                }
+              }
+            }
+          }
+        }
+
+        fragment c_query on BlogPost {
+          c
+        }
+
+        fragment d_query on BlogPost {
+          d
+        }
+      $$)
+    );
+rollback;

--- a/test/sql/issue_237_field_merging.sql
+++ b/test/sql/issue_237_field_merging.sql
@@ -1,5 +1,6 @@
 begin;
     -- https://github.com/supabase/pg_graphql/issues/237
+    savepoint a;
     create table blog_post(
         id int primary key,
         a text,
@@ -47,4 +48,111 @@ begin;
         }
       $$)
     );
+
+    rollback to savepoint a;
+
+    create table account(
+        id serial primary key,
+        email varchar(255) not null
+    );
+
+    insert into public.account(email)
+    values
+        ('aardvark@x.com');
+
+    create table blog(
+        id serial primary key,
+        owner_id integer not null references account(id),
+        name varchar(255) not null
+    );
+
+    insert into blog(owner_id, name)
+    values
+        (1, 'A: Blog 1');
+
+    select jsonb_pretty(graphql.resolve($$ {
+        accountCollection {
+            edges {
+                node {
+                    email
+                    email
+                    id_alias: id
+                    id_alias: id
+                }
+            }
+        }
+    }$$));
+
+    select jsonb_pretty(graphql.resolve($$ {
+        accountCollection(first: 1) {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+        accountCollection(first: 1) {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+    }$$));
+
+    select jsonb_pretty(graphql.resolve($$ {
+        accountCollection(first: $count) {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+        accountCollection(first: $count) {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+    }$$,
+    jsonb_build_object(
+        'count', 1
+    )));
+
+    select jsonb_pretty(graphql.resolve($$ {
+        accountCollection {
+            edges {
+                cursor
+                cursor
+                node {
+                    id
+                    email
+                }
+                node {
+                    id
+                    email
+                }
+            }
+            edges {
+                cursor
+                cursor
+                node {
+                    id
+                    email
+                }
+                node {
+                    id
+                    email
+                }
+            }
+        }
+    }
+
+    $$));
+
 rollback;

--- a/test/sql/issue_237_field_merging.sql
+++ b/test/sql/issue_237_field_merging.sql
@@ -202,4 +202,37 @@ begin;
     }
     $$));
 
+    select graphql.encode('["public", "account", 1]'::jsonb);
+    select graphql.encode('["public", "blog", 1]'::jsonb);
+
+    select jsonb_pretty(graphql.resolve($$ {
+        node(nodeId: "WyJwdWJsaWMiLCAiYWNjb3VudCIsIDFd") {
+            nodeId
+            ... on Account {
+                id
+                str: email
+            }
+            ... on Blog {
+                id
+                str: name
+            }
+        }
+    }
+    $$));
+
+    select jsonb_pretty(graphql.resolve($$ {
+        node(nodeId: "WyJwdWJsaWMiLCAiYmxvZyIsIDFd") {
+            nodeId
+            ... on Account {
+                id
+                str: email
+            }
+            ... on Blog {
+                id
+                str: name
+            }
+        }
+    }
+    $$));
+
 rollback;

--- a/test/sql/issue_237_field_merging.sql
+++ b/test/sql/issue_237_field_merging.sql
@@ -127,6 +127,54 @@ begin;
     select jsonb_pretty(graphql.resolve($$ {
         accountCollection {
             edges {
+                ... on AccountEdge {
+                    cursor
+                    cursor
+                    node {
+                        id
+                        email
+                    }
+                }
+                ... on AccountEdge {
+                    cursor
+                    cursor
+                    node {
+                        id
+                        email
+                    }
+                }
+                ... cursorsFragment
+                ... anotherCursorsFragment
+                cursor
+                cursor
+                node {
+                    id
+                    email
+                }
+            }
+        }
+    }
+    fragment cursorsFragment on AccountEdge {
+        cursor
+        cursor
+        node {
+            id
+            email
+        }
+    }
+    fragment anotherCursorsFragment on AccountEdge {
+        cursor
+        cursor
+        node {
+            id
+            email
+        }
+    }
+    $$));
+
+    select jsonb_pretty(graphql.resolve($$ {
+        accountCollection {
+            edges {
                 cursor
                 cursor
                 node {
@@ -152,7 +200,6 @@ begin;
             }
         }
     }
-
     $$));
 
 rollback;

--- a/test/sql/issue_237_field_merging_mismatched.sql
+++ b/test/sql/issue_237_field_merging_mismatched.sql
@@ -1,0 +1,75 @@
+begin;
+    -- https://github.com/supabase/pg_graphql/issues/237
+    create table blog_post(
+        id int primary key,
+        a text,
+        b text,
+        c text,
+        d text,
+        e text,
+        f text
+    );
+    insert into public.blog_post
+    values (1, 'a', 'b', 'c', 'd', 'e', 'f');
+    -- mismatched field names
+    select jsonb_pretty(
+      graphql.resolve($$
+        query {
+          blogPostCollection {
+            edges {
+              node {
+                a
+              }
+            }
+          }
+          blogPostCollection {
+            edges {
+              node {
+                a: b
+              }
+            }
+          }
+        }
+      $$)
+    );
+    -- mismatched arguments
+    select jsonb_pretty(
+      graphql.resolve($$
+        query {
+          blogPostCollection(filter: {
+            id: { eq: 1 }
+          }) {
+            edges {
+              node {
+                a
+              }
+            }
+          }
+          blogPostCollection {
+            edges {
+              node {
+                b
+              }
+            }
+          }
+        }
+      $$)
+    );
+    -- mismatched list to node
+    select jsonb_pretty(
+      graphql.resolve($$
+        query {
+          blogPostCollection {
+            a: edges {
+              cursor
+            }
+          }
+          blogPostCollection {
+            a: pageInfo {
+              cursor: endCursor
+            }
+          }
+        }
+      $$)
+    );
+rollback;

--- a/test/sql/issue_237_field_merging_mismatched.sql
+++ b/test/sql/issue_237_field_merging_mismatched.sql
@@ -1,5 +1,6 @@
 begin;
     -- https://github.com/supabase/pg_graphql/issues/237
+    savepoint a;
     create table blog_post(
         id int primary key,
         a text,
@@ -72,4 +73,120 @@ begin;
         }
       $$)
     );
+
+    rollback to savepoint a;
+
+    create table account(
+        id serial primary key,
+        email varchar(255) not null
+    );
+
+    insert into public.account(email)
+    values
+        ('aardvark@x.com');
+
+    create table blog(
+        id serial primary key,
+        owner_id integer not null references account(id),
+        name varchar(255) not null
+    );
+
+    insert into blog(owner_id, name)
+    values
+        (1, 'A: Blog 1');
+
+    select jsonb_pretty(graphql.resolve($$ {
+        accountCollection {
+            edges {
+                node {
+                    email: id
+                    email
+                }
+            }
+        }
+    }$$));
+
+    select jsonb_pretty(graphql.resolve($$ {
+        accountCollection(first: 1) {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+        accountCollection(first: 2) {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+    }$$));
+
+    select jsonb_pretty(graphql.resolve($$ {
+        accountCollection(first: $count) {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+        accountCollection(first: 1) {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+    }$$,
+    jsonb_build_object(
+        'count', 1
+    )));
+
+    select jsonb_pretty(graphql.resolve($$ {
+        accountCollection(first: $count) {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+        accountCollection(first: $num) {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+    }$$,
+    jsonb_build_object(
+        'count', 1,
+        'num', 1
+    )));
+
+    select jsonb_pretty(graphql.resolve($$ {
+        accountCollection(first: 1) {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+        accountCollection {
+            edges {
+                node {
+                    id
+                    email
+                }
+            }
+        }
+    }$$));
+
 rollback;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Field merging doesn't work because it was reverted recently.

## What is the new behavior?

Fields at the same level will be merged according to the GraphQL spec. The new algo is O(n) in the total number of fields and is much faster than the old algo. Tests from the old algo are also included with more added to cover additional cases.

## Additional context

N/A