### PR TITLE
Partial Unique Indexes should not be marked as `is_unique`

### DIFF
--- a/sql/load_sql_context.sql
+++ b/sql/load_sql_context.sql
@@ -280,7 +280,7 @@ select
                                                     ),
                                                     array[]::text[]
                                                 ),
-                                                'is_unique', pi.indisunique,
+                                                'is_unique', pi.indisunique and pi.indpred is null,
                                                 'is_primary_key', pi.indisprimary
                                             )
                                         )

--- a/test/expected/issue_542_partial_unique.out
+++ b/test/expected/issue_542_partial_unique.out
@@ -1,0 +1,116 @@
+begin;
+    create table public.works(
+        work_id int primary key
+    );
+    create table public.readthroughs (
+        readthrough_id int primary key,
+        work_id int not null references public.works(work_id),
+        status text not null
+    );
+    select jsonb_pretty(
+      graphql.resolve($$
+        {
+          __type(name: "Works") {
+            kind
+            fields {
+              name
+              type {
+                kind
+                name
+              }
+            }
+          }
+        }
+      $$)
+    );
+                     jsonb_pretty                      
+-------------------------------------------------------
+ {                                                    +
+     "data": {                                        +
+         "__type": {                                  +
+             "kind": "OBJECT",                        +
+             "fields": [                              +
+                 {                                    +
+                     "name": "nodeId",                +
+                     "type": {                        +
+                         "kind": "NON_NULL",          +
+                         "name": null                 +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "workId",                +
+                     "type": {                        +
+                         "kind": "NON_NULL",          +
+                         "name": null                 +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "readthroughsCollection",+
+                     "type": {                        +
+                         "kind": "NON_NULL",          +
+                         "name": null                 +
+                     }                                +
+                 }                                    +
+             ]                                        +
+         }                                            +
+     }                                                +
+ }
+(1 row)
+
+    /* Creating partial unique referencing status should NOT change the relationship with
+    the readthroughs to a non-null unique because its partial and other statuses may
+    have multiple associated readthroughs */
+    create unique index idx_unique_in_progress_readthrough
+      on public.readthroughs (work_id)
+      where status in ('in_progress');
+    select jsonb_pretty(
+        graphql.resolve($$
+        {
+          __type(name: "Works") {
+            kind
+            fields {
+              name
+              type {
+                kind
+                name
+              }
+            }
+          }
+        }
+        $$)
+    );
+                jsonb_pretty                 
+---------------------------------------------
+ {                                          +
+     "data": {                              +
+         "__type": {                        +
+             "kind": "OBJECT",              +
+             "fields": [                    +
+                 {                          +
+                     "name": "nodeId",      +
+                     "type": {              +
+                         "kind": "NON_NULL",+
+                         "name": null       +
+                     }                      +
+                 },                         +
+                 {                          +
+                     "name": "workId",      +
+                     "type": {              +
+                         "kind": "NON_NULL",+
+                         "name": null       +
+                     }                      +
+                 },                         +
+                 {                          +
+                     "name": "work",        +
+                     "type": {              +
+                         "kind": "NON_NULL",+
+                         "name": null       +
+                     }                      +
+                 }                          +
+             ]                              +
+         }                                  +
+     }                                      +
+ }
+(1 row)
+
+rollback;

--- a/test/expected/issue_542_partial_unique.out
+++ b/test/expected/issue_542_partial_unique.out
@@ -79,37 +79,37 @@ begin;
         }
         $$)
     );
-                jsonb_pretty                 
----------------------------------------------
- {                                          +
-     "data": {                              +
-         "__type": {                        +
-             "kind": "OBJECT",              +
-             "fields": [                    +
-                 {                          +
-                     "name": "nodeId",      +
-                     "type": {              +
-                         "kind": "NON_NULL",+
-                         "name": null       +
-                     }                      +
-                 },                         +
-                 {                          +
-                     "name": "workId",      +
-                     "type": {              +
-                         "kind": "NON_NULL",+
-                         "name": null       +
-                     }                      +
-                 },                         +
-                 {                          +
-                     "name": "work",        +
-                     "type": {              +
-                         "kind": "NON_NULL",+
-                         "name": null       +
-                     }                      +
-                 }                          +
-             ]                              +
-         }                                  +
-     }                                      +
+                     jsonb_pretty                      
+-------------------------------------------------------
+ {                                                    +
+     "data": {                                        +
+         "__type": {                                  +
+             "kind": "OBJECT",                        +
+             "fields": [                              +
+                 {                                    +
+                     "name": "nodeId",                +
+                     "type": {                        +
+                         "kind": "NON_NULL",          +
+                         "name": null                 +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "workId",                +
+                     "type": {                        +
+                         "kind": "NON_NULL",          +
+                         "name": null                 +
+                     }                                +
+                 },                                   +
+                 {                                    +
+                     "name": "readthroughsCollection",+
+                     "type": {                        +
+                         "kind": "NON_NULL",          +
+                         "name": null                 +
+                     }                                +
+                 }                                    +
+             ]                                        +
+         }                                            +
+     }                                                +
  }
 (1 row)
 

--- a/test/sql/issue_542_partial_unique.sql
+++ b/test/sql/issue_542_partial_unique.sql
@@ -1,0 +1,54 @@
+begin;
+
+    create table public.works(
+        work_id int primary key
+    );
+
+    create table public.readthroughs (
+        readthrough_id int primary key,
+        work_id int not null references public.works(work_id),
+        status text not null
+    );
+
+    select jsonb_pretty(
+      graphql.resolve($$
+        {
+          __type(name: "Works") {
+            kind
+            fields {
+              name
+              type {
+                kind
+                name
+              }
+            }
+          }
+        }
+      $$)
+    );
+
+    /* Creating partial unique referencing status should NOT change the relationship with
+    the readthroughs to a non-null unique because its partial and other statuses may
+    have multiple associated readthroughs */
+    create unique index idx_unique_in_progress_readthrough
+      on public.readthroughs (work_id)
+      where status in ('in_progress');
+
+    select jsonb_pretty(
+        graphql.resolve($$
+        {
+          __type(name: "Works") {
+            kind
+            fields {
+              name
+              type {
+                kind
+                name
+              }
+            }
+          }
+        }
+        $$)
+    );
+
+rollback;


### PR DESCRIPTION
## What kind of change does this PR introduce?
Currently if a partial unique index is created it counts as a fully unique index and if there is an associated foreign key the relationship changes from a 1:N to 1:1

This change prevents partial unique indexes from being marked as `is_unique`  in the SQL context

resolves #542 