### PR TITLE
bugfix: arguments with null default were required

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -69,3 +69,4 @@
 - feature: improved descriptions for all internal error states
 
 ## master
+- bugfix: function arguments with a null default value were required instead of optional

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -371,7 +371,7 @@ Functions accepting or returning arrays of non-composite types are also supporte
 
 ## Default Arguments
 
-Functions with default arguments can have their default arguments omitted.
+Arguments without a default value are required in the GraphQL schema, to make them optional they should have a default value.
 
 === "Function"
 
@@ -409,6 +409,66 @@ Functions with default arguments can have their default arguments omitted.
       }
     }
     ```
+
+If there is no sensible default, and you still want to make the argument optional, consider using the default value null.
+
+
+=== "Function"
+
+    ```sql
+    create function "addNums"(a int default null, b int default null)
+        returns int
+        immutable
+        language plpgsql
+    as $$
+    begin
+
+        if a is null and b is null then
+            raise exception 'a and b both can''t be null';
+        end if;
+
+        if a is null then
+            return b;
+        end if;
+
+        if b is null then
+            return a;
+        end if;
+
+        return a + b;
+    end;
+    $$;
+    ```
+
+=== "QueryType"
+
+    ```graphql
+    type Query {
+      addNums(a: Int, b: Int): Int
+    }
+    ```
+
+
+=== "Query"
+
+    ```graphql
+    query {
+      addNums(a: 42)
+    }
+    ```
+
+=== "Response"
+
+    ```json
+    {
+      "data": {
+        "addNums": 42
+      }
+    }
+    ```
+
+Currently, null defaults are only supported as simple expressions, as shown in the previous example.
+
 
 ## Limitations
 

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1374,11 +1374,10 @@ fn function_args(schema: &Arc<__Schema>, func: &Arc<Function>) -> Vec<__InputVal
             })
         })
         .map(|(arg_type, arg_name, arg_default)| {
-            let default_value = if let Some((default_value, is_null)) = arg_default {
-                if is_null {
-                    None
-                } else {
-                    Some(default_value)
+            let default_value = if let Some(default_value) = arg_default {
+                match default_value {
+                    DefaultValue::Value(value) => Some(value),
+                    DefaultValue::Null => None,
                 }
             } else {
                 None

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1373,12 +1373,24 @@ fn function_args(schema: &Arc<__Schema>, func: &Arc<Function>) -> Vec<__InputVal
                 (t, arg_name, arg_default)
             })
         })
-        .map(|(arg_type, arg_name, arg_default)| __InputValue {
-            name_: schema.graphql_function_arg_name(func, arg_name),
-            type_: arg_type,
-            description: None,
-            default_value: arg_default,
-            sql_type: None,
+        .map(|(arg_type, arg_name, arg_default)| {
+            let default_value = if arg_default.is_some() {
+                let (default_value, is_null) = arg_default.unwrap();
+                if is_null {
+                    None
+                } else {
+                    Some(default_value)
+                }
+            } else {
+                None
+            };
+            __InputValue {
+                name_: schema.graphql_function_arg_name(func, arg_name),
+                type_: arg_type,
+                description: None,
+                default_value,
+                sql_type: None,
+            }
         })
         .collect()
 }

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1376,7 +1376,7 @@ fn function_args(schema: &Arc<__Schema>, func: &Arc<Function>) -> Vec<__InputVal
         .map(|(arg_type, arg_name, arg_default)| {
             let default_value = if let Some(default_value) = arg_default {
                 match default_value {
-                    DefaultValue::Value(value) => Some(value),
+                    DefaultValue::NonNull(value) => Some(value),
                     DefaultValue::Null => None,
                 }
             } else {

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1374,8 +1374,7 @@ fn function_args(schema: &Arc<__Schema>, func: &Arc<Function>) -> Vec<__InputVal
             })
         })
         .map(|(arg_type, arg_name, arg_default)| {
-            let default_value = if arg_default.is_some() {
-                let (default_value, is_null) = arg_default.unwrap();
+            let default_value = if let Some((default_value, is_null)) = arg_default {
                 if is_null {
                     None
                 } else {

--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -205,7 +205,7 @@ struct ArgsIterator<'a> {
 
 #[derive(Clone)]
 pub(crate) enum DefaultValue {
-    Value(String),
+    NonNull(String),
     Null,
 }
 
@@ -270,17 +270,17 @@ impl<'a> ArgsIterator<'a> {
             21 | 23 => trimmed
                 .parse::<i32>()
                 .ok()
-                .map(|i| DefaultValue::Value(i.to_string())),
+                .map(|i| DefaultValue::NonNull(i.to_string())),
             16 => trimmed
                 .parse::<bool>()
                 .ok()
-                .map(|i| DefaultValue::Value(i.to_string())),
+                .map(|i| DefaultValue::NonNull(i.to_string())),
             700 | 701 => trimmed
                 .parse::<f64>()
                 .ok()
-                .map(|i| DefaultValue::Value(i.to_string())),
+                .map(|i| DefaultValue::NonNull(i.to_string())),
             25 => trimmed.strip_suffix("::text").map(|i| {
-                DefaultValue::Value(format!("\"{}\"", i.trim_matches(',').trim_matches('\'')))
+                DefaultValue::NonNull(format!("\"{}\"", i.trim_matches(',').trim_matches('\'')))
             }),
             _ => None,
         }

--- a/test/expected/function_calls_default_args.out
+++ b/test/expected/function_calls_default_args.out
@@ -1,0 +1,181 @@
+begin;
+    create function func_with_null_defaults(
+        a smallint default null,
+        b integer default null,
+        c boolean default null,
+        d real default null,
+        e double precision default null,
+        f text default null,
+        g uuid default null
+    )
+        returns text language sql immutable
+    as $$ select a::text || b::text || c::text || d::text || e::text || f::text || g::text; $$;
+    select jsonb_pretty(graphql.resolve($$
+        query {
+            funcWithNullDefaults
+        }
+    $$));
+             jsonb_pretty             
+--------------------------------------
+ {                                   +
+     "data": {                       +
+         "funcWithNullDefaults": null+
+     }                               +
+ }
+(1 row)
+
+    select jsonb_pretty(graphql.resolve($$
+        query {
+            funcWithNullDefaults(a: 1, b: 2, c: false, d: 1.1, e: 2.3, f: "f_arg", g: "8871277a-de9c-4156-b31f-5b4060001081")
+        }
+    $$));
+                                       jsonb_pretty                                       
+------------------------------------------------------------------------------------------
+ {                                                                                       +
+     "data": {                                                                           +
+         "funcWithNullDefaults": "12false1.12.3f_arg8871277a-de9c-4156-b31f-5b4060001081"+
+     }                                                                                   +
+ }
+(1 row)
+
+    select jsonb_pretty(graphql.resolve($$
+        query {
+            funcWithNullDefaults(a: 1, c: false, e: 2.3, g: "8871277a-de9c-4156-b31f-5b4060001081")
+        }
+    $$));
+             jsonb_pretty             
+--------------------------------------
+ {                                   +
+     "data": {                       +
+         "funcWithNullDefaults": null+
+     }                               +
+ }
+(1 row)
+
+    select jsonb_pretty(
+        graphql.resolve($$
+            query IntrospectionQuery {
+              __schema {
+                queryType {
+                  name
+                  fields {
+                    name
+                    args {
+                      name
+                      defaultValue
+                      type {
+                        kind
+                        name
+                        ofType {
+                            kind
+                            name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        $$)
+    );
+                       jsonb_pretty                        
+-----------------------------------------------------------
+ {                                                        +
+     "data": {                                            +
+         "__schema": {                                    +
+             "queryType": {                               +
+                 "name": "Query",                         +
+                 "fields": [                              +
+                     {                                    +
+                         "args": [                        +
+                             {                            +
+                                 "name": "a",             +
+                                 "type": {                +
+                                     "kind": "SCALAR",    +
+                                     "name": "Int",       +
+                                     "ofType": null       +
+                                 },                       +
+                                 "defaultValue": null     +
+                             },                           +
+                             {                            +
+                                 "name": "b",             +
+                                 "type": {                +
+                                     "kind": "SCALAR",    +
+                                     "name": "Int",       +
+                                     "ofType": null       +
+                                 },                       +
+                                 "defaultValue": null     +
+                             },                           +
+                             {                            +
+                                 "name": "c",             +
+                                 "type": {                +
+                                     "kind": "SCALAR",    +
+                                     "name": "Boolean",   +
+                                     "ofType": null       +
+                                 },                       +
+                                 "defaultValue": null     +
+                             },                           +
+                             {                            +
+                                 "name": "d",             +
+                                 "type": {                +
+                                     "kind": "SCALAR",    +
+                                     "name": "Float",     +
+                                     "ofType": null       +
+                                 },                       +
+                                 "defaultValue": null     +
+                             },                           +
+                             {                            +
+                                 "name": "e",             +
+                                 "type": {                +
+                                     "kind": "SCALAR",    +
+                                     "name": "Float",     +
+                                     "ofType": null       +
+                                 },                       +
+                                 "defaultValue": null     +
+                             },                           +
+                             {                            +
+                                 "name": "f",             +
+                                 "type": {                +
+                                     "kind": "SCALAR",    +
+                                     "name": "String",    +
+                                     "ofType": null       +
+                                 },                       +
+                                 "defaultValue": null     +
+                             },                           +
+                             {                            +
+                                 "name": "g",             +
+                                 "type": {                +
+                                     "kind": "SCALAR",    +
+                                     "name": "UUID",      +
+                                     "ofType": null       +
+                                 },                       +
+                                 "defaultValue": null     +
+                             }                            +
+                         ],                               +
+                         "name": "funcWithNullDefaults"   +
+                     },                                   +
+                     {                                    +
+                         "args": [                        +
+                             {                            +
+                                 "name": "nodeId",        +
+                                 "type": {                +
+                                     "kind": "NON_NULL",  +
+                                     "name": null,        +
+                                     "ofType": {          +
+                                         "kind": "SCALAR",+
+                                         "name": "ID"     +
+                                     }                    +
+                                 },                       +
+                                 "defaultValue": null     +
+                             }                            +
+                         ],                               +
+                         "name": "node"                   +
+                     }                                    +
+                 ]                                        +
+             }                                            +
+         }                                                +
+     }                                                    +
+ }
+(1 row)
+
+rollback;

--- a/test/expected/function_calls_default_args.out
+++ b/test/expected/function_calls_default_args.out
@@ -80,54 +80,116 @@ begin;
 
     create function func_with_null_defaults(
         a smallint default null,
-        b integer default null,
-        c boolean default null,
+        b int default null,
+        c bigint default null,
         d real default null,
         e double precision default null,
-        f text default null,
-        g uuid default null
+        f numeric default null,
+        g bool default null,
+        h uuid default null,
+        i text default null,
+        j date default null,
+        k time default null,
+        l time with time zone default null,
+        m timestamp default null,
+        n timestamptz default null,
+        o json default null,
+        p jsonb default null,
+        q char(2) default null,
+        r varchar(2) default null
     )
-        returns text language sql immutable
-    as $$ select a::text || b::text || c::text || d::text || e::text || f::text || g::text; $$;
+        returns text language plpgsql immutable
+    as $$
+    begin
+
+        if
+            a is null and
+            b is null and
+            c is null and
+            d is null and
+            e is null and
+            f is null and
+            g is null and
+            h is null and
+            i is null and
+            j is null and
+            k is null and
+            l is null and
+            m is null and
+            n is null and
+            o is null and
+            p is null and
+            q is null and
+            r is null
+        then
+            return 'all args null';
+        end if;
+
+        return
+            a::text || ', ' ||
+            b::text || ', ' ||
+            c::text || ', ' ||
+            d::text || ', ' ||
+            e::text || ', ' ||
+            f::text || ', ' ||
+            g::text || ', ' ||
+            h::text || ', ' ||
+            i::text || ', ' ||
+            j::text || ', ' ||
+            k::text || ', ' ||
+            l::text || ', ' ||
+            m::text || ', ' ||
+            n::text || ', ' ||
+            o::text || ', ' ||
+            p::text || ', ' ||
+            q::text || ', ' ||
+            r::text;
+    end;
+    $$;
     select jsonb_pretty(graphql.resolve($$
         query {
             funcWithNullDefaults
         }
     $$));
-             jsonb_pretty             
---------------------------------------
- {                                   +
-     "data": {                       +
-         "funcWithNullDefaults": null+
-     }                               +
+                  jsonb_pretty                   
+-------------------------------------------------
+ {                                              +
+     "data": {                                  +
+         "funcWithNullDefaults": "all args null"+
+     }                                          +
  }
 (1 row)
 
     select jsonb_pretty(graphql.resolve($$
         query {
-            funcWithNullDefaults(a: 1, b: 2, c: false, d: 1.1, e: 2.3, f: "f_arg", g: "8871277a-de9c-4156-b31f-5b4060001081")
+            funcWithNullDefaults(
+                a: 1,
+                b: 2,
+                c: 3,
+                d: 1.1,
+                e: 2.3,
+                f: "3.4",
+                g: false,
+                h: "8871277a-de9c-4156-b31f-5b4060001081",
+                i: "text",
+                j: "2023-07-28",
+                k: "10:20",
+                l: "10:20+05:30",
+                m: "2023-07-28 12:39:05",
+                n: "2023-07-28 12:39:05+05:30",
+                o: "{\"a\": {\"b\": \"foo\"}}",
+                p: "{\"a\": {\"b\": \"foo\"}}",
+                q: "hi",
+                r: "ho"
+            )
         }
     $$));
-                                       jsonb_pretty                                       
-------------------------------------------------------------------------------------------
- {                                                                                       +
-     "data": {                                                                           +
-         "funcWithNullDefaults": "12false1.12.3f_arg8871277a-de9c-4156-b31f-5b4060001081"+
-     }                                                                                   +
- }
-(1 row)
-
-    select jsonb_pretty(graphql.resolve($$
-        query {
-            funcWithNullDefaults(a: 1, c: false, e: 2.3, g: "8871277a-de9c-4156-b31f-5b4060001081")
-        }
-    $$));
-             jsonb_pretty             
---------------------------------------
- {                                   +
-     "data": {                       +
-         "funcWithNullDefaults": null+
-     }                               +
+                                                                                                                              jsonb_pretty                                                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {                                                                                                                                                                                                                                                                      +
+     "data": {                                                                                                                                                                                                                                                          +
+         "funcWithNullDefaults": "1, 2, 3, 1.1, 2.3, 3.4, false, 8871277a-de9c-4156-b31f-5b4060001081, text, 07-28-2023, 10:20:00, 10:20:00+05:30, Fri Jul 28 12:39:05 2023, Fri Jul 28 00:09:05 2023 PDT, {\"a\": {\"b\": \"foo\"}}, {\"a\": {\"b\": \"foo\"}}, hi, ho"+
+     }                                                                                                                                                                                                                                                                  +
  }
 (1 row)
 
@@ -212,7 +274,7 @@ begin;
                                  "name": "c",             +
                                  "type": {                +
                                      "kind": "SCALAR",    +
-                                     "name": "Boolean",   +
+                                     "name": "BigInt",    +
                                      "ofType": null       +
                                  },                       +
                                  "defaultValue": null     +
@@ -239,7 +301,7 @@ begin;
                                  "name": "f",             +
                                  "type": {                +
                                      "kind": "SCALAR",    +
-                                     "name": "String",    +
+                                     "name": "BigFloat",  +
                                      "ofType": null       +
                                  },                       +
                                  "defaultValue": null     +
@@ -248,7 +310,106 @@ begin;
                                  "name": "g",             +
                                  "type": {                +
                                      "kind": "SCALAR",    +
+                                     "name": "Boolean",   +
+                                     "ofType": null       +
+                                 },                       +
+                                 "defaultValue": null     +
+                             },                           +
+                             {                            +
+                                 "name": "h",             +
+                                 "type": {                +
+                                     "kind": "SCALAR",    +
                                      "name": "UUID",      +
+                                     "ofType": null       +
+                                 },                       +
+                                 "defaultValue": null     +
+                             },                           +
+                             {                            +
+                                 "name": "i",             +
+                                 "type": {                +
+                                     "kind": "SCALAR",    +
+                                     "name": "String",    +
+                                     "ofType": null       +
+                                 },                       +
+                                 "defaultValue": null     +
+                             },                           +
+                             {                            +
+                                 "name": "j",             +
+                                 "type": {                +
+                                     "kind": "SCALAR",    +
+                                     "name": "Date",      +
+                                     "ofType": null       +
+                                 },                       +
+                                 "defaultValue": null     +
+                             },                           +
+                             {                            +
+                                 "name": "k",             +
+                                 "type": {                +
+                                     "kind": "SCALAR",    +
+                                     "name": "Time",      +
+                                     "ofType": null       +
+                                 },                       +
+                                 "defaultValue": null     +
+                             },                           +
+                             {                            +
+                                 "name": "l",             +
+                                 "type": {                +
+                                     "kind": "SCALAR",    +
+                                     "name": "Opaque",    +
+                                     "ofType": null       +
+                                 },                       +
+                                 "defaultValue": null     +
+                             },                           +
+                             {                            +
+                                 "name": "m",             +
+                                 "type": {                +
+                                     "kind": "SCALAR",    +
+                                     "name": "Datetime",  +
+                                     "ofType": null       +
+                                 },                       +
+                                 "defaultValue": null     +
+                             },                           +
+                             {                            +
+                                 "name": "n",             +
+                                 "type": {                +
+                                     "kind": "SCALAR",    +
+                                     "name": "Datetime",  +
+                                     "ofType": null       +
+                                 },                       +
+                                 "defaultValue": null     +
+                             },                           +
+                             {                            +
+                                 "name": "o",             +
+                                 "type": {                +
+                                     "kind": "SCALAR",    +
+                                     "name": "JSON",      +
+                                     "ofType": null       +
+                                 },                       +
+                                 "defaultValue": null     +
+                             },                           +
+                             {                            +
+                                 "name": "p",             +
+                                 "type": {                +
+                                     "kind": "SCALAR",    +
+                                     "name": "JSON",      +
+                                     "ofType": null       +
+                                 },                       +
+                                 "defaultValue": null     +
+                             },                           +
+                             {                            +
+                                 "name": "q",             +
+                                 "type": {                +
+                                     "kind": "SCALAR",    +
+                                     "name": "String",    +
+                                     "ofType": null       +
+                                 },                       +
+                                 "defaultValue": null     +
+                             },                           +
+                             {                            +
+                                 "name": "r",             +
+                                 "type": {                +
+                                     "kind": "SCALAR",    +
+                                     "name": "String",    +
                                      "ofType": null       +
                                  },                       +
                                  "defaultValue": null     +

--- a/test/expected/function_calls_default_args.out
+++ b/test/expected/function_calls_default_args.out
@@ -193,6 +193,17 @@ begin;
  }
 (1 row)
 
+    create function defaul_null_mixed_case(
+        a smallint default null,
+        b integer default NULL,
+        c integer default NuLl
+    )
+        returns text language plpgsql immutable
+    as $$
+    begin
+        return 'mixed case';
+    end;
+    $$;
     select jsonb_pretty(
         graphql.resolve($$
             query IntrospectionQuery {
@@ -249,6 +260,38 @@ begin;
                              }                            +
                          ],                               +
                          "name": "bothArgsOptional"       +
+                     },                                   +
+                     {                                    +
+                         "args": [                        +
+                             {                            +
+                                 "name": "a",             +
+                                 "type": {                +
+                                     "kind": "SCALAR",    +
+                                     "name": "Int",       +
+                                     "ofType": null       +
+                                 },                       +
+                                 "defaultValue": null     +
+                             },                           +
+                             {                            +
+                                 "name": "b",             +
+                                 "type": {                +
+                                     "kind": "SCALAR",    +
+                                     "name": "Int",       +
+                                     "ofType": null       +
+                                 },                       +
+                                 "defaultValue": null     +
+                             },                           +
+                             {                            +
+                                 "name": "c",             +
+                                 "type": {                +
+                                     "kind": "SCALAR",    +
+                                     "name": "Int",       +
+                                     "ofType": null       +
+                                 },                       +
+                                 "defaultValue": null     +
+                             }                            +
+                         ],                               +
+                         "name": "defaulNullMixedCase"    +
                      },                                   +
                      {                                    +
                          "args": [                        +

--- a/test/expected/function_calls_default_args.out
+++ b/test/expected/function_calls_default_args.out
@@ -1,4 +1,83 @@
 begin;
+    create function both_args_optional(
+        a smallint default null,
+        b integer default null
+    )
+        returns text language plpgsql immutable
+    as $$
+    begin
+
+        if a is null and b is null then
+            return 'both null';
+        end if;
+
+        if a is null then
+            return 'b = ' || b::text;
+        end if;
+
+        if b is null then
+            return 'a = ' || a::text;
+        end if;
+
+        return 'a = ' || a::text || ', b = ' || b::text;
+    end;
+    $$;
+    select jsonb_pretty(graphql.resolve($$
+        query {
+            bothArgsOptional
+        }
+    $$));
+              jsonb_pretty               
+-----------------------------------------
+ {                                      +
+     "data": {                          +
+         "bothArgsOptional": "both null"+
+     }                                  +
+ }
+(1 row)
+
+    select jsonb_pretty(graphql.resolve($$
+        query {
+            bothArgsOptional(a: 1)
+        }
+    $$));
+            jsonb_pretty             
+-------------------------------------
+ {                                  +
+     "data": {                      +
+         "bothArgsOptional": "a = 1"+
+     }                              +
+ }
+(1 row)
+
+    select jsonb_pretty(graphql.resolve($$
+        query {
+            bothArgsOptional(b: 2)
+        }
+    $$));
+            jsonb_pretty             
+-------------------------------------
+ {                                  +
+     "data": {                      +
+         "bothArgsOptional": "b = 2"+
+     }                              +
+ }
+(1 row)
+
+    select jsonb_pretty(graphql.resolve($$
+        query {
+            bothArgsOptional(a: 1, b: 2)
+        }
+    $$));
+                jsonb_pretty                
+--------------------------------------------
+ {                                         +
+     "data": {                             +
+         "bothArgsOptional": "a = 1, b = 2"+
+     }                                     +
+ }
+(1 row)
+
     create function func_with_null_defaults(
         a smallint default null,
         b integer default null,
@@ -86,6 +165,29 @@ begin;
              "queryType": {                               +
                  "name": "Query",                         +
                  "fields": [                              +
+                     {                                    +
+                         "args": [                        +
+                             {                            +
+                                 "name": "a",             +
+                                 "type": {                +
+                                     "kind": "SCALAR",    +
+                                     "name": "Int",       +
+                                     "ofType": null       +
+                                 },                       +
+                                 "defaultValue": null     +
+                             },                           +
+                             {                            +
+                                 "name": "b",             +
+                                 "type": {                +
+                                     "kind": "SCALAR",    +
+                                     "name": "Int",       +
+                                     "ofType": null       +
+                                 },                       +
+                                 "defaultValue": null     +
+                             }                            +
+                         ],                               +
+                         "name": "bothArgsOptional"       +
+                     },                                   +
                      {                                    +
                          "args": [                        +
                              {                            +

--- a/test/sql/function_calls_default_args.sql
+++ b/test/sql/function_calls_default_args.sql
@@ -1,5 +1,53 @@
 begin;
 
+    create function both_args_optional(
+        a smallint default null,
+        b integer default null
+    )
+        returns text language plpgsql immutable
+    as $$
+    begin
+
+        if a is null and b is null then
+            return 'both null';
+        end if;
+
+        if a is null then
+            return 'b = ' || b::text;
+        end if;
+
+        if b is null then
+            return 'a = ' || a::text;
+        end if;
+
+        return 'a = ' || a::text || ', b = ' || b::text;
+    end;
+    $$;
+
+    select jsonb_pretty(graphql.resolve($$
+        query {
+            bothArgsOptional
+        }
+    $$));
+
+    select jsonb_pretty(graphql.resolve($$
+        query {
+            bothArgsOptional(a: 1)
+        }
+    $$));
+
+    select jsonb_pretty(graphql.resolve($$
+        query {
+            bothArgsOptional(b: 2)
+        }
+    $$));
+
+    select jsonb_pretty(graphql.resolve($$
+        query {
+            bothArgsOptional(a: 1, b: 2)
+        }
+    $$));
+
     create function func_with_null_defaults(
         a smallint default null,
         b integer default null,

--- a/test/sql/function_calls_default_args.sql
+++ b/test/sql/function_calls_default_args.sql
@@ -50,15 +50,72 @@ begin;
 
     create function func_with_null_defaults(
         a smallint default null,
-        b integer default null,
-        c boolean default null,
+        b int default null,
+        c bigint default null,
         d real default null,
         e double precision default null,
-        f text default null,
-        g uuid default null
+        f numeric default null,
+        g bool default null,
+        h uuid default null,
+        i text default null,
+        j date default null,
+        k time default null,
+        l time with time zone default null,
+        m timestamp default null,
+        n timestamptz default null,
+        o json default null,
+        p jsonb default null,
+        q char(2) default null,
+        r varchar(2) default null
     )
-        returns text language sql immutable
-    as $$ select a::text || b::text || c::text || d::text || e::text || f::text || g::text; $$;
+        returns text language plpgsql immutable
+    as $$
+    begin
+
+        if
+            a is null and
+            b is null and
+            c is null and
+            d is null and
+            e is null and
+            f is null and
+            g is null and
+            h is null and
+            i is null and
+            j is null and
+            k is null and
+            l is null and
+            m is null and
+            n is null and
+            o is null and
+            p is null and
+            q is null and
+            r is null
+        then
+            return 'all args null';
+        end if;
+
+        return
+            a::text || ', ' ||
+            b::text || ', ' ||
+            c::text || ', ' ||
+            d::text || ', ' ||
+            e::text || ', ' ||
+            f::text || ', ' ||
+            g::text || ', ' ||
+            h::text || ', ' ||
+            i::text || ', ' ||
+            j::text || ', ' ||
+            k::text || ', ' ||
+            l::text || ', ' ||
+            m::text || ', ' ||
+            n::text || ', ' ||
+            o::text || ', ' ||
+            p::text || ', ' ||
+            q::text || ', ' ||
+            r::text;
+    end;
+    $$;
 
     select jsonb_pretty(graphql.resolve($$
         query {
@@ -68,13 +125,26 @@ begin;
 
     select jsonb_pretty(graphql.resolve($$
         query {
-            funcWithNullDefaults(a: 1, b: 2, c: false, d: 1.1, e: 2.3, f: "f_arg", g: "8871277a-de9c-4156-b31f-5b4060001081")
-        }
-    $$));
-
-    select jsonb_pretty(graphql.resolve($$
-        query {
-            funcWithNullDefaults(a: 1, c: false, e: 2.3, g: "8871277a-de9c-4156-b31f-5b4060001081")
+            funcWithNullDefaults(
+                a: 1,
+                b: 2,
+                c: 3,
+                d: 1.1,
+                e: 2.3,
+                f: "3.4",
+                g: false,
+                h: "8871277a-de9c-4156-b31f-5b4060001081",
+                i: "text",
+                j: "2023-07-28",
+                k: "10:20",
+                l: "10:20+05:30",
+                m: "2023-07-28 12:39:05",
+                n: "2023-07-28 12:39:05+05:30",
+                o: "{\"a\": {\"b\": \"foo\"}}",
+                p: "{\"a\": {\"b\": \"foo\"}}",
+                q: "hi",
+                r: "ho"
+            )
         }
     $$));
 

--- a/test/sql/function_calls_default_args.sql
+++ b/test/sql/function_calls_default_args.sql
@@ -1,0 +1,60 @@
+begin;
+
+    create function func_with_null_defaults(
+        a smallint default null,
+        b integer default null,
+        c boolean default null,
+        d real default null,
+        e double precision default null,
+        f text default null,
+        g uuid default null
+    )
+        returns text language sql immutable
+    as $$ select a::text || b::text || c::text || d::text || e::text || f::text || g::text; $$;
+
+    select jsonb_pretty(graphql.resolve($$
+        query {
+            funcWithNullDefaults
+        }
+    $$));
+
+    select jsonb_pretty(graphql.resolve($$
+        query {
+            funcWithNullDefaults(a: 1, b: 2, c: false, d: 1.1, e: 2.3, f: "f_arg", g: "8871277a-de9c-4156-b31f-5b4060001081")
+        }
+    $$));
+
+    select jsonb_pretty(graphql.resolve($$
+        query {
+            funcWithNullDefaults(a: 1, c: false, e: 2.3, g: "8871277a-de9c-4156-b31f-5b4060001081")
+        }
+    $$));
+
+    select jsonb_pretty(
+        graphql.resolve($$
+            query IntrospectionQuery {
+              __schema {
+                queryType {
+                  name
+                  fields {
+                    name
+                    args {
+                      name
+                      defaultValue
+                      type {
+                        kind
+                        name
+                        ofType {
+                            kind
+                            name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        $$)
+    );
+
+rollback;

--- a/test/sql/function_calls_default_args.sql
+++ b/test/sql/function_calls_default_args.sql
@@ -148,6 +148,18 @@ begin;
         }
     $$));
 
+    create function defaul_null_mixed_case(
+        a smallint default null,
+        b integer default NULL,
+        c integer default NuLl
+    )
+        returns text language plpgsql immutable
+    as $$
+    begin
+        return 'mixed case';
+    end;
+    $$;
+
     select jsonb_pretty(
         graphql.resolve($$
             query IntrospectionQuery {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

UDF args with a default value of null were either required or had a default value of "NULL" in case of string.

## What is the new behavior?

UDF args with a null default value will be optional.

## Additional context

Fixes #507 
