### PR TITLE
Bump versions for 1.5.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "pg_graphql"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "base64 0.13.1",
  "bimap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_graphql"
-version = "1.5.6"
+version = "1.5.7"
 edition = "2021"
 
 [lib]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -84,5 +84,8 @@
 ## 1.5.6
 - feature: add support for filtering on array column types using `contains`, `containedBy`, `overlaps`, `is`, `eq`
 
-## master
+## 1.5.7
 - bugfix: UDF argument with a complex default expression was marked as required
+- bugfix: not null foreign keys referencing tables with RLS are marked as nullable
+
+## master


### PR DESCRIPTION
## What kind of change does this PR introduce?
bumps version for 1.5.7 for latest bugfixes