### PR TITLE
bump version to 1.5.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "pg_graphql"
-version = "1.5.7"
+version = "1.5.8"
 dependencies = [
  "base64 0.13.1",
  "bimap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_graphql"
-version = "1.5.7"
+version = "1.5.8"
 edition = "2021"
 
 [lib]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -88,5 +88,7 @@
 - bugfix: UDF argument with a complex default expression was marked as required
 - bugfix: not null foreign keys referencing tables with RLS are marked as nullable
 
-## master
+## 1.5.8
 - bugfix: relational query with more than 100 fields fails
+
+## master


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bumps version for release.

## Additional context

My team is soft-blocked on the fix to #551.
