### PR TITLE
Adding support for filtering on array column types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_graphql"
-version = "1.5.4"
+version = "1.5.5"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_graphql"
-version = "1.5.5"
+version = "1.5.4"
 edition = "2021"
 
 [lib]

--- a/dockerfiles/db/setup.sql
+++ b/dockerfiles/db/setup.sql
@@ -50,7 +50,7 @@ create table blog(
 );
 
 
-create type blog_post_status as enum ('PENDING', 'RELEASED', 'ARCHIVED');
+create type blog_post_status as enum ('PENDING', 'RELEASED');
 
 
 create table blog_post(
@@ -86,7 +86,7 @@ values
     ((SELECT id FROM blog WHERE name = 'A: Blog 1'), 'Post 1 in A Blog 1', 'Content for post 1 in A Blog 1', '{"tech", "update"}', 'RELEASED', NOW()),
     ((SELECT id FROM blog WHERE name = 'A: Blog 1'), 'Post 2 in A Blog 1', 'Content for post 2 in A Blog 1', '{"announcement", "tech"}', 'PENDING', NOW()),
     ((SELECT id FROM blog WHERE name = 'A: Blog 2'), 'Post 1 in A Blog 2', 'Content for post 1 in A Blog 2', '{"personal"}', 'RELEASED', NOW()),
-    ((SELECT id FROM blog WHERE name = 'A: Blog 2'), 'Post 2 in A Blog 2', 'Content for post 2 in A Blog 2', '{"update"}', 'ARCHIVED', NOW()),
+    ((SELECT id FROM blog WHERE name = 'A: Blog 2'), 'Post 2 in A Blog 2', 'Content for post 2 in A Blog 2', '{"update"}', 'RELEASED', NOW()),
     ((SELECT id FROM blog WHERE name = 'A: Blog 3'), 'Post 1 in A Blog 3', 'Content for post 1 in A Blog 3', '{"travel", "adventure"}', 'PENDING', NOW()),
     ((SELECT id FROM blog WHERE name = 'B: Blog 3'), 'Post 1 in B Blog 3', 'Content for post 1 in B Blog 3', '{"tech", "review"}', 'RELEASED', NOW()),
     ((SELECT id FROM blog WHERE name = 'B: Blog 3'), 'Post 2 in B Blog 3', 'Content for post 2 in B Blog 3', '{"coding", "tutorial"}', 'PENDING', NOW());

--- a/dockerfiles/db/setup.sql
+++ b/dockerfiles/db/setup.sql
@@ -50,7 +50,7 @@ create table blog(
 );
 
 
-create type blog_post_status as enum ('PENDING', 'RELEASED');
+create type blog_post_status as enum ('PENDING', 'RELEASED', 'ARCHIVED');
 
 
 create table blog_post(

--- a/dockerfiles/db/setup.sql
+++ b/dockerfiles/db/setup.sql
@@ -80,7 +80,6 @@ values
     ((select id from account where email ilike 'a%'), 'A: Blog 3', 'a desc3', now()),
     ((select id from account where email ilike 'b%'), 'B: Blog 3', 'b desc1', now());
 
--- Sample inserts for blog_post
 insert into blog_post (blog_id, title, body, tags, status, created_at)
 values
     ((SELECT id FROM blog WHERE name = 'A: Blog 1'), 'Post 1 in A Blog 1', 'Content for post 1 in A Blog 1', '{"tech", "update"}', 'RELEASED', NOW()),

--- a/dockerfiles/db/setup.sql
+++ b/dockerfiles/db/setup.sql
@@ -58,6 +58,7 @@ create table blog_post(
     blog_id integer not null references blog(id) on delete cascade,
     title varchar(255) not null,
     body varchar(10000),
+    tags TEXT[],
     status blog_post_status not null,
     created_at timestamp not null
 );
@@ -78,6 +79,17 @@ values
     ((select id from account where email ilike 'a%'), 'A: Blog 2', 'a desc2', now()),
     ((select id from account where email ilike 'a%'), 'A: Blog 3', 'a desc3', now()),
     ((select id from account where email ilike 'b%'), 'B: Blog 3', 'b desc1', now());
+
+-- Sample inserts for blog_post
+insert into blog_post (blog_id, title, body, tags, status, created_at)
+values
+    ((SELECT id FROM blog WHERE name = 'A: Blog 1'), 'Post 1 in A Blog 1', 'Content for post 1 in A Blog 1', '{"tech", "update"}', 'RELEASED', NOW()),
+    ((SELECT id FROM blog WHERE name = 'A: Blog 1'), 'Post 2 in A Blog 1', 'Content for post 2 in A Blog 1', '{"announcement", "tech"}', 'PENDING', NOW()),
+    ((SELECT id FROM blog WHERE name = 'A: Blog 2'), 'Post 1 in A Blog 2', 'Content for post 1 in A Blog 2', '{"personal"}', 'RELEASED', NOW()),
+    ((SELECT id FROM blog WHERE name = 'A: Blog 2'), 'Post 2 in A Blog 2', 'Content for post 2 in A Blog 2', '{"update"}', 'ARCHIVED', NOW()),
+    ((SELECT id FROM blog WHERE name = 'A: Blog 3'), 'Post 1 in A Blog 3', 'Content for post 1 in A Blog 3', '{"travel", "adventure"}', 'PENDING', NOW()),
+    ((SELECT id FROM blog WHERE name = 'B: Blog 3'), 'Post 1 in B Blog 3', 'Content for post 1 in B Blog 3', '{"tech", "review"}', 'RELEASED', NOW()),
+    ((SELECT id FROM blog WHERE name = 'B: Blog 3'), 'Post 2 in B Blog 3', 'Content for post 2 in B Blog 3', '{"coding", "tutorial"}', 'PENDING', NOW());
 
 
 comment on schema public is '@graphql({"inflect_names": true})';

--- a/docs/api.md
+++ b/docs/api.md
@@ -526,6 +526,7 @@ Where the `<Table>Filter` type enumerates filterable fields and their associated
       id: IntFilter
       name: StringFilter
       description: StringFilter
+      tags: StringListFilter
       createdAt: DatetimeFilter
       updatedAt: DatetimeFilter
       and: [BlogFilter!]
@@ -575,6 +576,25 @@ Where the `<Table>Filter` type enumerates filterable fields and their associated
     }
     ```
 
+=== "StringListFilter"
+
+    ```graphql
+    """
+    Boolean expression comparing fields on type "StringList"
+    """
+    input StringListFilter {
+      cd: [String!]
+      cs: [String!]
+      eq: [String!]
+      gt: [String!]
+      gte: [String!]
+      lt: [String!]
+      lte: [String!]
+      neq: [String!]
+      ov: [String!]
+    }
+    ```
+
 === "FilterIs"
 
     ```graphql
@@ -587,21 +607,24 @@ Where the `<Table>Filter` type enumerates filterable fields and their associated
 The following list shows the operators that may be available on `<Type>Filter` types.
 
 
-| Operator    | Description                                      |
-| ----------- | -------------------------------------------------|
-| eq          | Equal To                                         |
-| neq         | Not Equal To                                     |
-| gt          | Greater Than                                     |
-| gte         | Greater Than Or Equal To                         |
-| in          | Contained by Value List                          |
-| lt          | Less Than                                        |
-| lte         | Less Than Or Equal To                            |
-| is          | Null or Not Null                                 |
-| startsWith  | Starts with prefix                               |
-| like        | Pattern Match. '%' as wildcard                   |
-| ilike       | Pattern Match. '%' as wildcard. Case Insensitive |
-| regex       | POSIX Regular Expression Match                   |
-| iregex      | POSIX Regular Expression Match. Case Insensitive |
+| Operator   | Description                                                       |
+|------------|-------------------------------------------------------------------|
+| eq         | Equal To                                                          |
+| neq        | Not Equal To                                                      |
+| gt         | Greater Than                                                      |
+| gte        | Greater Than Or Equal To                                          |
+| in         | Contained by Value List                                           |
+| lt         | Less Than                                                         |
+| lte        | Less Than Or Equal To                                             |
+| is         | Null or Not Null                                                  |
+| startsWith | Starts with prefix                                                |
+| like       | Pattern Match. '%' as wildcard                                    |
+| ilike      | Pattern Match. '%' as wildcard. Case Insensitive                  |
+| regex      | POSIX Regular Expression Match                                    |
+| iregex     | POSIX Regular Expression Match. Case Insensitive                  |
+| cs         | Contains. Applies to array columns only.                          |
+| cd         | Contained in. Applies to array columns only.                      |
+| ov         | Overlap (have points in common). Applies to array columns only.   |
 
 Not all operators are available on every `<Type>Filter` type. For example, `UUIDFilter` only supports `eq` and `neq` because `UUID`s are not ordered.
 
@@ -650,7 +673,256 @@ Not all operators are available on every `<Type>Filter` type. For example, `UUID
     ```
 
 
-** Example: and/or **
+**Example: array column**
+
+The `cs` filter is used to return results where all the elements in the input array appear in the array column.
+
+=== "`cs` Filter Query"
+    ```graphql
+    {
+      blogCollection(
+        filter: {tags: {cs: ["tech", "innovation"]}},
+      ) {
+        edges {
+          cursor
+          node {
+            id
+            name
+            tags
+            createdAt
+          }
+        }
+      }
+    }
+    ```
+
+=== "`cs` Filter Result"
+    ```json
+    {
+      "data": {
+        "blogCollection": {
+          "edges": [
+            {
+              "node": {
+                "id": 1,
+                "name": "A: Blog 1",
+                "createdAt": "2023-07-24T04:01:09.882781",
+                "tags": ["tech", "innovation"]
+              },
+              "cursor": "WzFd"
+            },
+            {
+              "node": {
+                "id": 2,
+                "name": "A: Blog 2",
+                "createdAt": "2023-07-24T04:01:09.882781",
+                "tags": ["tech", "innovation", "entrepreneurship"]
+              },
+              "cursor": "WzJd"
+            }
+          ]
+        }
+      }
+    }
+    ```
+
+The `cs` filter can also accept a single scalar.
+
+=== "`cs` Filter with Scalar Query"
+    ```graphql
+    {
+      blogCollection(
+        filter: {tags: {cs: "tech"}},
+      ) {
+        edges {
+          cursor
+          node {
+            id
+            name
+            tags
+            createdAt
+          }
+        }
+      }
+    }
+    ```
+
+=== "`cs` Filter with Scalar Result"
+    ```json
+    {
+      "data": {
+        "blogCollection": {
+          "edges": [
+            {
+              "node": {
+                "id": 1,
+                "name": "A: Blog 1",
+                "createdAt": "2023-07-24T04:01:09.882781",
+                "tags": ["tech", "innovation"]
+              },
+              "cursor": "WzFd"
+            },
+            {
+              "node": {
+                "id": 2,
+                "name": "A: Blog 2",
+                "createdAt": "2023-07-24T04:01:09.882781",
+                "tags": ["tech", "innovation", "entrepreneurship"]
+              },
+              "cursor": "WzJd"
+            }
+          ]
+        }
+      }
+    }
+    ```
+
+The `cd` filter is used to return results where every element of the array column appears in the input array.
+
+=== "`cd` Filter Query"
+    ```graphql
+    {
+      blogCollection(
+        filter: {tags: {cd: ["entrepreneurship", "innovation", "tech"]}},
+      ) {
+        edges {
+          cursor
+          node {
+            id
+            name
+            tags
+            createdAt
+          }
+        }
+      }
+    }
+    ```
+
+=== "`cd` Filter Result"
+    ```json
+    {
+      "data": {
+        "blogCollection": {
+          "edges": [
+            {
+              "node": {
+                "id": 3,
+                "name": "A: Blog 3",
+                "createdAt": "2023-07-24T04:01:09.882781",
+                "tags": ["innovation", "entrepreneurship"]
+              },
+              "cursor": "WzNd"
+            }
+          ]
+        }
+      }
+    }
+    ```
+
+The `cd` filter can also accept a single scalar. In this case, only results where the only element in the array column is the input scalar.
+
+=== "`cd` Filter with Scalar Query"
+    ```graphql
+    {
+      blogCollection(
+        filter: {tags: {cd: "travel"}},
+      ) {
+        edges {
+          cursor
+          node {
+            id
+            name
+            tags
+            createdAt
+          }
+        }
+      }
+    }
+    ```
+
+=== "`cd` Filter with Scalar Result"
+    ```json
+    {
+      "data": {
+        "blogCollection": {
+          "edges": [
+            {
+              "node": {
+                "id": 4,
+                "name": "A: Blog 4",
+                "createdAt": "2023-07-24T04:01:09.882781",
+                "tags": ["travel"]
+              },
+              "cursor": "WzPd"
+            }
+          ]
+        }
+      }
+    }
+    ```
+
+The `ov` filter is used to return results where the array column and the input array have at least one element in common.
+
+=== "`ov` Filter Query"
+    ```graphql
+    {
+      blogCollection(
+        filter: {tags: {ov: ["tech", "travel"]}},
+      ) {
+        edges {
+          cursor
+          node {
+            id
+            name
+            tags
+            createdAt
+          }
+        }
+      }
+    }
+    ```
+
+=== "`ov` Filter Result"
+    ```json
+    {
+      "data": {
+        "blogCollection": {
+          "edges": [
+            {
+              "node": {
+                "id": 1,
+                "name": "A: Blog 1",
+                "createdAt": "2023-07-24T04:01:09.882781",
+                "tags": ["tech", "innovation"]
+              },
+              "cursor": "WzFd"
+            },
+            {
+              "node": {
+                "id": 2,
+                "name": "A: Blog 2",
+                "createdAt": "2023-07-24T04:01:09.882781",
+                "tags": ["tech", "innovation", "entrepreneurship"]
+              },
+              "cursor": "WzJd"
+            },
+            {
+              "node": {
+                "id": 4,
+                "name": "A: Blog 4",
+                "createdAt": "2023-07-24T04:01:09.882781",
+                "tags": ["travel"]
+              },
+              "cursor": "WzPd"
+            }
+          ]
+        }
+      }
+    }
+    ```
+
+
+**Example: and/or**
 
 Multiple filters can be combined with `and`, `or` and `not` operators. The `and` and `or` operators accept a list of `<Type>Filter`.
 
@@ -754,7 +1026,7 @@ Multiple filters can be combined with `and`, `or` and `not` operators. The `and`
     ```
 
 
-** Example: not **
+**Example: not**
 
 `not` accepts a single `<Type>Filter`.
 
@@ -819,7 +1091,7 @@ Multiple filters can be combined with `and`, `or` and `not` operators. The `and`
     ```
 
 
-** Example: nested composition **
+**Example: nested composition**
 
 The `and`, `or` and `not` operators can be arbitrarily nested inside each other.
 
@@ -888,7 +1160,7 @@ The `and`, `or` and `not` operators can be arbitrarily nested inside each other.
     }
     ```
 
-** Example: empty **
+**Example: empty**
 
 Empty filters are ignored, i.e. they behave as if the operator was not specified at all.
 
@@ -963,7 +1235,7 @@ Empty filters are ignored, i.e. they behave as if the operator was not specified
     ```
 
 
