### PR TITLE
Restrict Filtering List types to primary scalar elements

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -583,15 +583,10 @@ Where the `<Table>Filter` type enumerates filterable fields and their associated
     Boolean expression comparing fields on type "StringList"
     """
     input StringListFilter {
-      cd: [String!]
-      cs: [String!]
+      contains: [String!]
+      containedBy: [String!]
       eq: [String!]
-      gt: [String!]
-      gte: [String!]
-      lt: [String!]
-      lte: [String!]
-      neq: [String!]
-      ov: [String!]
+      overlaps: [String!]
     }
     ```
 
@@ -607,24 +602,24 @@ Where the `<Table>Filter` type enumerates filterable fields and their associated
 The following list shows the operators that may be available on `<Type>Filter` types.
 
 
-| Operator   | Description                                                       |
-|------------|-------------------------------------------------------------------|
-| eq         | Equal To                                                          |
-| neq        | Not Equal To                                                      |
-| gt         | Greater Than                                                      |
-| gte        | Greater Than Or Equal To                                          |
-| in         | Contained by Value List                                           |
-| lt         | Less Than                                                         |
-| lte        | Less Than Or Equal To                                             |
-| is         | Null or Not Null                                                  |
-| startsWith | Starts with prefix                                                |
-| like       | Pattern Match. '%' as wildcard                                    |
-| ilike      | Pattern Match. '%' as wildcard. Case Insensitive                  |
-| regex      | POSIX Regular Expression Match                                    |
-| iregex     | POSIX Regular Expression Match. Case Insensitive                  |
-| cs         | Contains. Applies to array columns only.                          |
-| cd         | Contained in. Applies to array columns only.                      |
-| ov         | Overlap (have points in common). Applies to array columns only.   |
+| Operator    | Description                                                       |
+|-------------|-------------------------------------------------------------------|
+| eq          | Equal To                                                          |
+| neq         | Not Equal To                                                      |
+| gt          | Greater Than                                                      |
+| gte         | Greater Than Or Equal To                                          |
+| in          | Contained by Value List                                           |
+| lt          | Less Than                                                         |
+| lte         | Less Than Or Equal To                                             |
+| is          | Null or Not Null                                                  |
+| startsWith  | Starts with prefix                                                |
+| like        | Pattern Match. '%' as wildcard                                    |
+| ilike       | Pattern Match. '%' as wildcard. Case Insensitive                  |
+| regex       | POSIX Regular Expression Match                                    |
+| iregex      | POSIX Regular Expression Match. Case Insensitive                  |
+| contains    | Contains. Applies to array columns only.                          |
+| containedBy | Contained in. Applies to array columns only.                      |
+| overlaps    | Overlap (have points in common). Applies to array columns only.   |
 
 Not all operators are available on every `<Type>Filter` type. For example, `UUIDFilter` only supports `eq` and `neq` because `UUID`s are not ordered.
 
@@ -675,13 +670,13 @@ Not all operators are available on every `<Type>Filter` type. For example, `UUID
 
 **Example: array column**
 
-The `cs` filter is used to return results where all the elements in the input array appear in the array column.
+The `contains` filter is used to return results where all the elements in the input array appear in the array column.
 
-=== "`cs` Filter Query"
+=== "`contains` Filter Query"
     ```graphql
     {
       blogCollection(
-        filter: {tags: {cs: ["tech", "innovation"]}},
+        filter: {tags: {contains: ["tech", "innovation"]}},
       ) {
         edges {
           cursor
@@ -696,7 +691,7 @@ The `cs` filter is used to return results where all the elements in the input ar
     }
     ```
 
-=== "`cs` Filter Result"
+=== "`contains` Filter Result"
     ```json
     {
       "data": {
@@ -726,13 +721,13 @@ The `cs` filter is used to return results where all the elements in the input ar
     }
     ```
 
-The `cs` filter can also accept a single scalar.
+The `contains` filter can also accept a single scalar.
 
-=== "`cs` Filter with Scalar Query"
+=== "`contains` Filter with Scalar Query"
     ```graphql
     {
       blogCollection(
-        filter: {tags: {cs: "tech"}},
+        filter: {tags: {contains: "tech"}},
       ) {
         edges {
           cursor
@@ -747,7 +742,7 @@ The `cs` filter can also accept a single scalar.
     }
     ```
 
-=== "`cs` Filter with Scalar Result"
+=== "`contains` Filter with Scalar Result"
     ```json
     {
       "data": {
@@ -777,13 +772,13 @@ The `cs` filter can also accept a single scalar.
     }
     ```
 
-The `cd` filter is used to return results where every element of the array column appears in the input array.
+The `containedBy` filter is used to return results where every element of the array column appears in the input array.
 
-=== "`cd` Filter Query"
+=== "`containedBy` Filter Query"
     ```graphql
     {
       blogCollection(
-        filter: {tags: {cd: ["entrepreneurship", "innovation", "tech"]}},
+        filter: {tags: {containedBy: ["entrepreneurship", "innovation", "tech"]}},
       ) {
         edges {
           cursor
@@ -798,7 +793,7 @@ The `cd` filter is used to return results where every element of the array colum
     }
     ```
 
-=== "`cd` Filter Result"
+=== "`containedBy` Filter Result"
     ```json
     {
       "data": {
@@ -828,13 +823,13 @@ The `cd` filter is used to return results where every element of the array colum
     }
     ```
 
-The `cd` filter can also accept a single scalar. In this case, only results where the only element in the array column is the input scalar are returned.
+The `containedBy` filter can also accept a single scalar. In this case, only results where the only element in the array column is the input scalar are returned.
 
-=== "`cd` Filter with Scalar Query"
+=== "`containedBy` Filter with Scalar Query"
     ```graphql
     {
       blogCollection(
-        filter: {tags: {cd: "travel"}},
+        filter: {tags: {containedBy: "travel"}},
       ) {
         edges {
           cursor
@@ -849,7 +844,7 @@ The `cd` filter can also accept a single scalar. In this case, only results wher
     }
     ```
 
-=== "`cd` Filter with Scalar Result"
+=== "`containedBy` Filter with Scalar Result"
     ```json
     {
       "data": {
@@ -870,13 +865,13 @@ The `cd` filter can also accept a single scalar. In this case, only results wher
     }
     ```
 
-The `ov` filter is used to return results where the array column and the input array have at least one element in common.
+The `overlaps` filter is used to return results where the array column and the input array have at least one element in common.
 
-=== "`ov` Filter Query"
+=== "`overlaps` Filter Query"
     ```graphql
     {
       blogCollection(
-        filter: {tags: {ov: ["tech", "travel"]}},
+        filter: {tags: {overlaps: ["tech", "travel"]}},
       ) {
         edges {
           cursor
@@ -891,7 +886,7 @@ The `ov` filter is used to return results where the array column and the input a
     }
     ```
 
-=== "`ov` Filter Result"
+=== "`overlaps` Filter Result"
     ```json
     {
       "data": {

--- a/docs/assets/demo_schema.graphql
+++ b/docs/assets/demo_schema.graphql
@@ -129,15 +129,10 @@ input BigFloatFilter {
 Boolean expression comparing fields on type "BigFloatList"
 """
 input BigFloatListFilter {
-  cd: [BigFloat!]
-  cs: [BigFloat!]
+  containedBy: [BigFloat!]
+  contains: [BigFloat!]
   eq: [BigFloat!]
-  gt: [BigFloat!]
-  gte: [BigFloat!]
-  lt: [BigFloat!]
-  lte: [BigFloat!]
-  neq: [BigFloat!]
-  ov: [BigFloat!]
+  overlaps: [BigFloat!]
 }
 
 """An arbitrary size integer represented as a string"""
