### PR TITLE
docs(installation): add missing pgrx initialization and database connection steps

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
-First, install [pgrx](https://github.com/tcdi/pgrx) by running `cargo install --locked cargo-pgrx@version`, where version should be compatible with the [pgrx version used by pg_graphl](https://github.com/supabase/pg_graphql/blob/master/Cargo.toml#L16)
+First, install [pgrx](https://github.com/tcdi/pgrx) by running `cargo install --locked cargo-pgrx@version`, where version should be compatible with the [pgrx version used by pg_graphql](https://github.com/supabase/pg_graphql/blob/master/Cargo.toml#L16).
 
-Then clone the repo and install using
+Then clone the repo and install using:
 
 ```bash
 git clone https://github.com/supabase/pg_graphql.git
@@ -8,8 +8,28 @@ cd pg_graphql
 cargo pgrx install --release
 ```
 
-To enable the extension in PostgreSQL we must execute a `create extension` statement. The extension creates its own schema/namespace named `graphql` to avoid naming conflicts.
+Before enabling the extension in PostgreSQL, you need to initialize `pgrx`. Depending on your PostgreSQL installation, you might need to specify the path to `pg_config`. For example, on macOS with PostgreSQL installed via Homebrew:
+
+```bash
+cargo pgrx init --pg14 "/opt/homebrew/bin/pg_config"
+```
+
+To start the database:
+
+```bash
+cargo pgrx start pg14
+```
+
+To connect:
+
+```bash
+cargo pgrx connect pg14
+```
+
+Finally, to enable the `pg_graphql` extension in PostgreSQL, execute the `create extension` statement. This extension creates its own schema/namespace named `graphql` to avoid naming conflicts.
 
 ```psql
 create extension pg_graphql;
 ```
+
+These additional steps ensure that `pgrx` is properly initialized, and the database is started and connected before attempting to install and use the `pg_graphql` extension.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,28 +8,30 @@ cd pg_graphql
 cargo pgrx install --release
 ```
 
-Before enabling the extension in PostgreSQL, you need to initialize `pgrx`. Depending on your PostgreSQL installation, you might need to specify the path to `pg_config`. For example, on macOS with PostgreSQL installed via Homebrew:
+Before enabling the extension you need to initialize `pgrx`. The easiest way to get started is to allow `pgrx` to manage its own version/s of Postgres:
 
 ```bash
-cargo pgrx init --pg14 "/opt/homebrew/bin/pg_config"
+cargo pgrx init --pg16=download
 ```
+
+For more advanced configuration options, like building against an existing Postgres installation from e.g. Homebrew, see the [pgrx docs](https://github.com/pgcentralfoundation/pgrx)
 
 To start the database:
 
 ```bash
-cargo pgrx start pg14
+cargo pgrx start pg16
 ```
 
 To connect:
 
 ```bash
-cargo pgrx connect pg14
+cargo pgrx connect pg16
 ```
 
-Finally, to enable the `pg_graphql` extension in PostgreSQL, execute the `create extension` statement. This extension creates its own schema/namespace named `graphql` to avoid naming conflicts.
+Finally, to enable the `pg_graphql` extension in Postgres, execute the `create extension` statement. This extension creates its own schema/namespace named `graphql` to avoid naming conflicts.
 
 ```psql
 create extension pg_graphql;
 ```
 
-These additional steps ensure that `pgrx` is properly initialized, and the database is started and connected before attempting to install and use the `pg_graphql` extension.
+These steps ensure that `pgrx` is properly initialized, and the database is started and connected before attempting to install and use the `pg_graphql` extension.


### PR DESCRIPTION
## What kind of change does this PR introduce?

doc update

## What is the current behavior?

[Installation Documentation missing some steps "cargo pgrx init ... start ... connect" #403](https://github.com/supabase/pg_graphql/issues/403)

## What is the new behavior?

This update includes the necessary steps to initialize pgrx, start the PostgreSQL database, and connect to it before enabling the pg_graphql extension. These steps address the gap in the installation process for new users, ensuring a smoother setup experience.

## Additional context

Closes #403
