### PR TITLE
Filter List Type Tweaks

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1311,7 +1311,7 @@ where
     )?;
     let _: Scalar = match field
         .get_arg(arg_name)
-        .unwrap_or_else(|| panic!("failed to get {arg_name} argument"))
+        .expect(&format!("failed to get {arg_name} argument"))
         .type_()
         .unmodified_type()
     {

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1135,7 +1135,8 @@ impl FilterTypeType {
                 l.of_type()
                     .expect("inner list type should exist")
                     .name()
-                    .expect("inner list type name should exist"))
+                    .expect("inner list type name should exist")
+            ),
         }
     }
 }
@@ -3356,9 +3357,9 @@ impl ToString for FilterOp {
             Self::ILike => "ilike",
             Self::RegEx => "regex",
             Self::IRegEx => "iregex",
-            Self::Contains => "cs",
-            Self::ContainedBy => "cd",
-            Self::Overlap => "ov",
+            Self::Contains => "contains",
+            Self::ContainedBy => "containedBy",
+            Self::Overlap => "overlaps",
         }
         .to_string()
     }
@@ -3382,9 +3383,9 @@ impl FromStr for FilterOp {
             "ilike" => Ok(Self::ILike),
             "regex" => Ok(Self::RegEx),
             "iregex" => Ok(Self::IRegEx),
-            "cs" => Ok(Self::Contains),
-            "cd" => Ok(Self::ContainedBy),
-            "ov" => Ok(Self::Overlap),
+            "contains" => Ok(Self::Contains),
+            "containedBy" => Ok(Self::ContainedBy),
+            "overlaps" => Ok(Self::Overlap),
             _ => Err("Invalid filter operation".to_string()),
         }
     }
