### PR TITLE
Add inflection comment directive to the SQL schema in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ create table blog_post(
     created_at timestamp not null,
     updated_at timestamp not null
 );
+
+-- This enables default inflection, which automatically renames
+-- snake_case to PascalCase for type names, and snake_case to camelCase for field names.
+-- See https://supabase.github.io/pg_graphql/configuration/#inflection for more details.
+COMMENT ON SCHEMA public IS e'@graphql({"inflect_names": true})';
 ```
 Translates into a GraphQL schema displayed below.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- [x] Documentation (README) update only.

This PR updates the SQL schema in the TL;DR section of the README to include the inflection comment directive, especially since the screenshot below has inflected field and type names.

While I was trying to figure out if there was a way to do this using supabase / pg_graphql, the README in this repo was confusing because the screenshot clearly showed what I wanted (camelCase and PascalCase in my GraphQL schema), yet I wasn't getting that in my own project. Because this feature is super useful but not very well documented (at least visibility-wise), I think it would benefit folks to just show that this feature is available front and center.

I will probably follow up with another PR / doc suggestion for the main supabase documentation as well.
