### PR TITLE
Bugfix relationship 1:1 nullability

### DIFF
--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1952,13 +1952,19 @@ pub fn sql_column_to_graphql_type(col: &Column, schema: &Arc<__Schema>) -> Optio
 }
 
 impl NodeType {
-    fn foreign_key_type(&self, fkey: &ForeignKey, type_: __Type) -> __Type {
+    fn foreign_key_type(
+        &self,
+        fkey: &ForeignKey,
+        type_: __Type,
+        is_reverse_reference: bool,
+    ) -> __Type {
         if fkey.local_table_meta.column_names.iter().any(|colname| {
             self.table
                 .columns
                 .iter()
                 .any(|c| &c.name == colname && c.is_not_null)
                 && !fkey.referenced_table_meta.is_rls_enabled
+                && !is_reverse_reference
         }) {
             __Type::NonNull(NonNullType {
                 type_: Box::new(type_),
@@ -2127,6 +2133,7 @@ impl ___Type for NodeType {
                     reverse_reference: Some(reverse_reference),
                     schema: Arc::clone(&self.schema),
                 }),
+                reverse_reference,
             );
 
             let relation_field = __Field {
@@ -2180,7 +2187,11 @@ impl ___Type for NodeType {
                     };
                     let connection_args = connection_type.get_connection_input_args();
 
-                    let type_ = self.foreign_key_type(fkey, __Type::Connection(connection_type));
+                    let type_ = self.foreign_key_type(
+                        fkey,
+                        __Type::Connection(connection_type),
+                        reverse_reference,
+                    );
 
                     __Field {
                         name_: self
@@ -2202,6 +2213,7 @@ impl ___Type for NodeType {
                             reverse_reference: Some(reverse_reference),
                             schema: Arc::clone(&self.schema),
                         }),
+                        reverse_reference,
                     );
 
                     __Field {

--- a/test/expected/issue_542_partial_unique.out
+++ b/test/expected/issue_542_partial_unique.out
@@ -23,37 +23,37 @@ begin;
         }
       $$)
     );
-                     jsonb_pretty                      
--------------------------------------------------------
- {                                                    +
-     "data": {                                        +
-         "__type": {                                  +
-             "kind": "OBJECT",                        +
-             "fields": [                              +
-                 {                                    +
-                     "name": "nodeId",                +
-                     "type": {                        +
-                         "kind": "NON_NULL",          +
-                         "name": null                 +
-                     }                                +
-                 },                                   +
-                 {                                    +
-                     "name": "workId",                +
-                     "type": {                        +
-                         "kind": "NON_NULL",          +
-                         "name": null                 +
-                     }                                +
-                 },                                   +
-                 {                                    +
-                     "name": "readthroughsCollection",+
-                     "type": {                        +
-                         "kind": "NON_NULL",          +
-                         "name": null                 +
-                     }                                +
-                 }                                    +
-             ]                                        +
-         }                                            +
-     }                                                +
+                       jsonb_pretty                       
+----------------------------------------------------------
+ {                                                       +
+     "data": {                                           +
+         "__type": {                                     +
+             "kind": "OBJECT",                           +
+             "fields": [                                 +
+                 {                                       +
+                     "name": "nodeId",                   +
+                     "type": {                           +
+                         "kind": "NON_NULL",             +
+                         "name": null                    +
+                     }                                   +
+                 },                                      +
+                 {                                       +
+                     "name": "workId",                   +
+                     "type": {                           +
+                         "kind": "NON_NULL",             +
+                         "name": null                    +
+                     }                                   +
+                 },                                      +
+                 {                                       +
+                     "name": "readthroughsCollection",   +
+                     "type": {                           +
+                         "kind": "OBJECT",               +
+                         "name": "ReadthroughsConnection"+
+                     }                                   +
+                 }                                       +
+             ]                                           +
+         }                                               +
+     }                                                   +
  }
 (1 row)
 
@@ -79,37 +79,37 @@ begin;
         }
         $$)
     );