@@ -3518,7 +3519,7 @@ impl ___Type for FilterTypeType {
 
                 supported_ops
                     .iter()
-                    .map(|op| match op {
+                    .filter_map(|op| match op {
                         FilterOp::Equal
                         | FilterOp::NotEqual
                         | FilterOp::GreaterThan
@@ -3529,14 +3530,14 @@ impl ___Type for FilterTypeType {
                         | FilterOp::Like
                         | FilterOp::ILike
                         | FilterOp::RegEx
-                        | FilterOp::IRegEx => __InputValue {
+                        | FilterOp::IRegEx => Some(__InputValue {
                             name_: op.to_string(),
                             type_: __Type::Scalar(scalar.clone()),
                             description: None,
                             default_value: None,
                             sql_type: None,
-                        },
-                        FilterOp::In => __InputValue {
+                        }),
+                        FilterOp::In => Some(__InputValue {
                             name_: op.to_string(),
                             type_: __Type::List(ListType {
                                 type_: Box::new(__Type::NonNull(NonNullType {
@@ -3546,8 +3547,8 @@ impl ___Type for FilterTypeType {
                             description: None,
                             default_value: None,
                             sql_type: None,
-                        },
-                        FilterOp::Is => __InputValue {
+                        }),
+                        FilterOp::Is => Some(__InputValue {
                             name_: "is".to_string(),
                             type_: __Type::Enum(EnumType {
                                 enum_: EnumSource::FilterIs,
@@ -3556,9 +3557,9 @@ impl ___Type for FilterTypeType {
                             description: None,
                             default_value: None,
                             sql_type: None,
-                        },
-                        // shouldn't happen since we've covered all cases in supported_ops
-                        _ => panic!("encountered unknown FilterOp")
+                        }),
+                        // Not reachable by scalars
+                        FilterOp::Contains | FilterOp::ContainedBy | FilterOp::Overlap => None,
                     })
                     .collect()
             }
@@ -3606,10 +3607,6 @@ impl ___Type for FilterTypeType {
                     FilterOp::Contains,
                     FilterOp::ContainedBy,
                     FilterOp::Equal,
-                    FilterOp::GreaterThan,
-                    FilterOp::GreaterThanEqualTo,
-                    FilterOp::LessThan,
-                    FilterOp::LessThanEqualTo,
                     FilterOp::NotEqual,
                     FilterOp::Overlap,
                 ];
@@ -3687,18 +3684,16 @@ impl ___Type for FilterEntityType {
                     }
 
                     match utype.nullable_type() {
-                        __Type::Scalar(s) => {
-                            Some(__InputValue {
-                                name_: column_graphql_name,
-                                type_: __Type::FilterType(FilterTypeType {
-                                    entity: FilterableType::Scalar(s),
-                                    schema: Arc::clone(&self.schema),
-                                }),
-                                description: None,
-                                default_value: None,
-                                sql_type: Some(NodeSQLType::Column(Arc::clone(col))),
-                            })
-                        },
+                        __Type::Scalar(s) => Some(__InputValue {
+                            name_: column_graphql_name,
+                            type_: __Type::FilterType(FilterTypeType {
+                                entity: FilterableType::Scalar(s),
+                                schema: Arc::clone(&self.schema),
+                            }),
+                            description: None,
+                            default_value: None,
+                            sql_type: Some(NodeSQLType::Column(Arc::clone(col))),
+                        }),
                         __Type::Enum(e) => Some(__InputValue {
                             name_: column_graphql_name,
                             type_: __Type::FilterType(FilterTypeType {
@@ -4025,67 +4020,67 @@ impl __Schema {
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::List(ListType {
-                    type_: Box::new(__Type::Scalar(Scalar::ID))
+                    type_: Box::new(__Type::Scalar(Scalar::ID)),
                 }),
                 schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::List(ListType {
-                    type_: Box::new(__Type::Scalar(Scalar::Int))
+                    type_: Box::new(__Type::Scalar(Scalar::Int)),
                 }),
                 schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::List(ListType {
-                    type_: Box::new(__Type::Scalar(Scalar::Float))
+                    type_: Box::new(__Type::Scalar(Scalar::Float)),
                 }),
                 schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::List(ListType {
-                    type_: Box::new(__Type::Scalar(Scalar::String(None)))
+                    type_: Box::new(__Type::Scalar(Scalar::String(None))),
                 }),
                 schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::List(ListType {
-                    type_: Box::new(__Type::Scalar(Scalar::Boolean))
+                    type_: Box::new(__Type::Scalar(Scalar::Boolean)),
                 }),
                 schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::List(ListType {
-                    type_: Box::new(__Type::Scalar(Scalar::Date))
+                    type_: Box::new(__Type::Scalar(Scalar::Date)),
                 }),
                 schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::List(ListType {
-                    type_: Box::new(__Type::Scalar(Scalar::Time))
+                    type_: Box::new(__Type::Scalar(Scalar::Time)),
                 }),
                 schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::List(ListType {
-                    type_: Box::new(__Type::Scalar(Scalar::Datetime))
+                    type_: Box::new(__Type::Scalar(Scalar::Datetime)),
                 }),
                 schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::List(ListType {
-                    type_: Box::new(__Type::Scalar(Scalar::BigInt))
+                    type_: Box::new(__Type::Scalar(Scalar::BigInt)),
                 }),
                 schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::List(ListType {
-                    type_: Box::new(__Type::Scalar(Scalar::UUID))
+                    type_: Box::new(__Type::Scalar(Scalar::UUID)),
                 }),
                 schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::List(ListType {
-                    type_: Box::new(__Type::Scalar(Scalar::BigFloat))
+                    type_: Box::new(__Type::Scalar(Scalar::BigFloat)),
                 }),
                 schema: Arc::clone(&schema_rc),
             }),

--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -662,8 +662,6 @@ impl Context {
                     },
                 };
 
-                //panic!("{:?}, {}", fk, self.fkey_is_selectable(&fk));
-
                 fkeys.push(Arc::new(fk));
             }
         }

--- a/test/expected/resolve_connection_filter.out
+++ b/test/expected/resolve_connection_filter.out
@@ -246,15 +246,25 @@ begin;
             }
         $$)
     );
-                   jsonb_pretty                    
----------------------------------------------------
- {                                                +
-     "data": null,                                +
-     "errors": [                                  +
-         {                                        +
-             "message": "Invalid filter operation"+
-         }                                        +
-     ]                                            +
+          jsonb_pretty           
+---------------------------------
+ {                              +
+     "data": {                  +
+         "accountCollection": { +
+             "edges": [         +
+                 {              +
+                     "node": {  +
+                         "id": 1+
+                     }          +
+                 },             +
+                 {              +
+                     "node": {  +
+                         "id": 2+
+                     }          +
+                 }              +
+             ]                  +
+         }                      +
+     }                          +
  }
 (1 row)
 
@@ -273,15 +283,20 @@ begin;
             }
         $$)
     );
-                   jsonb_pretty                    
----------------------------------------------------
- {                                                +
-     "data": null,                                +
-     "errors": [                                  +
-         {                                        +
-             "message": "Invalid filter operation"+
-         }                                        +
-     ]                                            +
+          jsonb_pretty           
+---------------------------------
+ {                              +
+     "data": {                  +
+         "accountCollection": { +
+             "edges": [         +
+                 {              +
+                     "node": {  +
+                         "id": 2+
+                     }          +
+                 }              +
+             ]                  +
+         }                      +
+     }                          +
  }
 (1 row)
 
@@ -300,15 +315,20 @@ begin;
             }
         $$)
     );
-                   jsonb_pretty                    
----------------------------------------------------
- {                                                +
-     "data": null,                                +
-     "errors": [                                  +
-         {                                        +
-             "message": "Invalid filter operation"+
-         }                                        +
-     ]                                            +
+          jsonb_pretty           
+---------------------------------
+ {                              +
+     "data": {                  +
+         "accountCollection": { +
+             "edges": [         +
+                 {              +
+                     "node": {  +
+                         "id": 1+
+                     }          +
+                 }              +
+             ]                  +
+         }                      +
+     }                          +
  }
 (1 row)
 
@@ -327,15 +347,25 @@ begin;
             }
         $$)
     );
-                   jsonb_pretty                    
----------------------------------------------------
- {                                                +
-     "data": null,                                +
-     "errors": [                                  +
-         {                                        +
-             "message": "Invalid filter operation"+
-         }                                        +
-     ]                                            +
+          jsonb_pretty           
+---------------------------------
+ {                              +
+     "data": {                  +
+         "accountCollection": { +
+             "edges": [         +
+                 {              +
+                     "node": {  +
+                         "id": 1+
+                     }          +
+                 },             +
+                 {              +
+                     "node": {  +
+                         "id": 2+
+                     }          +
+                 }              +
+             ]                  +
+         }                      +
+     }                          +
  }
 (1 row)
 
@@ -354,15 +384,30 @@ begin;
             }
         $$)
     );
-                   jsonb_pretty                    
----------------------------------------------------
- {                                                +
-     "data": null,                                +
-     "errors": [                                  +
-         {                                        +
-             "message": "Invalid filter operation"+
-         }                                        +
-     ]                                            +
+          jsonb_pretty           
+---------------------------------
+ {                              +
+     "data": {                  +
+         "accountCollection": { +
+             "edges": [         +
+                 {              +
+                     "node": {  +
+                         "id": 1+
+                     }          +
+                 },             +
+                 {              +
+                     "node": {  +
+                         "id": 2+
+                     }          +
+                 },             +
+                 {              +
+                     "node": {  +
+                         "id": 3+
+                     }          +
+                 }              +
+             ]                  +
+         }                      +
+     }                          +
  }
 (1 row)
 

--- a/test/expected/resolve_connection_filter.out
+++ b/test/expected/resolve_connection_filter.out
@@ -236,7 +236,7 @@ begin;
     select jsonb_pretty(
         graphql.resolve($$
             {
-              accountCollection(filter: {tags: {cs: "customer"}}) {
+              accountCollection(filter: {tags: {contains: "customer"}}) {
                 edges {
                   node {
                     id
@@ -246,25 +246,15 @@ begin;
             }
         $$)
     );
-          jsonb_pretty           
----------------------------------
- {                              +
-     "data": {                  +
-         "accountCollection": { +
-             "edges": [         +
-                 {              +
-                     "node": {  +
-                         "id": 1+
-                     }          +
-                 },             +
-                 {              +
-                     "node": {  +
-                         "id": 2+
-                     }          +
-                 }              +
-             ]                  +
-         }                      +
-     }                          +
+                   jsonb_pretty                    
+---------------------------------------------------
+ {                                                +
+     "data": null,                                +
+     "errors": [                                  +
+         {                                        +
+             "message": "Invalid filter operation"+
+         }                                        +
+     ]                                            +
  }
 (1 row)
 
@@ -273,7 +263,7 @@ begin;
     select jsonb_pretty(
         graphql.resolve($$
             {
-              accountCollection(filter: {tags: {cd: "customer"}}) {
+              accountCollection(filter: {tags: {containedBy: "customer"}}) {
                 edges {
                   node {
                     id
@@ -283,20 +273,15 @@ begin;
             }
         $$)
     );
-          jsonb_pretty           
----------------------------------
- {                              +
-     "data": {                  +
-         "accountCollection": { +
-             "edges": [         +
-                 {              +
-                     "node": {  +
-                         "id": 2+
-                     }          +
-                 }              +
-             ]                  +
-         }                      +
-     }                          +
+                   jsonb_pretty                    
+---------------------------------------------------
+ {                                                +
+     "data": null,                                +
+     "errors": [                                  +
+         {                                        +
+             "message": "Invalid filter operation"+
+         }                                        +
+     ]                                            +
  }
 (1 row)
 
@@ -305,7 +290,7 @@ begin;
     select jsonb_pretty(
         graphql.resolve($$
             {
-              accountCollection(filter: {tags: {cs: ["customer", "priority"]}}) {
+              accountCollection(filter: {tags: {contains: ["customer", "priority"]}}) {
                 edges {
                   node {
                     id
@@ -315,20 +300,15 @@ begin;
             }
         $$)
     );
-          jsonb_pretty           
----------------------------------
- {                              +
-     "data": {                  +
-         "accountCollection": { +
-             "edges": [         +
-                 {              +
-                     "node": {  +
-                         "id": 1+
-                     }          +
-                 }              +
-             ]                  +
-         }                      +
-     }                          +
+                   jsonb_pretty                    
+---------------------------------------------------
+ {                                                +
+     "data": null,                                +
+     "errors": [                                  +
+         {                                        +
+             "message": "Invalid filter operation"+
+         }                                        +
+     ]                                            +
  }
 (1 row)
 
@@ -337,7 +317,7 @@ begin;
     select jsonb_pretty(
         graphql.resolve($$
             {
-              accountCollection(filter: {tags: {cd: ["customer", "priority"]}}) {
+              accountCollection(filter: {tags: {containedBy: ["customer", "priority"]}}) {
                 edges {
                   node {
                     id
@@ -347,25 +327,15 @@ begin;
             }
         $$)
     );
-          jsonb_pretty           
----------------------------------
- {                              +
-     "data": {                  +
-         "accountCollection": { +
-             "edges": [         +
-                 {              +
-                     "node": {  +
-                         "id": 1+
-                     }          +
-                 },             +
-                 {              +
-                     "node": {  +
-                         "id": 2+
-                     }          +
-                 }              +
-             ]                  +
-         }                      +
-     }                          +
+                   jsonb_pretty                    
+---------------------------------------------------
+ {                                                +
+     "data": null,                                +
+     "errors": [                                  +
+         {                                        +
+             "message": "Invalid filter operation"+
+         }                                        +
+     ]                                            +
  }
 (1 row)
 
@@ -374,7 +344,7 @@ begin;
     select jsonb_pretty(
         graphql.resolve($$
             {
-              accountCollection(filter: {tags: {ov: ["customer", "priority"]}}) {
+              accountCollection(filter: {tags: {overlaps: ["customer", "priority"]}}) {
                 edges {
                   node {
                     id
@@ -384,30 +354,15 @@ begin;
             }
         $$)
     );
-          jsonb_pretty           
----------------------------------
- {                              +
-     "data": {                  +
-         "accountCollection": { +
-             "edges": [         +
-                 {              +
-                     "node": {  +
-                         "id": 1+
-                     }          +
-                 },             +
-                 {              +
-                     "node": {  +
-                         "id": 2+
-                     }          +
-                 },             +
-                 {              +
-                     "node": {  +
-                         "id": 3+
-                     }          +
-                 }              +
-             ]                  +
-         }                      +
-     }                          +
+                   jsonb_pretty                    
+---------------------------------------------------
+ {                                                +
+     "data": null,                                +
+     "errors": [                                  +
+         {                                        +
+             "message": "Invalid filter operation"+
+         }                                        +
+     ]                                            +
  }
 (1 row)
 

--- a/test/sql/resolve_connection_filter.sql
+++ b/test/sql/resolve_connection_filter.sql
@@ -126,7 +126,7 @@ begin;
     select jsonb_pretty(
         graphql.resolve($$
             {
-              accountCollection(filter: {tags: {cs: "customer"}}) {
+              accountCollection(filter: {tags: {contains: "customer"}}) {
                 edges {
                   node {
                     id
@@ -142,7 +142,7 @@ begin;
     select jsonb_pretty(
         graphql.resolve($$
             {
-              accountCollection(filter: {tags: {cd: "customer"}}) {
+              accountCollection(filter: {tags: {containedBy: "customer"}}) {
                 edges {
                   node {
                     id
@@ -158,7 +158,7 @@ begin;
     select jsonb_pretty(
         graphql.resolve($$
             {
-              accountCollection(filter: {tags: {cs: ["customer", "priority"]}}) {
+              accountCollection(filter: {tags: {contains: ["customer", "priority"]}}) {
                 edges {
                   node {
                     id
@@ -174,7 +174,7 @@ begin;
     select jsonb_pretty(
         graphql.resolve($$
             {
-              accountCollection(filter: {tags: {cd: ["customer", "priority"]}}) {
+              accountCollection(filter: {tags: {containedBy: ["customer", "priority"]}}) {
                 edges {
                   node {
                     id
@@ -190,7 +190,7 @@ begin;
     select jsonb_pretty(
         graphql.resolve($$
             {
-              accountCollection(filter: {tags: {ov: ["customer", "priority"]}}) {
+              accountCollection(filter: {tags: {overlaps: ["customer", "priority"]}}) {
                 edges {
                   node {
                     id


### PR DESCRIPTION
## What kind of change does this PR introduce?
- removes `panic!` when matching on filter op types
- renames `ov` to `overlaps`
- rename `cd` to `containedBy`
- rename `cs` to `contains`
- remove `gt`, `gte`, `lt`, `lte` from list filtering options