### PR TITLE
Fix typo in `installation.md`

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,4 +1,4 @@
-First, install [pgrx](https://github.com/tcdi/pgrx) by running `cargo install --locked cargo-pgrx@version`, where version should be compatible with the [pgrx version used by pg_graphl](https://github.com/supabase/pg_graphql/blob/master/Cargo.toml#L16)
+First, install [pgrx](https://github.com/tcdi/pgrx) by running `cargo install --locked cargo-pgrx@version`, where version should be compatible with the [pgrx version used by pg_graphql](https://github.com/supabase/pg_graphql/blob/master/Cargo.toml#L16)
 
 Then clone the repo and install using
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

`pg_graphql` is misspelled.

## What is the new behavior?

Typo is fixed.

## Additional context

Just a minor typo fix in the word `pg_graphql`