### PR TITLE
Pin react and react-dom to version 18

### DIFF
--- a/dockerfiles/graphiql/index.html
+++ b/dockerfiles/graphiql/index.html
@@ -10,11 +10,11 @@
     <div id="graphiql" style="height: 100vh"></div>
     <script
       crossorigin
-      src="https://unpkg.com/react/umd/react.production.min.js"
+      src="https://unpkg.com/react@18/umd/react.production.min.js"
     ></script>
     <script
       crossorigin
-      src="https://unpkg.com/react-dom/umd/react-dom.production.min.js"
+      src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"
     ></script>
     <script
       crossorigin


### PR DESCRIPTION
Fixes #584 by pinning react and react-dom to version 18, because

1. GraphiQL does not yet support React 19 (see https://github.com/graphql/graphiql/blob/main/packages/graphiql/package.json)

2. "Starting with React 19, React will no longer produce UMD builds" - [React 19 Upgrade Guide: UMD builds removed](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#umd-builds-removed)