-                     jsonb_pretty                      
--------------------------------------------------------
- {                                                    +
-     "data": {                                        +
-         "__type": {                                  +
-             "kind": "OBJECT",                        +
-             "fields": [                              +
-                 {                                    +
-                     "name": "nodeId",                +
-                     "type": {                        +
-                         "kind": "NON_NULL",          +
-                         "name": null                 +
-                     }                                +
-                 },                                   +
-                 {                                    +
-                     "name": "workId",                +
-                     "type": {                        +
-                         "kind": "NON_NULL",          +
-                         "name": null                 +
-                     }                                +
-                 },                                   +
-                 {                                    +
-                     "name": "readthroughsCollection",+
-                     "type": {                        +
-                         "kind": "NON_NULL",          +
-                         "name": null                 +
-                     }                                +
-                 }                                    +
-             ]                                        +
-         }                                            +
-     }                                                +
+                       jsonb_pretty                       
+----------------------------------------------------------
+ {                                                       +
+     "data": {                                           +
+         "__type": {                                     +
+             "kind": "OBJECT",                           +
+             "fields": [                                 +
+                 {                                       +
+                     "name": "nodeId",                   +
+                     "type": {                           +
+                         "kind": "NON_NULL",             +
+                         "name": null                    +
+                     }                                   +
+                 },                                      +
+                 {                                       +
+                     "name": "workId",                   +
+                     "type": {                           +
+                         "kind": "NON_NULL",             +
+                         "name": null                    +
+                     }                                   +
+                 },                                      +
+                 {                                       +
+                     "name": "readthroughsCollection",   +
+                     "type": {                           +
+                         "kind": "OBJECT",               +
+                         "name": "ReadthroughsConnection"+
+                     }                                   +
+                 }                                       +
+             ]                                           +
+         }                                               +
+     }                                                   +
  }
 (1 row)
 

--- a/test/expected/issue_557_1_to_1_nullability.out
+++ b/test/expected/issue_557_1_to_1_nullability.out
@@ -1,0 +1,163 @@
+begin;
+    -- Create the party table
+    create table party (
+        id uuid primary key default gen_random_uuid(),
+        kind varchar not null -- Indicates whether the party is a 'contact' or an 'organisation'
+    );
+    -- Create the contact table
+    create table contact (
+        id uuid primary key, -- Also a foreign key to party.id
+        given_name text,
+        family_name text,
+        foreign key (id) references party(id)
+    );
+    -- Create the organisation table
+    create table organization (
+        id uuid primary key, -- Also a foreign key to party.id
+        name text not null,
+        foreign key (id) references party(id)
+    );
+    -- Party should have nullable relationships to Contact and Organization
+    select jsonb_pretty(
+      graphql.resolve($$
+        {
+          __type(name: "Party") {
+            kind
+            fields {
+              name
+              type {
+                ofType {
+                  name
+                  kind
+                  description
+                }
+
+              }
+            }
+          }
+        }
+        $$)
+    );
+                                         jsonb_pretty                                         
+----------------------------------------------------------------------------------------------
+ {                                                                                           +
+     "data": {                                                                               +
+         "__type": {                                                                         +
+             "kind": "OBJECT",                                                               +
+             "fields": [                                                                     +
+                 {                                                                           +
+                     "name": "nodeId",                                                       +
+                     "type": {                                                               +
+                         "ofType": {                                                         +
+                             "kind": "SCALAR",                                               +
+                             "name": "ID",                                                   +
+                             "description": "A globally unique identifier for a given record"+
+                         }                                                                   +
+                     }                                                                       +
+                 },                                                                          +
+                 {                                                                           +
+                     "name": "id",                                                           +
+                     "type": {                                                               +
+                         "ofType": {                                                         +
+                             "kind": "SCALAR",                                               +
+                             "name": "UUID",                                                 +
+                             "description": "A universally unique identifier"                +
+                         }                                                                   +
+                     }                                                                       +
+                 },                                                                          +
+                 {                                                                           +
+                     "name": "kind",                                                         +
+                     "type": {                                                               +
+                         "ofType": {                                                         +
+                             "kind": "SCALAR",                                               +
+                             "name": "String",                                               +
+                             "description": "A string"                                       +
+                         }                                                                   +
+                     }                                                                       +
+                 },                                                                          +
+                 {                                                                           +
+                     "name": "contact",                                                      +
+                     "type": {                                                               +
+                         "ofType": null                                                      +
+                     }                                                                       +
+                 },                                                                          +
+                 {                                                                           +
+                     "name": "organization",                                                 +
+                     "type": {                                                               +
+                         "ofType": null                                                      +
+                     }                                                                       +
+                 }                                                                           +
+             ]                                                                               +
+         }                                                                                   +
+     }                                                                                       +
+ }
+(1 row)
+
+    -- Contact and Organization should have non-nullable relationship to Party
+    select jsonb_pretty(
+      graphql.resolve($$
+        {
+          __type(name: "Organization") {
+            kind
+            fields {
+              name
+              kind
+              description
+              type {
+                ofType {
+                  name
+                  kind
+                  description
+                }
+              }
+            }
+          }
+        }
+        $$)
+    );
+                      jsonb_pretty                      
+--------------------------------------------------------
+ {                                                     +
+     "data": null,                                     +
+     "errors": [                                       +
+         {                                             +
+             "message": "unknown field in __Field kind"+
+         }                                             +
+     ]                                                 +
+ }
+(1 row)
+
+    select jsonb_pretty(
+      graphql.resolve($$
+        {
+          __type(name: "Contact") {
+            kind
+            fields {
+              name
+              kind
+              description
+              type {
+                ofType {
+                  name
+                  kind
+                  description
+                }
+              }
+            }
+          }
+        }
+        $$)
+    );
+                      jsonb_pretty                      
+--------------------------------------------------------
+ {                                                     +
+     "data": null,                                     +
+     "errors": [                                       +
+         {                                             +
+             "message": "unknown field in __Field kind"+
+         }                                             +
+     ]                                                 +
+ }
+(1 row)
+
+rollback;

--- a/test/sql/issue_557_1_to_1_nullability.sql
+++ b/test/sql/issue_557_1_to_1_nullability.sql
@@ -1,0 +1,91 @@
+begin;
+
+    -- Create the party table
+    create table party (
+        id uuid primary key default gen_random_uuid(),
+        kind varchar not null -- Indicates whether the party is a 'contact' or an 'organisation'
+    );
+
+    -- Create the contact table
+    create table contact (
+        id uuid primary key, -- Also a foreign key to party.id
+        given_name text,
+        family_name text,
+        foreign key (id) references party(id)
+    );
+
+    -- Create the organisation table
+    create table organization (
+        id uuid primary key, -- Also a foreign key to party.id
+        name text not null,
+        foreign key (id) references party(id)
+    );
+
+    -- Party should have nullable relationships to Contact and Organization
+    select jsonb_pretty(
+      graphql.resolve($$
+        {
+          __type(name: "Party") {
+            kind
+            fields {
+              name
+              type {
+                ofType {
+                  name
+                  kind
+                  description
+                }
+
+              }
+            }
+          }
+        }
+        $$)
+    );
+
+    -- Contact and Organization should have non-nullable relationship to Party
+    select jsonb_pretty(
+      graphql.resolve($$
+        {
+          __type(name: "Organization") {
+            kind
+            fields {
+              name
+              kind
+              description
+              type {
+                ofType {
+                  name
+                  kind
+                  description
+                }
+              }
+            }
+          }
+        }
+        $$)
+    );
+
+    select jsonb_pretty(
+      graphql.resolve($$
+        {
+          __type(name: "Contact") {
+            kind
+            fields {
+              name
+              kind
+              description
+              type {
+                ofType {
+                  name
+                  kind
+                  description
+                }
+              }
+            }
+          }
+        }
+        $$)
+    );
+
+rollback;


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bugfix. Reverse foreign key relationships are not known to be not null. This PR updates them to display nullability in Introspection schema. No transpilation behavior is changed.

Resolves #557 