### PR TITLE
disable sync_writes to fix #490

### DIFF
--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -544,8 +544,7 @@ pub enum __Type {
 #[cached(
     type = "SizedCache<u64, HashMap<String, __Field>>",
     create = "{ SizedCache::with_size(1000) }",
-    convert = r#"{ calculate_hash(type_) }"#,
-    sync_writes = true
+    convert = r#"{ calculate_hash(type_) }"#
 )]
 pub fn field_map(type_: &__Type) -> HashMap<String, __Field> {
     let mut hmap = HashMap::new();
@@ -570,8 +569,7 @@ pub fn field_map(type_: &__Type) -> HashMap<String, __Field> {
 #[cached(
     type = "SizedCache<u64, HashMap<String, __InputValue>>",
     create = "{ SizedCache::with_size(1000) }",
-    convert = r#"{ calculate_hash(type_) }"#,
-    sync_writes = true
+    convert = r#"{ calculate_hash(type_) }"#
 )]
 pub fn input_field_map(type_: &__Type) -> HashMap<String, __InputValue> {
     let mut hmap = HashMap::new();
@@ -3875,8 +3873,7 @@ pub struct __Schema {
 #[cached(
     type = "SizedCache<String, HashMap<String, __Type>>",
     create = "{ SizedCache::with_size(200) }",
-    convert = r#"{ serde_json::ser::to_string(&schema.context.config).expect("schema config should be a string") }"#,
-    sync_writes = true
+    convert = r#"{ serde_json::ser::to_string(&schema.context.config).expect("schema config should be a string") }"#
 )]
 pub fn type_map(schema: &__Schema) -> HashMap<String, __Type> {
     let tmap: HashMap<String, __Type> = schema

--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -791,8 +791,7 @@ pub fn calculate_hash<T: Hash>(t: &T) -> u64 {
 #[cached(
     type = "SizedCache<u64, Result<Arc<Context>, String>>",
     create = "{ SizedCache::with_size(250) }",
-    convert = r#"{ calculate_hash(_config) }"#,
-    sync_writes = true
+    convert = r#"{ calculate_hash(_config) }"#
 )]
 pub fn load_sql_context(_config: &Config) -> Result<Arc<Context>, String> {
     // cache value for next query


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If a function annotated with the `cached` attribute panics, all subsequent graphql queries fail with a lock poisoned error.

## What is the new behavior?

The subsequent queries no longer fail with lock poisoned error because we disable calling the function while the lock is held by disabling `sync_writes = true`.

## Additional context

Fix #490