@@ -161,15 +156,10 @@ input BigIntFilter {
 Boolean expression comparing fields on type "BigIntList"
 """
 input BigIntListFilter {
-  cd: [BigInt!]
-  cs: [BigInt!]
-  eq: [BigInt!]
-  gt: [BigInt!]
-  gte: [BigInt!]
-  lt: [BigInt!]
-  lte: [BigInt!]
-  neq: [BigInt!]
-  ov: [BigInt!]
+  containedBy: [BigFloat!]
+  contains: [BigFloat!]
+  eq: [BigFloat!]
+  overlaps: [BigFloat!]
 }
 
 type Blog implements Node {
@@ -420,15 +410,10 @@ input BooleanFilter {
 Boolean expression comparing fields on type "BooleanList"
 """
 input BooleanListFilter {
-  cd: [Boolean!]
-  cs: [Boolean!]
-  eq: [Boolean!]
-  gt: [Boolean!]
-  gte: [Boolean!]
-  lt: [Boolean!]
-  lte: [Boolean!]
-  neq: [Boolean!]
-  ov: [Boolean!]
+  containedBy: [BigFloat!]
+  contains: [BigFloat!]
+  eq: [BigFloat!]
+  overlaps: [BigFloat!]
 }
 
 """
@@ -457,15 +442,10 @@ input DateFilter {
 Boolean expression comparing fields on type "DateList"
 """
 input DateListFilter {
-  cd: [Date!]
-  cs: [Date!]
-  eq: [Date!]
-  gt: [Date!]
-  gte: [Date!]
-  lt: [Date!]
-  lte: [Date!]
-  neq: [Date!]
-  ov: [Date!]
+  containedBy: [BigFloat!]
+  contains: [BigFloat!]
+  eq: [BigFloat!]
+  overlaps: [BigFloat!]
 }
 
 """A date and time"""
@@ -489,15 +469,10 @@ input DatetimeFilter {
 Boolean expression comparing fields on type "DatetimeList"
 """
 input DatetimeListFilter {
-  cd: [Datetime!]
-  cs: [Datetime!]
-  eq: [Datetime!]
-  gt: [Datetime!]
-  gte: [Datetime!]
-  lt: [Datetime!]
-  lte: [Datetime!]
-  neq: [Datetime!]
-  ov: [Datetime!]
+  containedBy: [BigFloat!]
+  contains: [BigFloat!]
+  eq: [BigFloat!]
+  overlaps: [BigFloat!]
 }
 
 enum FilterIs {
@@ -523,15 +498,10 @@ input FloatFilter {
 Boolean expression comparing fields on type "FloatList"
 """
 input FloatListFilter {
-  cd: [Float!]
-  cs: [Float!]
-  eq: [Float!]
-  gt: [Float!]
-  gte: [Float!]
-  lt: [Float!]
-  lte: [Float!]
-  neq: [Float!]
-  ov: [Float!]
+  containedBy: [BigFloat!]
+  contains: [BigFloat!]
+  eq: [BigFloat!]
+  overlaps: [BigFloat!]
 }
 
 """
@@ -539,21 +509,6 @@ Boolean expression comparing fields on type "ID"
 """
 input IDFilter {
   eq: ID
-}
-
-"""
-Boolean expression comparing fields on type "IDList"
-"""
-input IDListFilter {
-  cd: [ID!]
-  cs: [ID!]
-  eq: [ID!]
-  gt: [ID!]
-  gte: [ID!]
-  lt: [ID!]
-  lte: [ID!]
-  neq: [ID!]
-  ov: [ID!]
 }
 
 """
@@ -574,15 +529,10 @@ input IntFilter {
 Boolean expression comparing fields on type "IntList"
 """
 input IntListFilter {
-  cd: [Int!]
-  cs: [Int!]
-  eq: [Int!]
-  gt: [Int!]
-  gte: [Int!]
-  lt: [Int!]
-  lte: [Int!]
-  neq: [Int!]
-  ov: [Int!]
+  containedBy: [BigFloat!]
+  contains: [BigFloat!]
+  eq: [BigFloat!]
+  overlaps: [BigFloat!]
 }
 
 """A Javascript Object Notation value serialized as a string"""
@@ -829,15 +779,10 @@ input StringFilter {
 Boolean expression comparing fields on type "StringList"
 """
 input StringListFilter {
-  cd: [String!]
-  cs: [String!]
-  eq: [String!]
-  gt: [String!]
-  gte: [String!]
-  lt: [String!]
-  lte: [String!]
-  neq: [String!]
-  ov: [String!]
+  containedBy: [BigFloat!]
+  contains: [BigFloat!]
+  eq: [BigFloat!]
+  overlaps: [BigFloat!]
 }
 
 """A time without date information"""
@@ -861,15 +806,10 @@ input TimeFilter {
 Boolean expression comparing fields on type "TimeList"
 """
 input TimeListFilter {
-  cd: [Time!]
-  cs: [Time!]
-  eq: [Time!]
-  gt: [Time!]
-  gte: [Time!]
-  lt: [Time!]
-  lte: [Time!]
-  neq: [Time!]
-  ov: [Time!]
+  containedBy: [BigFloat!]
+  contains: [BigFloat!]
+  eq: [BigFloat!]
+  overlaps: [BigFloat!]
 }
 
 """A universally unique identifier"""
@@ -889,13 +829,8 @@ input UUIDFilter {
 Boolean expression comparing fields on type "UUIDList"
 """
 input UUIDListFilter {
-  cd: [UUID!]
-  cs: [UUID!]
-  eq: [UUID!]
-  gt: [UUID!]
-  gte: [UUID!]
-  lt: [UUID!]
-  lte: [UUID!]
-  neq: [UUID!]
-  ov: [UUID!]
+  containedBy: [BigFloat!]
+  contains: [BigFloat!]
+  eq: [BigFloat!]
+  overlaps: [BigFloat!]
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1311,7 +1311,7 @@ where
     )?;
     let _: Scalar = match field
         .get_arg(arg_name)
-        .unwrap_or_else(|| panic!("failed to get {arg_name} argument"))
+        .expect(&format!("failed to get {} argument", arg_name))
         .type_()
         .unmodified_type()
     {

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1135,7 +1135,8 @@ impl FilterTypeType {
                 l.of_type()
                     .expect("inner list type should exist")
                     .name()
-                    .expect("inner list type name should exist"))
+                    .expect("inner list type name should exist")
+            ),
         }
     }
 }
@@ -3558,7 +3559,7 @@ impl ___Type for FilterTypeType {
                             sql_type: None,
                         },
                         // shouldn't happen since we've covered all cases in supported_ops
-                        _ => panic!("encountered unknown FilterOp")
+                        _ => panic!("encountered unknown FilterOp"),
                     })
                     .collect()
             }
@@ -3687,18 +3688,16 @@ impl ___Type for FilterEntityType {
                     }
 
                     match utype.nullable_type() {
-                        __Type::Scalar(s) => {
-                            Some(__InputValue {
-                                name_: column_graphql_name,
-                                type_: __Type::FilterType(FilterTypeType {
-                                    entity: FilterableType::Scalar(s),
-                                    schema: Arc::clone(&self.schema),
-                                }),
-                                description: None,
-                                default_value: None,
-                                sql_type: Some(NodeSQLType::Column(Arc::clone(col))),
-                            })
-                        },
+                        __Type::Scalar(s) => Some(__InputValue {
+                            name_: column_graphql_name,
+                            type_: __Type::FilterType(FilterTypeType {
+                                entity: FilterableType::Scalar(s),
+                                schema: Arc::clone(&self.schema),
+                            }),
+                            description: None,
+                            default_value: None,
+                            sql_type: Some(NodeSQLType::Column(Arc::clone(col))),
+                        }),
                         __Type::Enum(e) => Some(__InputValue {
                             name_: column_graphql_name,
                             type_: __Type::FilterType(FilterTypeType {
@@ -3709,16 +3708,31 @@ impl ___Type for FilterEntityType {
                             default_value: None,
                             sql_type: Some(NodeSQLType::Column(Arc::clone(col))),
                         }),
-                        __Type::List(l) => Some(__InputValue {
-                            name_: column_graphql_name,
-                            type_: __Type::FilterType(FilterTypeType {
-                                entity: FilterableType::List(l),
-                                schema: Arc::clone(&self.schema),
-                            }),
-                            description: None,
-                            default_value: None,
-                            sql_type: Some(NodeSQLType::Column(Arc::clone(col))),
-                        }),
+                        __Type::List(l) => match l.type_.nullable_type() {
+                            // Only non-json scalars are supported in list types
+                            __Type::Scalar(s) => match s {
+                                Scalar::Int
+                                | Scalar::Float
+                                | Scalar::String(_)
+                                | Scalar::Boolean
+                                | Scalar::UUID
+                                | Scalar::BigInt
+                                | Scalar::BigFloat
+                                | Scalar::Date
+                                | Scalar::Datetime => Some(__InputValue {
+                                    name_: column_graphql_name,
+                                    type_: __Type::FilterType(FilterTypeType {
+                                        entity: FilterableType::List(l),
+                                        schema: Arc::clone(&self.schema),
+                                    }),
+                                    description: None,
+                                    default_value: None,
+                                    sql_type: Some(NodeSQLType::Column(Arc::clone(col))),
+                                }),
+                                _ => None,
+                            },
+                            _ => None,
+                        },
                         _ => None,
                     }
                 } else {
@@ -4025,67 +4039,67 @@ impl __Schema {
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::List(ListType {
-                    type_: Box::new(__Type::Scalar(Scalar::ID))
+                    type_: Box::new(__Type::Scalar(Scalar::ID)),
                 }),
                 schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::List(ListType {
-                    type_: Box::new(__Type::Scalar(Scalar::Int))
+                    type_: Box::new(__Type::Scalar(Scalar::Int)),
                 }),
                 schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::List(ListType {
-                    type_: Box::new(__Type::Scalar(Scalar::Float))
+                    type_: Box::new(__Type::Scalar(Scalar::Float)),
                 }),
                 schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::List(ListType {
-                    type_: Box::new(__Type::Scalar(Scalar::String(None)))
+                    type_: Box::new(__Type::Scalar(Scalar::String(None))),
                 }),
                 schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::List(ListType {
-                    type_: Box::new(__Type::Scalar(Scalar::Boolean))
+                    type_: Box::new(__Type::Scalar(Scalar::Boolean)),
                 }),
                 schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::List(ListType {
-                    type_: Box::new(__Type::Scalar(Scalar::Date))
+                    type_: Box::new(__Type::Scalar(Scalar::Date)),
                 }),
                 schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::List(ListType {
-                    type_: Box::new(__Type::Scalar(Scalar::Time))
+                    type_: Box::new(__Type::Scalar(Scalar::Time)),
                 }),
                 schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::List(ListType {
-                    type_: Box::new(__Type::Scalar(Scalar::Datetime))
+                    type_: Box::new(__Type::Scalar(Scalar::Datetime)),
                 }),
                 schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::List(ListType {
-                    type_: Box::new(__Type::Scalar(Scalar::BigInt))
+                    type_: Box::new(__Type::Scalar(Scalar::BigInt)),
                 }),
                 schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::List(ListType {
-                    type_: Box::new(__Type::Scalar(Scalar::UUID))
+                    type_: Box::new(__Type::Scalar(Scalar::UUID)),
                 }),
                 schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::List(ListType {
-                    type_: Box::new(__Type::Scalar(Scalar::BigFloat))
+                    type_: Box::new(__Type::Scalar(Scalar::BigFloat)),
                 }),
                 schema: Arc::clone(&schema_rc),
             }),

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -3718,6 +3718,7 @@ impl ___Type for FilterEntityType {
                                 | Scalar::UUID
                                 | Scalar::BigInt
                                 | Scalar::BigFloat
+                                | Scalar::Time
                                 | Scalar::Date
                                 | Scalar::Datetime => Some(__InputValue {
                                     name_: column_graphql_name,
@@ -4035,12 +4036,6 @@ impl __Schema {
             }),
             __Type::FilterType(FilterTypeType {
                 entity: FilterableType::Scalar(Scalar::Opaque),
-                schema: Arc::clone(&schema_rc),
-            }),
-            __Type::FilterType(FilterTypeType {
-                entity: FilterableType::List(ListType {
-                    type_: Box::new(__Type::Scalar(Scalar::ID)),
-                }),
                 schema: Arc::clone(&schema_rc),
             }),
             __Type::FilterType(FilterTypeType {

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -3607,11 +3607,6 @@ impl ___Type for FilterTypeType {
                     FilterOp::Contains,
                     FilterOp::ContainedBy,
                     FilterOp::Equal,
-                    FilterOp::GreaterThan,
-                    FilterOp::GreaterThanEqualTo,
-                    FilterOp::LessThan,
-                    FilterOp::LessThanEqualTo,
-                    FilterOp::NotEqual,
                     FilterOp::Overlap,
                 ];
 

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -3357,9 +3357,9 @@ impl ToString for FilterOp {
             Self::ILike => "ilike",
             Self::RegEx => "regex",
             Self::IRegEx => "iregex",
-            Self::Contains => "cs",
-            Self::ContainedBy => "cd",
-            Self::Overlap => "ov",
+            Self::Contains => "contains",
+            Self::ContainedBy => "containedBy",
+            Self::Overlap => "overlaps",
         }
         .to_string()
     }
@@ -3383,9 +3383,9 @@ impl FromStr for FilterOp {
             "ilike" => Ok(Self::ILike),
             "regex" => Ok(Self::RegEx),
             "iregex" => Ok(Self::IRegEx),
-            "cs" => Ok(Self::Contains),
-            "cd" => Ok(Self::ContainedBy),
-            "ov" => Ok(Self::Overlap),
+            "contains" => Ok(Self::Contains),
+            "containedBy" => Ok(Self::ContainedBy),
+            "overlaps" => Ok(Self::Overlap),
             _ => Err("Invalid filter operation".to_string()),
         }
     }
@@ -3519,7 +3519,7 @@ impl ___Type for FilterTypeType {
 
                 supported_ops
                     .iter()
-                    .map(|op| match op {
+                    .filter_map(|op| match op {
                         FilterOp::Equal
                         | FilterOp::NotEqual
                         | FilterOp::GreaterThan
@@ -3530,14 +3530,14 @@ impl ___Type for FilterTypeType {
                         | FilterOp::Like
                         | FilterOp::ILike
                         | FilterOp::RegEx
-                        | FilterOp::IRegEx => __InputValue {
+                        | FilterOp::IRegEx => Some(__InputValue {
                             name_: op.to_string(),
                             type_: __Type::Scalar(scalar.clone()),
                             description: None,
                             default_value: None,
                             sql_type: None,
-                        },
-                        FilterOp::In => __InputValue {
+                        }),
+                        FilterOp::In => Some(__InputValue {
                             name_: op.to_string(),
                             type_: __Type::List(ListType {
                                 type_: Box::new(__Type::NonNull(NonNullType {
@@ -3547,8 +3547,8 @@ impl ___Type for FilterTypeType {
                             description: None,
                             default_value: None,
                             sql_type: None,
-                        },
-                        FilterOp::Is => __InputValue {
+                        }),
+                        FilterOp::Is => Some(__InputValue {
                             name_: "is".to_string(),
                             type_: __Type::Enum(EnumType {
                                 enum_: EnumSource::FilterIs,
@@ -3557,9 +3557,9 @@ impl ___Type for FilterTypeType {
                             description: None,
                             default_value: None,
                             sql_type: None,
-                        },
+                        }),
                         // shouldn't happen since we've covered all cases in supported_ops
-                        _ => panic!("encountered unknown FilterOp"),
+                        FilterOp::Contains | FilterOp::ContainedBy | FilterOp::Overlap => None,
                     })
                     .collect()
             }

--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -662,8 +662,6 @@ impl Context {
                     },
                 };
 
-                //panic!("{:?}, {}", fk, self.fkey_is_selectable(&fk));
-
                 fkeys.push(Arc::new(fk));
             }
         }

--- a/test/expected/omit_weird_names.out
+++ b/test/expected/omit_weird_names.out
@@ -85,9 +85,6 @@ begin;
                      "name": "IDFilter"           +
                  },                               +
                  {                                +
-                     "name": "IDListFilter"       +
-                 },                               +
-                 {                                +
                      "name": "Int"                +
                  },                               +
                  {                                +

--- a/test/expected/resolve___schema.out
+++ b/test/expected/resolve___schema.out
@@ -270,10 +270,6 @@ begin;
                      "name": "IDFilter"                                                                           +
                  },                                                                                               +
                  {                                                                                                +
-                     "kind": "INPUT_OBJECT",                                                                      +
-                     "name": "IDListFilter"                                                                       +
-                 },                                                                                               +
-                 {                                                                                                +
                      "kind": "SCALAR",                                                                            +
                      "name": "Int"                                                                                +
                  },                                                                                               +

--- a/test/expected/resolve_connection_filter.out
+++ b/test/expected/resolve_connection_filter.out
@@ -232,11 +232,11 @@ begin;
 (1 row)
 
     rollback to savepoint a;
-    -- cs - array column contains the input scalar
+    -- contains - array column contains the input scalar
     select jsonb_pretty(
         graphql.resolve($$
             {
-              accountCollection(filter: {tags: {cs: "customer"}}) {
+              accountCollection(filter: {tags: {contains: "customer"}}) {
                 edges {
                   node {
                     id
@@ -269,11 +269,11 @@ begin;
 (1 row)
 
     rollback to savepoint a;
-    -- cd - array column is contained by input scalar (aka, the only value in the array column is the input scalar)
+    -- containedBy - array column is contained by input scalar (aka, the only value in the array column is the input scalar)
     select jsonb_pretty(
         graphql.resolve($$
             {
-              accountCollection(filter: {tags: {cd: "customer"}}) {
+              accountCollection(filter: {tags: {containedBy: "customer"}}) {
                 edges {
                   node {
                     id
@@ -301,11 +301,11 @@ begin;
 (1 row)
 
     rollback to savepoint a;
-    -- cs - array column contains the input array
+    -- contains - array column contains the input array
     select jsonb_pretty(
         graphql.resolve($$
             {
-              accountCollection(filter: {tags: {cs: ["customer", "priority"]}}) {
+              accountCollection(filter: {tags: {contains: ["customer", "priority"]}}) {
                 edges {
                   node {
                     id
@@ -333,11 +333,11 @@ begin;
 (1 row)
 
     rollback to savepoint a;
-    -- cd - array column is contained by input array
+    -- containedByd - array column is contained by input array
     select jsonb_pretty(
         graphql.resolve($$
             {
-              accountCollection(filter: {tags: {cd: ["customer", "priority"]}}) {
+              accountCollection(filter: {tags: {containedBy: ["customer", "priority"]}}) {
                 edges {
                   node {
                     id
@@ -370,11 +370,11 @@ begin;
 (1 row)
 
     rollback to savepoint a;
-    -- ov - array column overlaps with input array
+    -- overlaps - array column overlaps with input array
     select jsonb_pretty(
         graphql.resolve($$
             {
-              accountCollection(filter: {tags: {ov: ["customer", "priority"]}}) {
+              accountCollection(filter: {tags: {overlaps: ["customer", "priority"]}}) {
                 edges {
                   node {
                     id

--- a/test/expected/roundtrip_types.out
+++ b/test/expected/roundtrip_types.out
@@ -686,26 +686,10 @@ begin;
                      }                                +
                  },                                   +
                  {                                    +
-                     "name": "typeArrayEnum",         +
-                     "type": {                        +
-                         "kind": "INPUT_OBJECT",      +
-                         "name": "ColorListFilter",   +
-                         "ofType": null               +
-                     }                                +
-                 },                                   +
-                 {                                    +
                      "name": "typeArrayText",         +
                      "type": {                        +
                          "kind": "INPUT_OBJECT",      +
                          "name": "StringListFilter",  +
-                         "ofType": null               +
-                     }                                +
-                 },                                   +
-                 {                                    +
-                     "name": "typeArrayJson",         +
-                     "type": {                        +
-                         "kind": "INPUT_OBJECT",      +
-                         "name": "JSONListFilter",    +
                          "ofType": null               +
                      }                                +
                  },                                   +

--- a/test/sql/resolve_connection_filter.sql
+++ b/test/sql/resolve_connection_filter.sql
@@ -122,11 +122,11 @@ begin;
     select graphql.resolve($${accountCollection(filter: {phone: {is: null}}) { edges { node { id } } }}$$);
     rollback to savepoint a;
 
-    -- cs - array column contains the input scalar
+    -- contains - array column contains the input scalar
     select jsonb_pretty(
         graphql.resolve($$
             {
-              accountCollection(filter: {tags: {cs: "customer"}}) {
+              accountCollection(filter: {tags: {contains: "customer"}}) {
                 edges {
                   node {
                     id
@@ -138,11 +138,11 @@ begin;
     );
     rollback to savepoint a;
 
-    -- cd - array column is contained by input scalar (aka, the only value in the array column is the input scalar)
+    -- containedBy - array column is contained by input scalar (aka, the only value in the array column is the input scalar)
     select jsonb_pretty(
         graphql.resolve($$
             {
-              accountCollection(filter: {tags: {cd: "customer"}}) {
+              accountCollection(filter: {tags: {containedBy: "customer"}}) {
                 edges {
                   node {
                     id
@@ -154,11 +154,11 @@ begin;
     );
     rollback to savepoint a;
 
-    -- cs - array column contains the input array
+    -- contains - array column contains the input array
     select jsonb_pretty(
         graphql.resolve($$
             {
-              accountCollection(filter: {tags: {cs: ["customer", "priority"]}}) {
+              accountCollection(filter: {tags: {contains: ["customer", "priority"]}}) {
                 edges {
                   node {
                     id
@@ -170,11 +170,11 @@ begin;
     );
     rollback to savepoint a;
 
-    -- cd - array column is contained by input array
+    -- containedByd - array column is contained by input array
     select jsonb_pretty(
         graphql.resolve($$
             {
-              accountCollection(filter: {tags: {cd: ["customer", "priority"]}}) {
+              accountCollection(filter: {tags: {containedBy: ["customer", "priority"]}}) {
                 edges {
                   node {
                     id
@@ -186,11 +186,11 @@ begin;
     );
     rollback to savepoint a;
 
-    -- ov - array column overlaps with input array
+    -- overlaps - array column overlaps with input array
     select jsonb_pretty(
         graphql.resolve($$
             {
-              accountCollection(filter: {tags: {ov: ["customer", "priority"]}}) {
+              accountCollection(filter: {tags: {overlaps: ["customer", "priority"]}}) {
                 edges {
                   node {
                     id


### PR DESCRIPTION
## What kind of change does this PR introduce?
1. Restricts Filtering list types to primary scalar elements like String/Int/BigFloat

The main set we want to exclude are:
- JSON/JSONB - these don't support equality 
- Opaque - its an unknown if they'll work and I'd prefer to keep simplicity rather than care about these
- Enum - doesn't work out of the box and is a low priority feature
- Composites - we don't support any composite filtering


2. removes panic! when matching on filter op types

3. Rename filter ops
- renames `ov` to `overlaps`
- rename `cd` to `containedBy`
- rename `cs` to `contains`

4. Remove filter ops `gt`, `gte`, `lt`, `lte` from list filtering options

resolves #523 