### PR TITLE
bump python version to 3.12

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -11,10 +11,10 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2
 
-    - name: set up python 3.8
+    - name: set up python 3.12
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.12
 
     - name: install pre-commit
       run: |


### PR DESCRIPTION
pre-commit hooks were failing because python 3.8 is no longer available for installation.