### PR TITLE
fix code coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,48 +17,52 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.81.0
-          components: llvm-tools-preview
-
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-
       - run: |
-          sudo apt remove -y postgres*
-          sudo apt-get install -y wget gnupg
-          sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-          sudo apt-get update -y -qq --fix-missing
-          sudo apt-get install -y \
-            clang-10 \
-            llvm-10 \
-            clang \
-            gcc \
-            make \
-            build-essential \
-            libz-dev \
-            zlib1g-dev \
-            strace \
-            libssl-dev \
-            pkg-config \
-            postgresql-16 \
-            postgresql-server-dev-16
-          sudo chmod a+rwx `/usr/lib/postgresql/16/bin/pg_config --pkglibdir` `/usr/lib/postgresql/16/bin/pg_config --sharedir`/extension /var/run/postgresql/
+          # Add postgres package repo
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc &>/dev/null
 
-      - run: cargo install cargo-pgrx --version 0.12.6
-      - run: cargo pgrx init --pg16 /usr/lib/postgresql/16/bin/pg_config
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends git build-essential libpq-dev curl libreadline6-dev zlib1g-dev pkg-config cmake
+          sudo apt-get install -y --no-install-recommends libreadline-dev zlib1g-dev flex bison libxml2-dev libxslt-dev libssl-dev libxml2-utils xsltproc ccache
+          sudo apt-get install -y --no-install-recommends clang libclang-dev gcc tree
+
+          # Install requested postgres version
+          sudo apt install -y postgresql-16 postgresql-server-dev-16 -y
+
+          # Ensure installed pg_config is first on path
+          export PATH=$PATH:/usr/lib/postgresql/16/bin
+
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable && \
+            rustup --version && \
+            rustc --version && \
+            cargo --version
+
+          # Ensure cargo/rust on path
+          source "$HOME/.cargo/env"
+
+          rustup component add llvm-tools-preview
+          cargo install cargo-llvm-cov
+          cargo install cargo-pgrx --version 0.12.6 --locked
+          cargo pgrx init --pg16=/usr/lib/postgresql/16/bin/pg_config
+
+          sudo chmod a+rw /usr/share/postgresql/16/extension
+          sudo chmod a+rw /usr/lib/postgresql/16/lib/
+
+          cargo pgrx install
+          source <(cargo llvm-cov show-env --export-prefix)
+          cargo llvm-cov clean --workspace
+          cargo build
+          cp ./target/debug/libpg_graphql.so /usr/lib/postgresql/16/lib/pg_graphql.so
+          ./bin/installcheck
 
       - name: Generate code coverage
         id: coverage
         run: |
-          cargo llvm-cov test --workspace --no-fail-fast --lcov --output-path lcov.info
+          cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Coveralls upload
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: lcov.info
-          debug: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -55,14 +55,6 @@ jobs:
           cargo build
           cp ./target/debug/libpg_graphql.so /usr/lib/postgresql/16/lib/pg_graphql.so
           ./bin/installcheck
-          echo 'listing files in target'
-          ls ./target
-          echo 'listing files in target/llvm-cov-target'
-          ls ./target/llvm-cov-target
-
-      - name: Generate code coverage
-        id: coverage
-        run: |
           cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Coveralls upload

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -55,6 +55,10 @@ jobs:
           cargo build
           cp ./target/debug/libpg_graphql.so /usr/lib/postgresql/16/lib/pg_graphql.so
           ./bin/installcheck
+          echo 'listing files in target'
+          ls ./target
+          echo 'listing files in target/llvm-cov-target'
+          ls ./target/llvm-cov-target
 
       - name: Generate code coverage
         id: coverage


### PR DESCRIPTION
The existing code coverage method did not include coverage data for integration tests run using `./bin/installcheck` command.