### PR TITLE
replace customScalars with customScalarTypes

### DIFF
--- a/docs/usage_with_relay.md
+++ b/docs/usage_with_relay.md
@@ -20,7 +20,7 @@ Modify your `relay.config.js` file to reflect the following:
        nodeInterfaceIdField: 'nodeId',
        nodeInterfaceIdVariableName: 'nodeId',
      },
-     customScalars: {
+     customScalarTypes: {
        UUID: 'string',
        Datetime: 'string',
        JSON: 'string',
@@ -32,7 +32,7 @@ Modify your `relay.config.js` file to reflect the following:
    ```
 
    - `schemaConfig` tells the Relay compiler where to find the `nodeId` field on the `node` interface
-   - `customScalars` will improve Relay's type emission
+   - `customScalarTypes` will improve Relay's type emission
 
 ### Configuring your Relay Environment
 

--- a/docs/usage_with_relay.md
+++ b/docs/usage_with_relay.md
@@ -34,6 +34,10 @@ Modify your `relay.config.js` file to reflect the following:
    - `schemaConfig` tells the Relay compiler where to find the `nodeId` field on the `node` interface
    - `customScalarTypes` will improve Relay's type emission
 
+!!! note
+
+    For Relay versions older than v16.2.0, it should be named `customScalars` instead.
+
 ### Configuring your Relay Environment
 
    This example uses [Supabase](https://supabase.com) for the GraphQL server, but pg_graphql can be used independently.


### PR DESCRIPTION
## What kind of change does this PR introduce?

update docs.
Replace customScalars with customScalarTypes on the usage with relay page.

## What is the current behavior?

Reflecting changes in relay v16.2.0

## Additional context
- https://github.com/facebook/relay/releases/tag/v16.2.0
- https://github.com/facebook/relay/tree/main/packages/relay-compiler