-** Example: implicit and **
+**Example: implicit and**
 
 Multiple column filters at the same level will be implicitly combined with boolean `and`. In the following example the `id: {eq: 1}` and `name: {eq: "A: Blog 1"}` will be `and`ed.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -806,6 +806,15 @@ The `cd` filter is used to return results where every element of the array colum
           "edges": [
             {
               "node": {
+                "id": 1,
+                "name": "A: Blog 1",
+                "createdAt": "2023-07-24T04:01:09.882781",
+                "tags": ["tech", "innovation"]
+              },
+              "cursor": "WzFd"
+            },
+            {
+              "node": {
                 "id": 3,
                 "name": "A: Blog 3",
                 "createdAt": "2023-07-24T04:01:09.882781",

--- a/docs/api.md
+++ b/docs/api.md
@@ -828,7 +828,7 @@ The `cd` filter is used to return results where every element of the array colum
     }
     ```
 
-The `cd` filter can also accept a single scalar. In this case, only results where the only element in the array column is the input scalar.
+The `cd` filter can also accept a single scalar. In this case, only results where the only element in the array column is the input scalar are returned.
 
 === "`cd` Filter with Scalar Query"
     ```graphql

--- a/docs/assets/demo_schema.graphql
+++ b/docs/assets/demo_schema.graphql
@@ -125,6 +125,21 @@ input BigFloatFilter {
   neq: BigFloat
 }
 
+"""
+Boolean expression comparing fields on type "BigFloatList"
+"""
+input BigFloatListFilter {
+  cd: [BigFloat!]
+  cs: [BigFloat!]
+  eq: [BigFloat!]
+  gt: [BigFloat!]
+  gte: [BigFloat!]
+  lt: [BigFloat!]
+  lte: [BigFloat!]
+  neq: [BigFloat!]
+  ov: [BigFloat!]
+}
+
 """An arbitrary size integer represented as a string"""
 scalar BigInt
 
@@ -142,6 +157,21 @@ input BigIntFilter {
   neq: BigInt
 }
 
+"""
+Boolean expression comparing fields on type "BigIntList"
+"""
+input BigIntListFilter {
+  cd: [BigInt!]
+  cs: [BigInt!]
+  eq: [BigInt!]
+  gt: [BigInt!]
+  gte: [BigInt!]
+  lt: [BigInt!]
+  lte: [BigInt!]
+  neq: [BigInt!]
+  ov: [BigInt!]
+}
+
 type Blog implements Node {
   """Globally Unique Record Identifier"""
   nodeId: ID!
@@ -149,6 +179,7 @@ type Blog implements Node {
   ownerId: Int!
   name: String!
   description: String
+  tags: [String]
   createdAt: Datetime!
   updatedAt: Datetime!
   owner: Account!
@@ -201,6 +232,7 @@ input BlogFilter {
   ownerId: IntFilter
   name: StringFilter
   description: StringFilter
+  tags: StringListFilter
   createdAt: DatetimeFilter
   updatedAt: DatetimeFilter
   nodeId: IDFilter
@@ -385,6 +417,21 @@ input BooleanFilter {
 }
 
 """
+Boolean expression comparing fields on type "BooleanList"
+"""
+input BooleanListFilter {
+  cd: [Boolean!]
+  cs: [Boolean!]
+  eq: [Boolean!]
+  gt: [Boolean!]
+  gte: [Boolean!]
+  lt: [Boolean!]
+  lte: [Boolean!]
+  neq: [Boolean!]
+  ov: [Boolean!]
+}
+
+"""
 An opaque string using for tracking a position in results during pagination
 """
 scalar Cursor
@@ -406,6 +453,21 @@ input DateFilter {
   neq: Date
 }
 
+"""
+Boolean expression comparing fields on type "DateList"
+"""
+input DateListFilter {
+  cd: [Date!]
+  cs: [Date!]
+  eq: [Date!]
+  gt: [Date!]
+  gte: [Date!]
+  lt: [Date!]
+  lte: [Date!]
+  neq: [Date!]
+  ov: [Date!]
+}
+
 """A date and time"""
 scalar Datetime
 
@@ -421,6 +483,21 @@ input DatetimeFilter {
   lt: Datetime
   lte: Datetime
   neq: Datetime
+}
+
+"""
+Boolean expression comparing fields on type "DatetimeList"
+"""
+input DatetimeListFilter {
+  cd: [Datetime!]
+  cs: [Datetime!]
+  eq: [Datetime!]
+  gt: [Datetime!]
+  gte: [Datetime!]
+  lt: [Datetime!]
+  lte: [Datetime!]
+  neq: [Datetime!]
+  ov: [Datetime!]
 }
 
 enum FilterIs {
@@ -443,10 +520,40 @@ input FloatFilter {
 }
 
 """
+Boolean expression comparing fields on type "FloatList"
+"""
+input FloatListFilter {
+  cd: [Float!]
+  cs: [Float!]
+  eq: [Float!]
+  gt: [Float!]
+  gte: [Float!]
+  lt: [Float!]
+  lte: [Float!]
+  neq: [Float!]
+  ov: [Float!]
+}
+
+"""
 Boolean expression comparing fields on type "ID"
 """
 input IDFilter {
   eq: ID
+}
+
+"""
+Boolean expression comparing fields on type "IDList"
+"""
+input IDListFilter {
+  cd: [ID!]
+  cs: [ID!]
+  eq: [ID!]
+  gt: [ID!]
+  gte: [ID!]
+  lt: [ID!]
+  lte: [ID!]
+  neq: [ID!]
+  ov: [ID!]
 }
 
 """
@@ -461,6 +568,21 @@ input IntFilter {
   lt: Int
   lte: Int
   neq: Int
+}
+
+"""
+Boolean expression comparing fields on type "IntList"
+"""
+input IntListFilter {
+  cd: [Int!]
+  cs: [Int!]
+  eq: [Int!]
+  gt: [Int!]
+  gte: [Int!]
+  lt: [Int!]
+  lte: [Int!]
+  neq: [Int!]
+  ov: [Int!]
 }
 
 """A Javascript Object Notation value serialized as a string"""
@@ -703,6 +825,21 @@ input StringFilter {
   startsWith: String
 }
 
+"""
+Boolean expression comparing fields on type "StringList"
+"""
+input StringListFilter {
+  cd: [String!]
+  cs: [String!]
+  eq: [String!]
+  gt: [String!]
+  gte: [String!]
+  lt: [String!]
+  lte: [String!]
+  neq: [String!]
+  ov: [String!]
+}
+
 """A time without date information"""
 scalar Time
 
@@ -720,6 +857,21 @@ input TimeFilter {
   neq: Time
 }
 
+"""
+Boolean expression comparing fields on type "TimeList"
+"""
+input TimeListFilter {
+  cd: [Time!]
+  cs: [Time!]
+  eq: [Time!]
+  gt: [Time!]
+  gte: [Time!]
+  lt: [Time!]
+  lte: [Time!]
+  neq: [Time!]
+  ov: [Time!]
+}
+
 """A universally unique identifier"""
 scalar UUID
 
@@ -731,4 +883,19 @@ input UUIDFilter {
   in: [UUID!]
   is: FilterIs
   neq: UUID
+}
+
+"""
+Boolean expression comparing fields on type "UUIDList"
+"""
+input UUIDListFilter {
+  cd: [UUID!]
+  cs: [UUID!]
+  eq: [UUID!]
+  gt: [UUID!]
+  gte: [UUID!]
+  lt: [UUID!]
+  lte: [UUID!]
+  neq: [UUID!]
+  ov: [UUID!]
 }

--- a/docs/assets/demo_schema.sql
+++ b/docs/assets/demo_schema.sql
@@ -16,6 +16,7 @@ create table blog(
     owner_id integer not null references account(id),
     name varchar(255) not null,
     description varchar(255),
+    tags text[],
     created_at timestamp not null,
     updated_at timestamp not null
 );

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1137,7 +1137,7 @@ fn create_filters(
                     }
                 }
             }
-            gson::Value::Array(values) => if k == AND_FILTER_NAME || k == OR_FILTER_NAME {
+            gson::Value::Array(values) if k == AND_FILTER_NAME || k == OR_FILTER_NAME => {
                 // If there are no inner filters we avoid creating an argumentless `and`/`or` expression
                 // which would have been anyways compiled away during transpilation
                 if !values.is_empty() {
@@ -1171,27 +1171,8 @@ fn create_filters(
 
                     filters.push(filter_builder);
                 }
-            } else {
-                if !values.is_empty() {
-                    for value in values {
-                        if let gson::Value::Object(filter_op_to_value_map) = value {
-                            for (filter_op_str, filter_val) in filter_op_to_value_map {
-                                let filter_op = FilterOp::from_str(filter_op_str)?;
-
-                                // Skip absent
-                                // Technically nulls should be treated as literals. It will always filter out all rows
-                                // val <op> null is never true
-                                if filter_val == &gson::Value::Absent {
-                                    continue;
-                                }
-
-                                filters.push(create_filter_builder_elem(filter_iv, filter_op, filter_val)?);
                             }
-                        }
-                    }
-                }
-            }
-            _ => return Err("Filter re-validation error op_to_value map".to_string()),
+            _ => return Err("Filter re-validation errror op_to_value map".to_string()),
         }
     }
     Ok(filters)

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1085,7 +1085,7 @@ fn create_filters(
     let kv_map = match validated {
         gson::Value::Absent | gson::Value::Null => return Ok(filters),
         gson::Value::Object(kv) => kv,
-        _ => return Err("Filter re-validation errror".to_string()),
+        _ => return Err("Filter re-validation error".to_string()),
     };
 
     for (k, op_to_v) in kv_map {
@@ -1174,22 +1174,19 @@ fn create_filters(
             } else {
                 if !values.is_empty() {
                     for value in values {
-                        match value {
-                            gson::Value::Object(filter_op_to_value_map) => {
-                                for (filter_op_str, filter_val) in filter_op_to_value_map {
-                                    let filter_op = FilterOp::from_str(filter_op_str)?;
+                        if let gson::Value::Object(filter_op_to_value_map) = value {
+                            for (filter_op_str, filter_val) in filter_op_to_value_map {
+                                let filter_op = FilterOp::from_str(filter_op_str)?;
 
-                                    // Skip absent
-                                    // Technically nulls should be treated as literals. It will always filter out all rows
-                                    // val <op> null is never true
-                                    if filter_val == &gson::Value::Absent {
-                                        continue;
-                                    }
-
-                                    filters.push(create_filter_builder_elem(filter_iv, filter_op, filter_val)?);
+                                // Skip absent
+                                // Technically nulls should be treated as literals. It will always filter out all rows
+                                // val <op> null is never true
+                                if filter_val == &gson::Value::Absent {
+                                    continue;
                                 }
-                            },
-                            _ => return Err("Filter re-validation error op_to_value map".to_string()),
+
+                                filters.push(create_filter_builder_elem(filter_iv, filter_op, filter_val)?);
+                            }
                         }
                     }
                 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1171,7 +1171,7 @@ fn create_filters(
 
                     filters.push(filter_builder);
                 }
-                            }
+            }
             _ => return Err("Filter re-validation errror op_to_value map".to_string()),
         }
     }

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1130,7 +1130,10 @@ impl FilterTypeType {
         match &self.entity {
             FilterableType::Scalar(s) => s.name().expect("scalar name should exist"),
             FilterableType::Enum(e) => e.name().expect("enum type name should exist"),
-            FilterableType::List(l) => l.name().expect("list type name should exist"),
+            FilterableType::List(l) => match l.of_type().unwrap().name() {
+                None => panic!("inner list type name should exist"),
+                Some(name) => format!("{}List", name)
+            },
         }
     }
 }

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -3704,9 +3704,13 @@ impl ___Type for FilterEntityType {
                         }),
                         __Type::List(l) => Some(__InputValue {
                             name_: column_graphql_name,
-                            type_: __Type::FilterType(FilterTypeType {
-                                entity: FilterableType::List(l),
-                                schema: Arc::clone(&self.schema),
+                            type_: __Type::List(ListType {
+                                type_: Box::new(__Type::NonNull(NonNullType {
+                                    type_: Box::new(__Type::FilterType(FilterTypeType {
+                                        entity: FilterableType::List(l),
+                                        schema: Arc::clone(&self.schema),
+                                    })),
+                                })),
                             }),
                             description: None,
                             default_value: None,

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -3681,7 +3681,7 @@ impl ___Type for FilterEntityType {
                         not_column_exists = true;
                     }
 
-                    match utype.unmodified_type() {
+                    match utype {
                         __Type::Scalar(s) => Some(__InputValue {
                             name_: column_graphql_name,
                             type_: __Type::FilterType(FilterTypeType {

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -3707,13 +3707,9 @@ impl ___Type for FilterEntityType {
                         }),
                         __Type::List(l) => Some(__InputValue {
                             name_: column_graphql_name,
-                            type_: __Type::List(ListType {
-                                type_: Box::new(__Type::NonNull(NonNullType {
-                                    type_: Box::new(__Type::FilterType(FilterTypeType {
-                                        entity: FilterableType::List(l),
-                                        schema: Arc::clone(&self.schema),
-                                    })),
-                                })),
+                            type_: __Type::FilterType(FilterTypeType {
+                                entity: FilterableType::List(l),
+                                schema: Arc::clone(&self.schema),
                             }),
                             description: None,
                             default_value: None,

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -3684,17 +3684,19 @@ impl ___Type for FilterEntityType {
                         not_column_exists = true;
                     }
 
-                    match utype {
-                        __Type::Scalar(s) => Some(__InputValue {
-                            name_: column_graphql_name,
-                            type_: __Type::FilterType(FilterTypeType {
-                                entity: FilterableType::Scalar(s),
-                                schema: Arc::clone(&self.schema),
-                            }),
-                            description: None,
-                            default_value: None,
-                            sql_type: Some(NodeSQLType::Column(Arc::clone(col))),
-                        }),
+                    match utype.nullable_type() {
+                        __Type::Scalar(s) => {
+                            Some(__InputValue {
+                                name_: column_graphql_name,
+                                type_: __Type::FilterType(FilterTypeType {
+                                    entity: FilterableType::Scalar(s),
+                                    schema: Arc::clone(&self.schema),
+                                }),
+                                description: None,
+                                default_value: None,
+                                sql_type: Some(NodeSQLType::Column(Arc::clone(col))),
+                            })
+                        },
                         __Type::Enum(e) => Some(__InputValue {
                             name_: column_graphql_name,
                             type_: __Type::FilterType(FilterTypeType {

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -3330,6 +3330,9 @@ pub enum FilterOp {
     ILike,
     RegEx,
     IRegEx,
+    Contains,
+    ContainedBy,
+    Overlap,
 }
 
 impl ToString for FilterOp {
@@ -3348,6 +3351,9 @@ impl ToString for FilterOp {
             Self::ILike => "ilike",
             Self::RegEx => "regex",
             Self::IRegEx => "iregex",
+            Self::Contains => "cs",
+            Self::ContainedBy => "cd",
+            Self::Overlap => "ov",
         }
         .to_string()
     }
@@ -3371,6 +3377,9 @@ impl FromStr for FilterOp {
             "ilike" => Ok(Self::ILike),
             "regex" => Ok(Self::RegEx),
             "iregex" => Ok(Self::IRegEx),
+            "cs" => Ok(Self::Contains),
+            "cd" => Ok(Self::ContainedBy),
+            "ov" => Ok(Self::Overlap),
             _ => Err("Invalid filter operation".to_string()),
         }
     }
@@ -3543,6 +3552,8 @@ impl ___Type for FilterTypeType {
                             default_value: None,
                             sql_type: None,
                         },
+                        // shouldn't happen since we've covered all cases in supported_ops
+                        _ => panic!("encountered unknown FilterOp")
                     })
                     .collect()
             }
@@ -3584,6 +3595,36 @@ impl ___Type for FilterTypeType {
                         sql_type: None,
                     },
                 ]
+            }
+            FilterableType::List(list_type) => {
+                let supported_ops = vec![
+                    FilterOp::Contains,
+                    FilterOp::ContainedBy,
+                    FilterOp::Equal,
+                    FilterOp::GreaterThan,
+                    FilterOp::GreaterThanEqualTo,
+                    FilterOp::LessThan,
+                    FilterOp::LessThanEqualTo,
+                    FilterOp::NotEqual,
+                    FilterOp::Overlap,
+                ];
+
+                supported_ops
+                    .iter()
+                    .map(|op| match op {
+                        _ => __InputValue {
+                            name_: op.to_string(),
+                            type_: __Type::List(ListType {
+                                type_: Box::new(__Type::NonNull(NonNullType {
+                                    type_: Box::new(*list_type.type_.clone()),
+                                })),
+                            }),
+                            description: None,
+                            default_value: None,
+                            sql_type: None,
+                        },
+                    })
+                    .collect()
             }
         };
 

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -4021,6 +4021,72 @@ impl __Schema {
                 entity: FilterableType::Scalar(Scalar::Opaque),
                 schema: Arc::clone(&schema_rc),
             }),
+            __Type::FilterType(FilterTypeType {
+                entity: FilterableType::List(ListType {
+                    type_: Box::new(__Type::Scalar(Scalar::ID))
+                }),
+                schema: Arc::clone(&schema_rc),
+            }),
+            __Type::FilterType(FilterTypeType {
+                entity: FilterableType::List(ListType {
+                    type_: Box::new(__Type::Scalar(Scalar::Int))
+                }),
+                schema: Arc::clone(&schema_rc),
+            }),
+            __Type::FilterType(FilterTypeType {
+                entity: FilterableType::List(ListType {
+                    type_: Box::new(__Type::Scalar(Scalar::Float))
+                }),
+                schema: Arc::clone(&schema_rc),
+            }),
+            __Type::FilterType(FilterTypeType {
+                entity: FilterableType::List(ListType {
+                    type_: Box::new(__Type::Scalar(Scalar::String(None)))
+                }),
+                schema: Arc::clone(&schema_rc),
+            }),
+            __Type::FilterType(FilterTypeType {
+                entity: FilterableType::List(ListType {
+                    type_: Box::new(__Type::Scalar(Scalar::Boolean))
+                }),
+                schema: Arc::clone(&schema_rc),
+            }),
+            __Type::FilterType(FilterTypeType {
+                entity: FilterableType::List(ListType {
+                    type_: Box::new(__Type::Scalar(Scalar::Date))
+                }),
+                schema: Arc::clone(&schema_rc),
+            }),
+            __Type::FilterType(FilterTypeType {
+                entity: FilterableType::List(ListType {
+                    type_: Box::new(__Type::Scalar(Scalar::Time))
+                }),
+                schema: Arc::clone(&schema_rc),
+            }),
+            __Type::FilterType(FilterTypeType {
+                entity: FilterableType::List(ListType {
+                    type_: Box::new(__Type::Scalar(Scalar::Datetime))
+                }),
+                schema: Arc::clone(&schema_rc),
+            }),
+            __Type::FilterType(FilterTypeType {
+                entity: FilterableType::List(ListType {
+                    type_: Box::new(__Type::Scalar(Scalar::BigInt))
+                }),
+                schema: Arc::clone(&schema_rc),
+            }),
+            __Type::FilterType(FilterTypeType {
+                entity: FilterableType::List(ListType {
+                    type_: Box::new(__Type::Scalar(Scalar::UUID))
+                }),
+                schema: Arc::clone(&schema_rc),
+            }),
+            __Type::FilterType(FilterTypeType {
+                entity: FilterableType::List(ListType {
+                    type_: Box::new(__Type::Scalar(Scalar::BigFloat))
+                }),
+                schema: Arc::clone(&schema_rc),
+            }),
             __Type::Query(QueryType {
                 schema: Arc::clone(&schema_rc),
             }),

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -3883,20 +3883,8 @@ impl ___Type for OrderByEntityType {
                 .columns
                 .iter()
                 .filter(|x| x.permissions.is_selectable)
-                // Previously, ordering by arrays was not supported, as shown on the next line.
-                // .filter(|x| !x.type_name.ends_with("[]"))
-                // However, in response to Issue #460, the line above has been commented out and
-                // array types are now exposed in the `orderBy` input for collections.
-                // Per the [latest PostgreSQL docs](https://www.postgresql.org/docs/16/functions-array.html#FUNCTIONS-ARRAY)
-                // at the time of writing, array comparison/ordering works as follows:
-                //
-                // The comparison operators compare the array contents element-by-element, using the
-                // default B-tree comparison function for the element data type, and sort based on the
-                // first difference. In multidimensional arrays the elements are visited in row-major
-                // order (last subscript varies most rapidly). If the contents of two arrays are equal
-                // but the dimensionality is different, the first difference in the dimensionality
-                // information determines the sort order.
-
+                // No ordering by arrays
+                .filter(|x| !x.type_name.ends_with("[]"))
                 // No ordering by composites
                 .filter(|x| !self.schema.context.is_composite(x.type_oid))
                 // No ordering by json/b. they do not support = or <>

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1130,10 +1130,12 @@ impl FilterTypeType {
         match &self.entity {
             FilterableType::Scalar(s) => s.name().expect("scalar name should exist"),
             FilterableType::Enum(e) => e.name().expect("enum type name should exist"),
-            FilterableType::List(l) => match l.of_type().unwrap().name() {
-                None => panic!("inner list type name should exist"),
-                Some(name) => format!("{}List", name)
-            },
+            FilterableType::List(l) => format!(
+                "{}List",
+                l.of_type()
+                    .expect("inner list type should exist")
+                    .name()
+                    .expect("inner list type name should exist"))
         }
     }
 }

--- a/src/transpile.rs
+++ b/src/transpile.rs
@@ -714,6 +714,9 @@ impl FilterBuilderElem {
                     _ => {
                         let cast_type_name = match op {
                             FilterOp::In => format!("{}[]", column.type_name),
+                            FilterOp::Contains => format!("{}[]", column.type_name),
+                            FilterOp::ContainedBy => format!("{}[]", column.type_name),
+                            FilterOp::Overlap => format!("{}[]", column.type_name),
                             _ => column.type_name.clone(),
                         };
 
@@ -735,6 +738,9 @@ impl FilterBuilderElem {
                                 FilterOp::ILike => "ilike",
                                 FilterOp::RegEx => "~",
                                 FilterOp::IRegEx => "~*",
+                                FilterOp::Contains => "@>",
+                                FilterOp::ContainedBy => "<@",
+                                FilterOp::Overlap => "&&",
                                 FilterOp::Is => {
                                     return Err("Error transpiling Is filter".to_string());
                                 }

--- a/test/expected/omit_exotic_types.out
+++ b/test/expected/omit_exotic_types.out
@@ -1,8 +1,7 @@
 begin;
     /*
-        Composite and array types are not currently supported as inputs
+        Composite types are not currently supported as inputs
         - confirm composites are not allowed anywhere
-        - confirm arrays are not allowed as input
     */
     create type complex as (r int, i int);
     create table something(
@@ -106,6 +105,9 @@ begin;
          },                            +
          {                             +
              "name": "name"            +
+         },                            +
+         {                             +
+             "name": "tags"            +
          },                            +
          {                             +
              "name": "nodeId"          +

--- a/test/expected/omit_weird_names.out
+++ b/test/expected/omit_weird_names.out
@@ -25,16 +25,25 @@ begin;
                      "name": "BigFloatFilter"     +
                  },                               +
                  {                                +
+                     "name": "BigFloatListFilter" +
+                 },                               +
+                 {                                +
                      "name": "BigInt"             +
                  },                               +
                  {                                +
                      "name": "BigIntFilter"       +
                  },                               +
                  {                                +
+                     "name": "BigIntListFilter"   +
+                 },                               +
+                 {                                +
                      "name": "Boolean"            +
                  },                               +
                  {                                +
                      "name": "BooleanFilter"      +
+                 },                               +
+                 {                                +
+                     "name": "BooleanListFilter"  +
                  },                               +
                  {                                +
                      "name": "Cursor"             +
@@ -46,10 +55,16 @@ begin;
                      "name": "DateFilter"         +
                  },                               +
                  {                                +
+                     "name": "DateListFilter"     +
+                 },                               +
+                 {                                +
                      "name": "Datetime"           +
                  },                               +
                  {                                +
                      "name": "DatetimeFilter"     +
+                 },                               +
+                 {                                +
+                     "name": "DatetimeListFilter" +
                  },                               +
                  {                                +
                      "name": "FilterIs"           +
@@ -61,16 +76,25 @@ begin;
                      "name": "FloatFilter"        +
                  },                               +
                  {                                +
+                     "name": "FloatListFilter"    +
+                 },                               +
+                 {                                +
                      "name": "ID"                 +
                  },                               +
                  {                                +
                      "name": "IDFilter"           +
                  },                               +
                  {                                +
+                     "name": "IDListFilter"       +
+                 },                               +
+                 {                                +
                      "name": "Int"                +
                  },                               +
                  {                                +
                      "name": "IntFilter"          +
+                 },                               +
+                 {                                +
+                     "name": "IntListFilter"      +
                  },                               +
                  {                                +
                      "name": "JSON"               +
@@ -100,16 +124,25 @@ begin;
                      "name": "StringFilter"       +
                  },                               +
                  {                                +
+                     "name": "StringListFilter"   +
+                 },                               +
+                 {                                +
                      "name": "Time"               +
                  },                               +
                  {                                +
                      "name": "TimeFilter"         +
                  },                               +
                  {                                +
+                     "name": "TimeListFilter"     +
+                 },                               +
+                 {                                +
                      "name": "UUID"               +
                  },                               +
                  {                                +
                      "name": "UUIDFilter"         +
+                 },                               +
+                 {                                +
+                     "name": "UUIDListFilter"     +
                  },                               +
                  {                                +
                      "name": "__Directive"        +

--- a/test/expected/resolve___schema.out
+++ b/test/expected/resolve___schema.out
@@ -102,12 +102,20 @@ begin;
                      "name": "BigFloatFilter"                                                                     +
                  },                                                                                               +
                  {                                                                                                +
+                     "kind": "INPUT_OBJECT",                                                                      +
+                     "name": "BigFloatListFilter"                                                                 +
+                 },                                                                                               +
+                 {                                                                                                +
                      "kind": "SCALAR",                                                                            +
                      "name": "BigInt"                                                                             +
                  },                                                                                               +
                  {                                                                                                +
                      "kind": "INPUT_OBJECT",                                                                      +
                      "name": "BigIntFilter"                                                                       +
+                 },                                                                                               +
+                 {                                                                                                +
+                     "kind": "INPUT_OBJECT",                                                                      +
+                     "name": "BigIntListFilter"                                                                   +
                  },                                                                                               +
                  {                                                                                                +
                      "kind": "OBJECT",                                                                            +
@@ -206,6 +214,10 @@ begin;
                      "name": "BooleanFilter"                                                                      +
                  },                                                                                               +
                  {                                                                                                +
+                     "kind": "INPUT_OBJECT",                                                                      +
+                     "name": "BooleanListFilter"                                                                  +
+                 },                                                                                               +
+                 {                                                                                                +
                      "kind": "SCALAR",                                                                            +
                      "name": "Cursor"                                                                             +
                  },                                                                                               +
@@ -218,12 +230,20 @@ begin;
                      "name": "DateFilter"                                                                         +
                  },                                                                                               +
                  {                                                                                                +
+                     "kind": "INPUT_OBJECT",                                                                      +
+                     "name": "DateListFilter"                                                                     +
+                 },                                                                                               +
+                 {                                                                                                +
                      "kind": "SCALAR",                                                                            +
                      "name": "Datetime"                                                                           +
                  },                                                                                               +
                  {                                                                                                +
                      "kind": "INPUT_OBJECT",                                                                      +
                      "name": "DatetimeFilter"                                                                     +
+                 },                                                                                               +
+                 {                                                                                                +
+                     "kind": "INPUT_OBJECT",                                                                      +
+                     "name": "DatetimeListFilter"                                                                 +
                  },                                                                                               +
                  {                                                                                                +
                      "kind": "ENUM",                                                                              +
@@ -238,6 +258,10 @@ begin;
                      "name": "FloatFilter"                                                                        +
                  },                                                                                               +
                  {                                                                                                +
+                     "kind": "INPUT_OBJECT",                                                                      +
+                     "name": "FloatListFilter"                                                                    +
+                 },                                                                                               +
+                 {                                                                                                +
                      "kind": "SCALAR",                                                                            +
                      "name": "ID"                                                                                 +
                  },                                                                                               +
@@ -246,12 +270,20 @@ begin;
                      "name": "IDFilter"                                                                           +
                  },                                                                                               +
                  {                                                                                                +
+                     "kind": "INPUT_OBJECT",                                                                      +
+                     "name": "IDListFilter"                                                                       +
+                 },                                                                                               +
+                 {                                                                                                +
                      "kind": "SCALAR",                                                                            +
                      "name": "Int"                                                                                +
                  },                                                                                               +
                  {                                                                                                +
                      "kind": "INPUT_OBJECT",                                                                      +
                      "name": "IntFilter"                                                                          +
+                 },                                                                                               +
+                 {                                                                                                +
+                     "kind": "INPUT_OBJECT",                                                                      +
+                     "name": "IntListFilter"                                                                      +
                  },                                                                                               +
                  {                                                                                                +
                      "kind": "SCALAR",                                                                            +
@@ -294,6 +326,10 @@ begin;
                      "name": "StringFilter"                                                                       +
                  },                                                                                               +
                  {                                                                                                +
+                     "kind": "INPUT_OBJECT",                                                                      +
+                     "name": "StringListFilter"                                                                   +
+                 },                                                                                               +
+                 {                                                                                                +
                      "kind": "SCALAR",                                                                            +
                      "name": "Time"                                                                               +
                  },                                                                                               +
@@ -302,12 +338,20 @@ begin;
                      "name": "TimeFilter"                                                                         +
                  },                                                                                               +
                  {                                                                                                +
+                     "kind": "INPUT_OBJECT",                                                                      +
+                     "name": "TimeListFilter"                                                                     +
+                 },                                                                                               +
+                 {                                                                                                +
                      "kind": "SCALAR",                                                                            +
                      "name": "UUID"                                                                               +
                  },                                                                                               +
                  {                                                                                                +
                      "kind": "INPUT_OBJECT",                                                                      +
                      "name": "UUIDFilter"                                                                         +
+                 },                                                                                               +
+                 {                                                                                                +
+                     "kind": "INPUT_OBJECT",                                                                      +
+                     "name": "UUIDListFilter"                                                                     +
                  },                                                                                               +
                  {                                                                                                +
                      "kind": "OBJECT",                                                                            +

--- a/test/expected/resolve_connection_filter.out
+++ b/test/expected/resolve_connection_filter.out
@@ -3,13 +3,14 @@ begin;
         id int primary key,
         is_verified bool,
         name text,
-        phone text
+        phone text,
+        tags text[]
     );
-    insert into public.account(id, is_verified, name, phone)
+    insert into public.account(id, is_verified, name, phone, tags)
     values
-        (1, true, 'foo', '1111111111'),
-        (2, true, 'bar', null),
-        (3, false, 'baz', '33333333333');
+        (1, true, 'foo', '1111111111', '{"customer", "priority"}'),
+        (2, true, 'bar', null, '{"customer"}'),
+        (3, false, 'baz', '33333333333', '{"lead", "priority"}');
     savepoint a;
     -- Filter by Int
     select jsonb_pretty(
@@ -228,6 +229,181 @@ begin;
                                       resolve                                      
 -----------------------------------------------------------------------------------
  {"data": null, "errors": [{"message": "Error transpiling Is filter value type"}]}
+(1 row)
+
+    rollback to savepoint a;
+    -- cs - array column contains the input scalar
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              accountCollection(filter: {tags: {cs: "customer"}}) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+        $$)
+    );
+          jsonb_pretty           
+---------------------------------
+ {                              +
+     "data": {                  +
+         "accountCollection": { +
+             "edges": [         +
+                 {              +
+                     "node": {  +
+                         "id": 1+
+                     }          +
+                 },             +
+                 {              +
+                     "node": {  +
+                         "id": 2+
+                     }          +
+                 }              +
+             ]                  +
+         }                      +
+     }                          +
+ }
+(1 row)
+
+    rollback to savepoint a;
+    -- cd - array column is contained by input scalar (aka, the only value in the array column is the input scalar)
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              accountCollection(filter: {tags: {cd: "customer"}}) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+        $$)
+    );
+          jsonb_pretty           
+---------------------------------
+ {                              +
+     "data": {                  +
+         "accountCollection": { +
+             "edges": [         +
+                 {              +
+                     "node": {  +
+                         "id": 2+
+                     }          +
+                 }              +
+             ]                  +
+         }                      +
+     }                          +
+ }
+(1 row)
+
+    rollback to savepoint a;
+    -- cs - array column contains the input array
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              accountCollection(filter: {tags: {cs: ["customer", "priority"]}}) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+        $$)
+    );
+          jsonb_pretty           
+---------------------------------
+ {                              +
+     "data": {                  +
+         "accountCollection": { +
+             "edges": [         +
+                 {              +
+                     "node": {  +
+                         "id": 1+
+                     }          +
+                 }              +
+             ]                  +
+         }                      +
+     }                          +
+ }
+(1 row)
+
+    rollback to savepoint a;
+    -- cd - array column is contained by input array
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              accountCollection(filter: {tags: {cd: ["customer", "priority"]}}) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+        $$)
+    );
+          jsonb_pretty           
+---------------------------------
+ {                              +
+     "data": {                  +
+         "accountCollection": { +
+             "edges": [         +
+                 {              +
+                     "node": {  +
+                         "id": 1+
+                     }          +
+                 },             +
+                 {              +
+                     "node": {  +
+                         "id": 2+
+                     }          +
+                 }              +
+             ]                  +
+         }                      +
+     }                          +
+ }
+(1 row)
+
+    rollback to savepoint a;
+    -- ov - array column overlaps with input array
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              accountCollection(filter: {tags: {cd: ["customer", "priority"]}}) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+        $$)
+    );
+          jsonb_pretty           
+---------------------------------
+ {                              +
+     "data": {                  +
+         "accountCollection": { +
+             "edges": [         +
+                 {              +
+                     "node": {  +
+                         "id": 1+
+                     }          +
+                 },             +
+                 {              +
+                     "node": {  +
+                         "id": 2+
+                     }          +
+                 }              +
+             ]                  +
+         }                      +
+     }                          +
+ }
 (1 row)
 
     rollback to savepoint a;

--- a/test/expected/resolve_connection_filter.out
+++ b/test/expected/resolve_connection_filter.out
@@ -374,7 +374,7 @@ begin;
     select jsonb_pretty(
         graphql.resolve($$
             {
-              accountCollection(filter: {tags: {cd: ["customer", "priority"]}}) {
+              accountCollection(filter: {tags: {ov: ["customer", "priority"]}}) {
                 edges {
                   node {
                     id
@@ -398,6 +398,11 @@ begin;
                  {              +
                      "node": {  +
                          "id": 2+
+                     }          +
+                 },             +
+                 {              +
+                     "node": {  +
+                         "id": 3+
                      }          +
                  }              +
              ]                  +

--- a/test/expected/roundtrip_types.out
+++ b/test/expected/roundtrip_types.out
@@ -566,166 +566,198 @@ begin;
         }
         $$)
     );
-                   jsonb_pretty                    
----------------------------------------------------
- {                                                +
-     "data": {                                    +
-         "__type": {                              +
-             "kind": "INPUT_OBJECT",              +
-             "inputFields": [                     +
-                 {                                +
-                     "name": "id",                +
-                     "type": {                    +
-                         "kind": "INPUT_OBJECT",  +
-                         "name": "IntFilter",     +
-                         "ofType": null           +
-                     }                            +
-                 },                               +
-                 {                                +
-                     "name": "typeBigint",        +
-                     "type": {                    +
-                         "kind": "INPUT_OBJECT",  +
-                         "name": "BigIntFilter",  +
-                         "ofType": null           +
-                     }                            +
-                 },                               +
-                 {                                +
-                     "name": "typeText",          +
-                     "type": {                    +
-                         "kind": "INPUT_OBJECT",  +
-                         "name": "StringFilter",  +
-                         "ofType": null           +
-                     }                            +
-                 },                               +
-                 {                                +
-                     "name": "typeVarchar",       +
-                     "type": {                    +
-                         "kind": "INPUT_OBJECT",  +
-                         "name": "StringFilter",  +
-                         "ofType": null           +
-                     }                            +
-                 },                               +
-                 {                                +
-                     "name": "typeVarchar_n",     +
-                     "type": {                    +
-                         "kind": "INPUT_OBJECT",  +
-                         "name": "StringFilter",  +
-                         "ofType": null           +
-                     }                            +
-                 },                               +
-                 {                                +
-                     "name": "typeChar",          +
-                     "type": {                    +
-                         "kind": "INPUT_OBJECT",  +
-                         "name": "StringFilter",  +
-                         "ofType": null           +
-                     }                            +
-                 },                               +
-                 {                                +
-                     "name": "typeUuid",          +
-                     "type": {                    +
-                         "kind": "INPUT_OBJECT",  +
-                         "name": "UUIDFilter",    +
-                         "ofType": null           +
-                     }                            +
-                 },                               +
-                 {                                +
-                     "name": "typeDate",          +
-                     "type": {                    +
-                         "kind": "INPUT_OBJECT",  +
-                         "name": "DateFilter",    +
-                         "ofType": null           +
-                     }                            +
-                 },                               +
-                 {                                +
-                     "name": "typeTime",          +
-                     "type": {                    +
-                         "kind": "INPUT_OBJECT",  +
-                         "name": "TimeFilter",    +
-                         "ofType": null           +
-                     }                            +
-                 },                               +
-                 {                                +
-                     "name": "typeDatetime",      +
-                     "type": {                    +
-                         "kind": "INPUT_OBJECT",  +
-                         "name": "DatetimeFilter",+
-                         "ofType": null           +
-                     }                            +
-                 },                               +
-                 {                                +
-                     "name": "typeEnum",          +
-                     "type": {                    +
-                         "kind": "INPUT_OBJECT",  +
-                         "name": "ColorFilter",   +
-                         "ofType": null           +
-                     }                            +
-                 },                               +
-                 {                                +
-                     "name": "typeNumeric",       +
-                     "type": {                    +
-                         "kind": "INPUT_OBJECT",  +
-                         "name": "BigFloatFilter",+
-                         "ofType": null           +
-                     }                            +
-                 },                               +
-                 {                                +
-                     "name": "typeFloat",         +
-                     "type": {                    +
-                         "kind": "INPUT_OBJECT",  +
-                         "name": "FloatFilter",   +
-                         "ofType": null           +
-                     }                            +
-                 },                               +
-                 {                                +
-                     "name": "typeDouble",        +
-                     "type": {                    +
-                         "kind": "INPUT_OBJECT",  +
-                         "name": "FloatFilter",   +
-                         "ofType": null           +
-                     }                            +
-                 },                               +
-                 {                                +
-                     "name": "nodeId",            +
-                     "type": {                    +
-                         "kind": "INPUT_OBJECT",  +
-                         "name": "IDFilter",      +
-                         "ofType": null           +
-                     }                            +
-                 },                               +
-                 {                                +
-                     "name": "and",               +
-                     "type": {                    +
-                         "kind": "LIST",          +
-                         "name": null,            +
-                         "ofType": {              +
-                             "kind": "NON_NULL",  +
-                             "name": null         +
-                         }                        +
-                     }                            +
-                 },                               +
-                 {                                +
-                     "name": "or",                +
-                     "type": {                    +
-                         "kind": "LIST",          +
-                         "name": null,            +
-                         "ofType": {              +
-                             "kind": "NON_NULL",  +
-                             "name": null         +
-                         }                        +
-                     }                            +
-                 },                               +
-                 {                                +
-                     "name": "not",               +
-                     "type": {                    +
-                         "kind": "INPUT_OBJECT",  +
-                         "name": "MainTypeFilter",+
-                         "ofType": null           +
-                     }                            +
-                 }                                +
-             ]                                    +
-         }                                        +
-     }                                            +
+                     jsonb_pretty                      
+-------------------------------------------------------
+ {                                                    +
+     "data": {                                        +
+         "__type": {                                  +
+             "kind": "INPUT_OBJECT",                  +
+             "inputFields": [                         +
+                 {                                    +
+                     "name": "id",                    +
+                     "type": {                        +
+                         "kind": "INPUT_OBJECT",      +
+                         "name": "IntFilter",         +
+                         "ofType": null               +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "typeBigint",            +
+                     "type": {                        +
+                         "kind": "INPUT_OBJECT",      +
+                         "name": "BigIntFilter",      +
+                         "ofType": null               +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "typeText",              +
+                     "type": {                        +
+                         "kind": "INPUT_OBJECT",      +
+                         "name": "StringFilter",      +
+                         "ofType": null               +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "typeVarchar",           +
+                     "type": {                        +
+                         "kind": "INPUT_OBJECT",      +
+                         "name": "StringFilter",      +
+                         "ofType": null               +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "typeVarchar_n",         +
+                     "type": {                        +
+                         "kind": "INPUT_OBJECT",      +
+                         "name": "StringFilter",      +
+                         "ofType": null               +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "typeChar",              +
+                     "type": {                        +
+                         "kind": "INPUT_OBJECT",      +
+                         "name": "StringFilter",      +
+                         "ofType": null               +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "typeUuid",              +
+                     "type": {                        +
+                         "kind": "INPUT_OBJECT",      +
+                         "name": "UUIDFilter",        +
+                         "ofType": null               +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "typeDate",              +
+                     "type": {                        +
+                         "kind": "INPUT_OBJECT",      +
+                         "name": "DateFilter",        +
+                         "ofType": null               +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "typeTime",              +
+                     "type": {                        +
+                         "kind": "INPUT_OBJECT",      +
+                         "name": "TimeFilter",        +
+                         "ofType": null               +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "typeDatetime",          +
+                     "type": {                        +
+                         "kind": "INPUT_OBJECT",      +
+                         "name": "DatetimeFilter",    +
+                         "ofType": null               +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "typeEnum",              +
+                     "type": {                        +
+                         "kind": "INPUT_OBJECT",      +
+                         "name": "ColorFilter",       +
+                         "ofType": null               +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "typeNumeric",           +
+                     "type": {                        +
+                         "kind": "INPUT_OBJECT",      +
+                         "name": "BigFloatFilter",    +
+                         "ofType": null               +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "typeFloat",             +
+                     "type": {                        +
+                         "kind": "INPUT_OBJECT",      +
+                         "name": "FloatFilter",       +
+                         "ofType": null               +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "typeDouble",            +
+                     "type": {                        +
+                         "kind": "INPUT_OBJECT",      +
+                         "name": "FloatFilter",       +
+                         "ofType": null               +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "typeArrayEnum",         +
+                     "type": {                        +
+                         "kind": "INPUT_OBJECT",      +
+                         "name": "ColorListFilter",   +
+                         "ofType": null               +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "typeArrayText",         +
+                     "type": {                        +
+                         "kind": "INPUT_OBJECT",      +
+                         "name": "StringListFilter",  +
+                         "ofType": null               +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "typeArrayJson",         +
+                     "type": {                        +
+                         "kind": "INPUT_OBJECT",      +
+                         "name": "JSONListFilter",    +
+                         "ofType": null               +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "typeArrayNumeric",      +
+                     "type": {                        +
+                         "kind": "INPUT_OBJECT",      +
+                         "name": "BigFloatListFilter",+
+                         "ofType": null               +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "nodeId",                +
+                     "type": {                        +
+                         "kind": "INPUT_OBJECT",      +
+                         "name": "IDFilter",          +
+                         "ofType": null               +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "and",                   +
+                     "type": {                        +
+                         "kind": "LIST",              +
+                         "name": null,                +
+                         "ofType": {                  +
+                             "kind": "NON_NULL",      +
+                             "name": null             +
+                         }                            +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "or",                    +
+                     "type": {                        +
+                         "kind": "LIST",              +
+                         "name": null,                +
+                         "ofType": {                  +
+                             "kind": "NON_NULL",      +
+                             "name": null             +
+                         }                            +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "not",                   +
+                     "type": {                        +
+                         "kind": "INPUT_OBJECT",      +
+                         "name": "MainTypeFilter",    +
+                         "ofType": null               +
+                     }                                +
+                 }                                    +
+             ]                                        +
+         }                                            +
+     }                                                +
  }
 (1 row)
 

--- a/test/sql/omit_exotic_types.sql
+++ b/test/sql/omit_exotic_types.sql
@@ -1,9 +1,8 @@
 begin;
 
     /*
-        Composite and array types are not currently supported as inputs
+        Composite types are not currently supported as inputs
         - confirm composites are not allowed anywhere
-        - confirm arrays are not allowed as input
     */
 
     create type complex as (r int, i int);

--- a/test/sql/resolve_connection_filter.sql
+++ b/test/sql/resolve_connection_filter.sql
@@ -190,7 +190,7 @@ begin;
     select jsonb_pretty(
         graphql.resolve($$
             {
-              accountCollection(filter: {tags: {cd: ["customer", "priority"]}}) {
+              accountCollection(filter: {tags: {ov: ["customer", "priority"]}}) {
                 edges {
                   node {
                     id

--- a/test/sql/resolve_connection_filter.sql
+++ b/test/sql/resolve_connection_filter.sql
@@ -3,14 +3,15 @@ begin;
         id int primary key,
         is_verified bool,
         name text,
-        phone text
+        phone text,
+        tags text[]
     );
 
-    insert into public.account(id, is_verified, name, phone)
+    insert into public.account(id, is_verified, name, phone, tags)
     values
-        (1, true, 'foo', '1111111111'),
-        (2, true, 'bar', null),
-        (3, false, 'baz', '33333333333');
+        (1, true, 'foo', '1111111111', '{"customer", "priority"}'),
+        (2, true, 'bar', null, '{"customer"}'),
+        (3, false, 'baz', '33333333333', '{"lead", "priority"}');
 
     savepoint a;
 
@@ -119,6 +120,86 @@ begin;
 
     -- is - null literal returns error (this may change but currently seems like the best option and "unbreaking" it is backwards compatible)
     select graphql.resolve($${accountCollection(filter: {phone: {is: null}}) { edges { node { id } } }}$$);
+    rollback to savepoint a;
+
+    -- cs - array column contains the input scalar
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              accountCollection(filter: {tags: {cs: "customer"}}) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+        $$)
+    );
+    rollback to savepoint a;
+
+    -- cd - array column is contained by input scalar (aka, the only value in the array column is the input scalar)
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              accountCollection(filter: {tags: {cd: "customer"}}) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+        $$)
+    );
+    rollback to savepoint a;
+
+    -- cs - array column contains the input array
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              accountCollection(filter: {tags: {cs: ["customer", "priority"]}}) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+        $$)
+    );
+    rollback to savepoint a;
+
+    -- cd - array column is contained by input array
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              accountCollection(filter: {tags: {cd: ["customer", "priority"]}}) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+        $$)
+    );
+    rollback to savepoint a;
+
+    -- ov - array column overlaps with input array
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              accountCollection(filter: {tags: {cd: ["customer", "priority"]}}) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+        $$)
+    );
     rollback to savepoint a;
 
     -- variable is - is null


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds the ability to filter by array columns and resolves #460 

## What is the current behavior?

Array columns are not filterable, and the schema does not create `{Scalar}ListFilter` types.

## What is the new behavior?

Array columns are filterable, and the schema now includes `{Scalar}ListFilter` types!

## Additional context

Note that `{Scalar}ListFilter` was not created for `Scalar::Opaque`!