### PR TITLE
fix typo in Date scalar doc string

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build docker images
-        run: PG_VERSION=${{ matrix.postgres }} docker-compose -f .ci/docker-compose.yml build
+        run: PG_VERSION=${{ matrix.postgres }} docker compose -f .ci/docker-compose.yml build
 
       - name: Run tests
-        run: PG_VERSION=${{ matrix.postgres }} docker-compose -f .ci/docker-compose.yml run test
+        run: PG_VERSION=${{ matrix.postgres }} docker compose -f .ci/docker-compose.yml run test

--- a/docs/assets/demo_schema.graphql
+++ b/docs/assets/demo_schema.graphql
@@ -424,7 +424,7 @@ An opaque string using for tracking a position in results during pagination
 """
 scalar Cursor
 
-"""A date wihout time information"""
+"""A date without time information"""
 scalar Date
 
 """

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1594,7 +1594,7 @@ impl ___Type for Scalar {
                 Self::String(_) => "A string",
                 Self::Boolean => "A value that is true or false",
                 Self::BigInt => "An arbitrary size integer represented as a string",
-                Self::Date => "A date wihout time information",
+                Self::Date => "A date without time information",
                 Self::Time => "A time without date information",
                 Self::Datetime => "A date and time",
                 Self::UUID => "A universally unique identifier",


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

Fixes typo in Date scalar doc string

## What is the current behavior?

Typo in the generated doc string
