### PR TITLE
fix a bug in which a closing parenthesis in @graphql directive failed to parse as json

### DIFF
--- a/sql/directives.sql
+++ b/sql/directives.sql
@@ -11,7 +11,7 @@ as $$
             (
                 regexp_match(
                     comment_,
-                    '@graphql\((.+?)\)'
+                    '@graphql\((.+)\)'
                 )
             )[1]::jsonb,
             jsonb_build_object()

--- a/test/expected/comment_directive.out
+++ b/test/expected/comment_directive.out
@@ -1,9 +1,36 @@
 select
     graphql.comment_directive(
         comment_ := '@graphql({"name": "myField"})'
-    )
+    );
   comment_directive  
 ---------------------
  {"name": "myField"}
+(1 row)
+
+select
+    graphql.comment_directive(
+        comment_ := '@graphql({"name": "myField with (parentheses)"})'
+    );
+           comment_directive            
+----------------------------------------
+ {"name": "myField with (parentheses)"}
+(1 row)
+
+select
+    graphql.comment_directive(
+        comment_ := '@graphql({"name": "myField with a (starting parenthesis"})'
+    );
+                comment_directive                 
+--------------------------------------------------
+ {"name": "myField with a (starting parenthesis"}
+(1 row)
+
+select
+    graphql.comment_directive(
+        comment_ := '@graphql({"name": "myField with an ending parenthesis)"})'
+    );
+                comment_directive                
+-------------------------------------------------
+ {"name": "myField with an ending parenthesis)"}
 (1 row)
 

--- a/test/sql/comment_directive.sql
+++ b/test/sql/comment_directive.sql
@@ -1,4 +1,19 @@
 select
     graphql.comment_directive(
         comment_ := '@graphql({"name": "myField"})'
-    )
+    );
+
+select
+    graphql.comment_directive(
+        comment_ := '@graphql({"name": "myField with (parentheses)"})'
+    );
+
+select
+    graphql.comment_directive(
+        comment_ := '@graphql({"name": "myField with a (starting parenthesis"})'
+    );
+
+select
+    graphql.comment_directive(
+        comment_ := '@graphql({"name": "myField with an ending parenthesis)"})'
+    );


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If a comment directive had a closing parenthesis, it failed to parse as valid json. E.g. `comment on column table.column is e'@graphql({"description": "column description)"})';` would fail with error `invalid input syntax for type json`

## What is the new behavior?

The comment directive parses as json successfully.

## Additional context

The parsing failed because the regex in `graphql.comment_directive` function had a non-greedy match (`.+?`). This terminated the search for an ending parenthesis early, resulting in an invalid json string. E.g. the following statement:

```sql
select regexp_match(
	'@graphql({"description": "column description)"})',
	'@graphql\((.+?)\)'
);
```

returns `{"{\"description\": \"column description"}`. While the fixed regexp correctly returns `{"{\"description\": \"column description)\"}"}`.