### PR TITLE
Add support for single record queries by primary key

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -959,6 +959,19 @@ pub struct NodeBuilder {
 }
 
 #[derive(Clone, Debug)]
+pub struct NodeByPkBuilder {
+    // args - map of column name to value
+    pub pk_values: HashMap<String, serde_json::Value>,
+
+    pub _alias: String,
+
+    // metadata
+    pub table: Arc<Table>,
+
+    pub selections: Vec<NodeSelection>,
+}
+
+#[derive(Clone, Debug)]
 pub enum NodeSelection {
     Connection(ConnectionBuilder),
     Node(NodeBuilder),
@@ -1814,6 +1827,188 @@ where
         reverse_reference: xtype.reverse_reference,
         selections: builder_fields,
     })
+}
+
+pub fn to_node_by_pk_builder<'a, T>(
+    field: &__Field,
+    query_field: &graphql_parser::query::Field<'a, T>,
+    fragment_definitions: &Vec<FragmentDefinition<'a, T>>,
+    variables: &serde_json::Value,
+    variable_definitions: &Vec<VariableDefinition<'a, T>>,
+) -> Result<NodeByPkBuilder, String>
+where
+    T: Text<'a> + Eq + AsRef<str> + Clone,
+    T::Value: Hash,
+{
+    let type_ = field.type_().unmodified_type();
+    let alias = alias_or_name(query_field);
+
+    match type_ {
+        __Type::Node(xtype) => {
+            let type_name = xtype
+                .name()
+                .ok_or("Encountered type without name in node_by_pk builder")?;
+
+            let field_map = field_map(&__Type::Node(xtype.clone()));
+
+            // Get primary key columns from the table
+            let pkey = xtype
+                .table
+                .primary_key()
+                .ok_or("Table has no primary key".to_string())?;
+
+            // Create a map of expected field arguments based on the field's arg definitions
+            let mut pk_arg_map = HashMap::new();
+            for arg in field.args() {
+                if let Some(NodeSQLType::Column(col)) = &arg.sql_type {
+                    pk_arg_map.insert(arg.name().to_string(), col.name.clone());
+                }
+            }
+
+            let mut pk_values = HashMap::new();
+
+            // Process each argument in the query
+            for arg in &query_field.arguments {
+                let arg_name = arg.0.as_ref();
+
+                // Find the corresponding column name from our argument map
+                if let Some(col_name) = pk_arg_map.get(arg_name) {
+                    let value = to_gson(&arg.1, variables, variable_definitions)?;
+                    let json_value = gson::gson_to_json(&value)?;
+                    pk_values.insert(col_name.clone(), json_value);
+                }
+            }
+
+            // Need values for all primary key columns
+            if pk_values.len() != pkey.column_names.len() {
+                return Err("All primary key columns must be provided".to_string());
+            }
+
+            let mut builder_fields = vec![];
+            let selection_fields = normalize_selection_set(
+                &query_field.selection_set,
+                fragment_definitions,
+                &type_name,
+                variables,
+            )?;
+
+            for selection_field in selection_fields {
+                match field_map.get(selection_field.name.as_ref()) {
+                    None => {
+                        return Err(format!(
+                            "Unknown field '{}' on type '{}'",
+                            selection_field.name.as_ref(),
+                            &type_name
+                        ))
+                    }
+                    Some(f) => {
+                        let alias = alias_or_name(&selection_field);
+
+                        let node_selection = match &f.sql_type {
+                            Some(node_sql_type) => match node_sql_type {
+                                NodeSQLType::Column(col) => NodeSelection::Column(ColumnBuilder {
+                                    alias,
+                                    column: Arc::clone(col),
+                                }),
+                                NodeSQLType::Function(func) => {
+                                    let function_selection = match &f.type_() {
+                                        __Type::Scalar(_) => FunctionSelection::ScalarSelf,
+                                        __Type::List(_) => FunctionSelection::Array,
+                                        __Type::Node(_) => {
+                                            let node_builder = to_node_builder(
+                                                f,
+                                                &selection_field,
+                                                fragment_definitions,
+                                                variables,
+                                                &[],
+                                                variable_definitions,
+                                            )?;
+                                            FunctionSelection::Node(node_builder)
+                                        }
+                                        __Type::Connection(_) => {
+                                            let connection_builder = to_connection_builder(
+                                                f,
+                                                &selection_field,
+                                                fragment_definitions,
+                                                variables,
+                                                &[],
+                                                variable_definitions,
+                                            )?;
+                                            FunctionSelection::Connection(connection_builder)
+                                        }
+                                        _ => {
+                                            return Err(
+                                                "invalid return type from function".to_string()
+                                            )
+                                        }
+                                    };
+                                    NodeSelection::Function(FunctionBuilder {
+                                        alias,
+                                        function: Arc::clone(func),
+                                        table: Arc::clone(&xtype.table),
+                                        selection: function_selection,
+                                    })
+                                }
+                                NodeSQLType::NodeId(pkey_columns) => {
+                                    NodeSelection::NodeId(NodeIdBuilder {
+                                        alias,
+                                        columns: pkey_columns.clone(),
+                                        table_name: xtype.table.name.clone(),
+                                        schema_name: xtype.table.schema.clone(),
+                                    })
+                                }
+                            },
+                            _ => match f.name().as_ref() {
+                                "__typename" => NodeSelection::Typename {
+                                    alias: alias_or_name(&selection_field),
+                                    typename: xtype.name().expect("node type should have a name"),
+                                },
+                                _ => match f.type_().unmodified_type() {
+                                    __Type::Connection(_) => {
+                                        let con_builder = to_connection_builder(
+                                            f,
+                                            &selection_field,
+                                            fragment_definitions,
+                                            variables,
+                                            &[],
+                                            variable_definitions,
+                                        );
+                                        NodeSelection::Connection(con_builder?)
+                                    }
+                                    __Type::Node(_) => {
+                                        let node_builder = to_node_builder(
+                                            f,
+                                            &selection_field,
+                                            fragment_definitions,
+                                            variables,
+                                            &[],
+                                            variable_definitions,
+                                        );
+                                        NodeSelection::Node(node_builder?)
+                                    }
+                                    _ => {
+                                        return Err(format!(
+                                            "unexpected field type on node {}",
+                                            f.name()
+                                        ));
+                                    }
+                                },
+                            },
+                        };
+                        builder_fields.push(node_selection);
+                    }
+                }
+            }
+
+            Ok(NodeByPkBuilder {
+                pk_values,
+                _alias: alias,
+                table: Arc::clone(&xtype.table),
+                selections: builder_fields,
+            })
+        }
+        _ => Err("cannot build query for non-node type".to_string()),
+    }
 }
 
 // Introspection

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1231,6 +1231,58 @@ impl ___Type for QueryType {
                 };
 
                 f.push(collection_entrypoint);
+
+                // Add single record query by primary key if the table has a primary key
+                if let Some(primary_key) = table.primary_key() {
+                    let node_type = NodeType {
+                        table: Arc::clone(table),
+                        fkey: None,
+                        reverse_reference: None,
+                        schema: Arc::clone(&self.schema),
+                    };
+
+                    // Create arguments for each primary key column
+                    let mut pk_args = Vec::new();
+                    for col_name in &primary_key.column_names {
+                        if let Some(col) = table.columns.iter().find(|c| &c.name == col_name) {
+                            let col_type = sql_column_to_graphql_type(col, &self.schema)
+                                .ok_or_else(|| {
+                                    format!(
+                                        "Could not determine GraphQL type for column {}",
+                                        col_name
+                                    )
+                                })
+                                .unwrap_or_else(|_| __Type::Scalar(Scalar::String(None)));
+
+                            // Use graphql_column_field_name to convert snake_case to camelCase if needed
+                            let arg_name = self.schema.graphql_column_field_name(col);
+
+                            pk_args.push(__InputValue {
+                                name_: arg_name,
+                                type_: __Type::NonNull(NonNullType {
+                                    type_: Box::new(col_type),
+                                }),
+                                description: Some(format!("The record's `{}` value", col_name)),
+                                default_value: None,
+                                sql_type: Some(NodeSQLType::Column(Arc::clone(col))),
+                            });
+                        }
+                    }
+
+                    let pk_entrypoint = __Field {
+                        name_: format!("{}ByPk", lowercase_first_letter(table_base_type_name)),
+                        type_: __Type::Node(node_type),
+                        args: pk_args,
+                        description: Some(format!(
+                            "Retrieve a record of type `{}` by its primary key",
+                            table_base_type_name
+                        )),
+                        deprecation_reason: None,
+                        sql_type: None,
+                    };
+
+                    f.push(pk_entrypoint);
+                }
             }
         }
 

--- a/src/transpile.rs
+++ b/src/transpile.rs
@@ -1322,12 +1322,10 @@ impl QueryEntrypoint for NodeBuilder {
         let quoted_table = quote_ident(&self.table.name);
         let object_clause = self.to_sql(&quoted_block_name, param_context)?;
 
-        let node_id = self
-            .node_id
-            .as_ref()
-            .ok_or("Expected nodeId argument missing")?;
-
-        let node_id_clause = node_id.to_sql(&quoted_block_name, &self.table, param_context)?;
+        let where_clause = match &self.node_id {
+            Some(node_id) => node_id.to_sql(&quoted_block_name, &self.table, param_context)?,
+            None => "true".to_string(),
+        };
 
         Ok(format!(
             "
@@ -1337,7 +1335,81 @@ impl QueryEntrypoint for NodeBuilder {
                 from
                     {quoted_schema}.{quoted_table} as {quoted_block_name}
                 where
-                    {node_id_clause}
+                    {where_clause}
+            )
+            "
+        ))
+    }
+}
+
+impl NodeByPkBuilder {
+    pub fn to_sql(
+        &self,
+        block_name: &str,
+        param_context: &mut ParamContext,
+    ) -> Result<String, String> {
+        let mut field_clauses = vec![];
+        for selection in &self.selections {
+            field_clauses.push(selection.to_sql(block_name, param_context)?);
+        }
+
+        if field_clauses.is_empty() {
+            return Ok("'{}'::jsonb".to_string());
+        }
+
+        let fields_clause = field_clauses.join(", ");
+        Ok(format!("jsonb_build_object({fields_clause})"))
+    }
+
+    pub fn to_pk_where_clause(
+        &self,
+        block_name: &str,
+        param_context: &mut ParamContext,
+    ) -> Result<String, String> {
+        let mut conditions = Vec::new();
+
+        for (column_name, value) in &self.pk_values {
+            let value_clause = param_context.clause_for(
+                value,
+                &self
+                    .table
+                    .columns
+                    .iter()
+                    .find(|c| &c.name == column_name)
+                    .ok_or_else(|| format!("Column {} not found", column_name))?
+                    .type_name,
+            )?;
+
+            conditions.push(format!(
+                "{}.{} = {}",
+                block_name,
+                quote_ident(column_name),
+                value_clause
+            ));
+        }
+
+        Ok(conditions.join(" AND "))
+    }
+}
+
+impl QueryEntrypoint for NodeByPkBuilder {
+    fn to_sql_entrypoint(&self, param_context: &mut ParamContext) -> Result<String, String> {
+        let quoted_block_name = rand_block_name();
+        let quoted_schema = quote_ident(&self.table.schema);
+        let quoted_table = quote_ident(&self.table.name);
+        let object_clause = self.to_sql(&quoted_block_name, param_context)?;
+
+        let where_clause = self.to_pk_where_clause(&quoted_block_name, param_context)?;
+
+        Ok(format!(
+            "
+            (
+                select
+                    {object_clause}
+                from
+                    {quoted_schema}.{quoted_table} as {quoted_block_name}
+                where
+                    {where_clause}
             )
             "
         ))
@@ -1351,19 +1423,43 @@ impl NodeIdInstance {
         table: &Table,
         param_context: &mut ParamContext,
     ) -> Result<String, String> {
-        // TODO: abstract this logical check into builder. It is not related to
-        // transpiling and should not be in this module
-        if (&self.schema_name, &self.table_name) != (&table.schema, &table.name) {
+        // Validate that nodeId belongs to the table being queried
+        if self.schema_name != table.schema || self.table_name != table.name {
             return Err("nodeId belongs to a different collection".to_string());
         }
 
-        let mut col_val_pairs: Vec<String> = vec![];
-        for (col, val) in table.primary_key_columns().iter().zip(self.values.iter()) {
-            let column_name = &col.name;
-            let val_clause = param_context.clause_for(val, &col.type_name)?;
-            col_val_pairs.push(format!("{block_name}.{column_name} = {val_clause}"))
+        let pkey = table
+            .primary_key()
+            .ok_or_else(|| "Found table with no primary key".to_string())?;
+
+        if pkey.column_names.len() != self.values.len() {
+            return Err(format!(
+                "Primary key column count mismatch. Expected {}, provided {}",
+                pkey.column_names.len(),
+                self.values.len()
+            ));
         }
-        Ok(col_val_pairs.join(" and "))
+
+        let mut conditions = vec![];
+
+        for (column_name, value) in pkey.column_names.iter().zip(&self.values) {
+            let column = table
+                .columns
+                .iter()
+                .find(|c| &c.name == column_name)
+                .ok_or(format!("Primary key column {} not found", column_name))?;
+
+            let value_clause = param_context.clause_for(value, &column.type_name)?;
+
+            conditions.push(format!(
+                "{}.{} = {}",
+                block_name,
+                quote_ident(column_name),
+                value_clause
+            ));
+        }
+
+        Ok(conditions.join(" AND "))
     }
 }
 

--- a/test/expected/function_calls.out
+++ b/test/expected/function_calls.out
@@ -2037,213 +2037,233 @@ begin;
             }
         }
     } $$));
-                                  jsonb_pretty                                   
----------------------------------------------------------------------------------
- {                                                                              +
-     "data": {                                                                  +
-         "__schema": {                                                          +
-             "queryType": {                                                     +
-                 "fields": [                                                    +
-                     {                                                          +
-                         "args": [                                              +
-                             {                                                  +
-                                 "name": "first",                               +
-                                 "type": {                                      +
-                                     "kind": "SCALAR",                          +
-                                     "name": "Int",                             +
-                                     "ofType": null                             +
-                                 }                                              +
-                             },                                                 +
-                             {                                                  +
-                                 "name": "last",                                +
-                                 "type": {                                      +
-                                     "kind": "SCALAR",                          +
-                                     "name": "Int",                             +
-                                     "ofType": null                             +
-                                 }                                              +
-                             },                                                 +
-                             {                                                  +
-                                 "name": "before",                              +
-                                 "type": {                                      +
-                                     "kind": "SCALAR",                          +
-                                     "name": "Cursor",                          +
-                                     "ofType": null                             +
-                                 }                                              +
-                             },                                                 +
-                             {                                                  +
-                                 "name": "after",                               +
-                                 "type": {                                      +
-                                     "kind": "SCALAR",                          +
-                                     "name": "Cursor",                          +
-                                     "ofType": null                             +
-                                 }                                              +
-                             },                                                 +
-                             {                                                  +
-                                 "name": "offset",                              +
-                                 "type": {                                      +
-                                     "kind": "SCALAR",                          +
-                                     "name": "Int",                             +
-                                     "ofType": null                             +
-                                 }                                              +
-                             },                                                 +
-                             {                                                  +
-                                 "name": "filter",                              +
-                                 "type": {                                      +
-                                     "kind": "INPUT_OBJECT",                    +
-                                     "name": "AccountFilter",                   +
-                                     "ofType": null                             +
-                                 }                                              +
-                             },                                                 +
-                             {                                                  +
-                                 "name": "orderBy",                             +
-                                 "type": {                                      +
-                                     "kind": "LIST",                            +
-                                     "name": null,                              +
-                                     "ofType": {                                +
-                                         "kind": "NON_NULL",                    +
-                                         "name": null                           +
-                                     }                                          +
-                                 }                                              +
-                             }                                                  +
-                         ],                                                     +
-                         "name": "accountCollection",                           +
-                         "type": {                                              +
-                             "kind": "OBJECT"                                   +
-                         },                                                     +
-                         "description": "A pagable collection of type `Account`"+
-                     },                                                         +
-                     {                                                          +
-                         "args": [                                              +
-                             {                                                  +
-                                 "name": "nodeId",                              +
-                                 "type": {                                      +
-                                     "kind": "NON_NULL",                        +
-                                     "name": null,                              +
-                                     "ofType": {                                +
-                                         "kind": "SCALAR",                      +
-                                         "name": "ID"                           +
-                                     }                                          +
-                                 }                                              +
-                             }                                                  +
-                         ],                                                     +
-                         "name": "node",                                        +
-                         "type": {                                              +
-                             "kind": "INTERFACE"                                +
-                         },                                                     +
-                         "description": "Retrieve a record by its `ID`"         +
-                     },                                                         +
-                     {                                                          +
-                         "args": [                                              +
-                         ],                                                     +
-                         "name": "returnsAccount",                              +
-                         "type": {                                              +
-                             "kind": "OBJECT"                                   +
-                         },                                                     +
-                         "description": null                                    +
-                     },                                                         +
-                     {                                                          +
-                         "args": [                                              +
-                             {                                                  +
-                                 "name": "idToSearch",                          +
-                                 "type": {                                      +
-                                     "kind": "NON_NULL",                        +
-                                     "name": null,                              +
-                                     "ofType": {                                +
-                                         "kind": "SCALAR",                      +
-                                         "name": "Int"                          +
-                                     }                                          +
-                                 }                                              +
-                             }                                                  +
-                         ],                                                     +
-                         "name": "returnsAccountWithId",                        +
-                         "type": {                                              +
-                             "kind": "OBJECT"                                   +
-                         },                                                     +
-                         "description": null                                    +
-                     },                                                         +
-                     {                                                          +
-                         "args": [                                              +
-                             {                                                  +
-                                 "name": "top",                                 +
-                                 "type": {                                      +
-                                     "kind": "NON_NULL",                        +
-                                     "name": null,                              +
-                                     "ofType": {                                +
-                                         "kind": "SCALAR",                      +
-                                         "name": "Int"                          +
-                                     }                                          +
-                                 }                                              +
-                             },                                                 +
-                             {                                                  +
-                                 "name": "first",                               +
-                                 "type": {                                      +
-                                     "kind": "SCALAR",                          +
-                                     "name": "Int",                             +
-                                     "ofType": null                             +
-                                 }                                              +
-                             },                                                 +
-                             {                                                  +
-                                 "name": "last",                                +
-                                 "type": {                                      +
-                                     "kind": "SCALAR",                          +
-                                     "name": "Int",                             +
-                                     "ofType": null                             +
-                                 }                                              +
-                             },                                                 +
-                             {                                                  +
-                                 "name": "before",                              +
-                                 "type": {                                      +
-                                     "kind": "SCALAR",                          +
-                                     "name": "Cursor",                          +
-                                     "ofType": null                             +
-                                 }                                              +
-                             },                                                 +
-                             {                                                  +
-                                 "name": "after",                               +
-                                 "type": {                                      +
-                                     "kind": "SCALAR",                          +
-                                     "name": "Cursor",                          +
-                                     "ofType": null                             +
-                                 }                                              +
-                             },                                                 +
-                             {                                                  +
-                                 "name": "offset",                              +
-                                 "type": {                                      +
-                                     "kind": "SCALAR",                          +
-                                     "name": "Int",                             +
-                                     "ofType": null                             +
-                                 }                                              +
-                             },                                                 +
-                             {                                                  +
-                                 "name": "filter",                              +
-                                 "type": {                                      +
-                                     "kind": "INPUT_OBJECT",                    +
-                                     "name": "AccountFilter",                   +
-                                     "ofType": null                             +
-                                 }                                              +
-                             },                                                 +
-                             {                                                  +
-                                 "name": "orderBy",                             +
-                                 "type": {                                      +
-                                     "kind": "LIST",                            +
-                                     "name": null,                              +
-                                     "ofType": {                                +
-                                         "kind": "NON_NULL",                    +
-                                         "name": null                           +
-                                     }                                          +
-                                 }                                              +
-                             }                                                  +
-                         ],                                                     +
-                         "name": "returnsSetofAccount",                         +
-                         "type": {                                              +
-                             "kind": "OBJECT"                                   +
-                         },                                                     +
-                         "description": null                                    +
-                     }                                                          +
-                 ]                                                              +
-             }                                                                  +
-         }                                                                      +
-     }                                                                          +
+                                          jsonb_pretty                                           
+-------------------------------------------------------------------------------------------------
+ {                                                                                              +
+     "data": {                                                                                  +
+         "__schema": {                                                                          +
+             "queryType": {                                                                     +
+                 "fields": [                                                                    +
+                     {                                                                          +
+                         "args": [                                                              +
+                             {                                                                  +
+                                 "name": "id",                                                  +
+                                 "type": {                                                      +
+                                     "kind": "NON_NULL",                                        +
+                                     "name": null,                                              +
+                                     "ofType": {                                                +
+                                         "kind": "NON_NULL",                                    +
+                                         "name": null                                           +
+                                     }                                                          +
+                                 }                                                              +
+                             }                                                                  +
+                         ],                                                                     +
+                         "name": "accountByPk",                                                 +
+                         "type": {                                                              +
+                             "kind": "OBJECT"                                                   +
+                         },                                                                     +
+                         "description": "Retrieve a record of type `Account` by its primary key"+
+                     },                                                                         +
+                     {                                                                          +
+                         "args": [                                                              +
+                             {                                                                  +
+                                 "name": "first",                                               +
+                                 "type": {                                                      +
+                                     "kind": "SCALAR",                                          +
+                                     "name": "Int",                                             +
+                                     "ofType": null                                             +
+                                 }                                                              +
+                             },                                                                 +
+                             {                                                                  +
+                                 "name": "last",                                                +
+                                 "type": {                                                      +
+                                     "kind": "SCALAR",                                          +
+                                     "name": "Int",                                             +
+                                     "ofType": null                                             +
+                                 }                                                              +
+                             },                                                                 +
+                             {                                                                  +
+                                 "name": "before",                                              +
+                                 "type": {                                                      +
+                                     "kind": "SCALAR",                                          +
+                                     "name": "Cursor",                                          +
+                                     "ofType": null                                             +
+                                 }                                                              +
+                             },                                                                 +
+                             {                                                                  +
+                                 "name": "after",                                               +
+                                 "type": {                                                      +
+                                     "kind": "SCALAR",                                          +
+                                     "name": "Cursor",                                          +
+                                     "ofType": null                                             +
+                                 }                                                              +
+                             },                                                                 +
+                             {                                                                  +
+                                 "name": "offset",                                              +
+                                 "type": {                                                      +
+                                     "kind": "SCALAR",                                          +
+                                     "name": "Int",                                             +
+                                     "ofType": null                                             +
+                                 }                                                              +
+                             },                                                                 +
+                             {                                                                  +
+                                 "name": "filter",                                              +
+                                 "type": {                                                      +
+                                     "kind": "INPUT_OBJECT",                                    +
+                                     "name": "AccountFilter",                                   +
+                                     "ofType": null                                             +
+                                 }                                                              +
+                             },                                                                 +
+                             {                                                                  +
+                                 "name": "orderBy",                                             +
+                                 "type": {                                                      +
+                                     "kind": "LIST",                                            +
+                                     "name": null,                                              +
+                                     "ofType": {                                                +
+                                         "kind": "NON_NULL",                                    +
+                                         "name": null                                           +
+                                     }                                                          +
+                                 }                                                              +
+                             }                                                                  +
+                         ],                                                                     +
+                         "name": "accountCollection",                                           +
+                         "type": {                                                              +
+                             "kind": "OBJECT"                                                   +
+                         },                                                                     +
+                         "description": "A pagable collection of type `Account`"                +
+                     },                                                                         +
+                     {                                                                          +
+                         "args": [                                                              +
+                             {                                                                  +
+                                 "name": "nodeId",                                              +
+                                 "type": {                                                      +
+                                     "kind": "NON_NULL",                                        +
+                                     "name": null,                                              +
+                                     "ofType": {                                                +
+                                         "kind": "SCALAR",                                      +
+                                         "name": "ID"                                           +
+                                     }                                                          +
+                                 }                                                              +
+                             }                                                                  +
+                         ],                                                                     +
+                         "name": "node",                                                        +
+                         "type": {                                                              +
+                             "kind": "INTERFACE"                                                +
+                         },                                                                     +
+                         "description": "Retrieve a record by its `ID`"                         +
+                     },                                                                         +
+                     {                                                                          +
+                         "args": [                                                              +
+                         ],                                                                     +
+                         "name": "returnsAccount",                                              +
+                         "type": {                                                              +
+                             "kind": "OBJECT"                                                   +
+                         },                                                                     +
+                         "description": null                                                    +
+                     },                                                                         +
+                     {                                                                          +
+                         "args": [                                                              +
+                             {                                                                  +
+                                 "name": "idToSearch",                                          +
+                                 "type": {                                                      +
+                                     "kind": "NON_NULL",                                        +
+                                     "name": null,                                              +
+                                     "ofType": {                                                +
+                                         "kind": "SCALAR",                                      +
+                                         "name": "Int"                                          +
+                                     }                                                          +
+                                 }                                                              +
+                             }                                                                  +
+                         ],                                                                     +
+                         "name": "returnsAccountWithId",                                        +
+                         "type": {                                                              +
+                             "kind": "OBJECT"                                                   +
+                         },                                                                     +
+                         "description": null                                                    +
+                     },                                                                         +
+                     {                                                                          +
+                         "args": [                                                              +
+                             {                                                                  +
+                                 "name": "top",                                                 +
+                                 "type": {                                                      +
+                                     "kind": "NON_NULL",                                        +
+                                     "name": null,                                              +
+                                     "ofType": {                                                +
+                                         "kind": "SCALAR",                                      +
+                                         "name": "Int"                                          +
+                                     }                                                          +
+                                 }                                                              +
+                             },                                                                 +
+                             {                                                                  +
+                                 "name": "first",                                               +
+                                 "type": {                                                      +
+                                     "kind": "SCALAR",                                          +
+                                     "name": "Int",                                             +
+                                     "ofType": null                                             +
+                                 }                                                              +
+                             },                                                                 +
+                             {                                                                  +
+                                 "name": "last",                                                +
+                                 "type": {                                                      +
+                                     "kind": "SCALAR",                                          +
+                                     "name": "Int",                                             +
+                                     "ofType": null                                             +
+                                 }                                                              +
+                             },                                                                 +
+                             {                                                                  +
+                                 "name": "before",                                              +
+                                 "type": {                                                      +
+                                     "kind": "SCALAR",                                          +
+                                     "name": "Cursor",                                          +
+                                     "ofType": null                                             +
+                                 }                                                              +
+                             },                                                                 +
+                             {                                                                  +
+                                 "name": "after",                                               +
+                                 "type": {                                                      +
+                                     "kind": "SCALAR",                                          +
+                                     "name": "Cursor",                                          +
+                                     "ofType": null                                             +
+                                 }                                                              +
+                             },                                                                 +
+                             {                                                                  +
+                                 "name": "offset",                                              +
+                                 "type": {                                                      +
+                                     "kind": "SCALAR",                                          +
+                                     "name": "Int",                                             +
+                                     "ofType": null                                             +
+                                 }                                                              +
+                             },                                                                 +
+                             {                                                                  +
+                                 "name": "filter",                                              +
+                                 "type": {                                                      +
+                                     "kind": "INPUT_OBJECT",                                    +
+                                     "name": "AccountFilter",                                   +
+                                     "ofType": null                                             +
+                                 }                                                              +
+                             },                                                                 +
+                             {                                                                  +
+                                 "name": "orderBy",                                             +
+                                 "type": {                                                      +
+                                     "kind": "LIST",                                            +
+                                     "name": null,                                              +
+                                     "ofType": {                                                +
+                                         "kind": "NON_NULL",                                    +
+                                         "name": null                                           +
+                                     }                                                          +
+                                 }                                                              +
+                             }                                                                  +
+                         ],                                                                     +
+                         "name": "returnsSetofAccount",                                         +
+                         "type": {                                                              +
+                             "kind": "OBJECT"                                                   +
+                         },                                                                     +
+                         "description": null                                                    +
+                     }                                                                          +
+                 ]                                                                              +
+             }                                                                                  +
+         }                                                                                      +
+     }                                                                                          +
  }
 (1 row)
 

--- a/test/expected/function_calls_unsupported.out
+++ b/test/expected/function_calls_unsupported.out
@@ -303,83 +303,98 @@ begin;
             }
         }
     } $$));
-                                  jsonb_pretty                                   
----------------------------------------------------------------------------------
- {                                                                              +
-     "data": {                                                                  +
-         "__schema": {                                                          +
-             "queryType": {                                                     +
-                 "fields": [                                                    +
-                     {                                                          +
-                         "args": [                                              +
-                             {                                                  +
-                                 "name": "first",                               +
-                                 "type": {                                      +
-                                     "name": "Int"                              +
-                                 }                                              +
-                             },                                                 +
-                             {                                                  +
-                                 "name": "last",                                +
-                                 "type": {                                      +
-                                     "name": "Int"                              +
-                                 }                                              +
-                             },                                                 +
-                             {                                                  +
-                                 "name": "before",                              +
-                                 "type": {                                      +
-                                     "name": "Cursor"                           +
-                                 }                                              +
-                             },                                                 +
-                             {                                                  +
-                                 "name": "after",                               +
-                                 "type": {                                      +
-                                     "name": "Cursor"                           +
-                                 }                                              +
-                             },                                                 +
-                             {                                                  +
-                                 "name": "offset",                              +
-                                 "type": {                                      +
-                                     "name": "Int"                              +
-                                 }                                              +
-                             },                                                 +
-                             {                                                  +
-                                 "name": "filter",                              +
-                                 "type": {                                      +
-                                     "name": "AccountFilter"                    +
-                                 }                                              +
-                             },                                                 +
-                             {                                                  +
-                                 "name": "orderBy",                             +
-                                 "type": {                                      +
-                                     "name": null                               +
-                                 }                                              +
-                             }                                                  +
-                         ],                                                     +
-                         "name": "accountCollection",                           +
-                         "type": {                                              +
-                             "kind": "OBJECT"                                   +
-                         },                                                     +
-                         "description": "A pagable collection of type `Account`"+
-                     },                                                         +
-                     {                                                          +
-                         "args": [                                              +
-                             {                                                  +
-                                 "name": "nodeId",                              +
-                                 "type": {                                      +
-                                     "name": null                               +
-                                 }                                              +
-                             }                                                  +
-                         ],                                                     +
-                         "name": "node",                                        +
-                         "type": {                                              +
-                             "kind": "INTERFACE"                                +
-                         },                                                     +
-                         "description": "Retrieve a record by its `ID`"         +
-                     }                                                          +
-                 ]                                                              +
-             }                                                                  +
-         }                                                                      +
-     }                                                                          +
+                                          jsonb_pretty                                           
+-------------------------------------------------------------------------------------------------
+ {                                                                                              +
+     "data": {                                                                                  +
+         "__schema": {                                                                          +
+             "queryType": {                                                                     +
+                 "fields": [                                                                    +
+                     {                                                                          +
+                         "args": [                                                              +
+                             {                                                                  +
+                                 "name": "id",                                                  +
+                                 "type": {                                                      +
+                                     "name": null                                               +
+                                 }                                                              +
+                             }                                                                  +
+                         ],                                                                     +
+                         "name": "accountByPk",                                                 +
+                         "type": {                                                              +
+                             "kind": "OBJECT"                                                   +
+                         },                                                                     +
+                         "description": "Retrieve a record of type `Account` by its primary key"+
+                     },                                                                         +
+                     {                                                                          +
+                         "args": [                                                              +
+                             {                                                                  +
+                                 "name": "first",                                               +
+                                 "type": {                                                      +
+                                     "name": "Int"                                              +
+                                 }                                                              +
+                             },                                                                 +
+                             {                                                                  +
+                                 "name": "last",                                                +
+                                 "type": {                                                      +
+                                     "name": "Int"                                              +
+                                 }                                                              +
+                             },                                                                 +
+                             {                                                                  +
+                                 "name": "before",                                              +
+                                 "type": {                                                      +
+                                     "name": "Cursor"                                           +
+                                 }                                                              +
+                             },                                                                 +
+                             {                                                                  +
+                                 "name": "after",                                               +
+                                 "type": {                                                      +
+                                     "name": "Cursor"                                           +
+                                 }                                                              +
+                             },                                                                 +
+                             {                                                                  +
+                                 "name": "offset",                                              +
+                                 "type": {                                                      +
+                                     "name": "Int"                                              +
+                                 }                                                              +
+                             },                                                                 +
+                             {                                                                  +
+                                 "name": "filter",                                              +
+                                 "type": {                                                      +
+                                     "name": "AccountFilter"                                    +
+                                 }                                                              +
+                             },                                                                 +
+                             {                                                                  +
+                                 "name": "orderBy",                                             +
+                                 "type": {                                                      +
+                                     "name": null                                               +
+                                 }                                                              +
+                             }                                                                  +
+                         ],                                                                     +
+                         "name": "accountCollection",                                           +
+                         "type": {                                                              +
+                             "kind": "OBJECT"                                                   +
+                         },                                                                     +
+                         "description": "A pagable collection of type `Account`"                +
+                     },                                                                         +
+                     {                                                                          +
+                         "args": [                                                              +
+                             {                                                                  +
+                                 "name": "nodeId",                                              +
+                                 "type": {                                                      +
+                                     "name": null                                               +
+                                 }                                                              +
+                             }                                                                  +
+                         ],                                                                     +
+                         "name": "node",                                                        +
+                         "type": {                                                              +
+                             "kind": "INTERFACE"                                                +
+                         },                                                                     +
+                         "description": "Retrieve a record by its `ID`"                         +
+                     }                                                                          +
+                 ]                                                                              +
+             }                                                                                  +
+         }                                                                                      +
+     }                                                                                          +
  }
 (1 row)
 

--- a/test/expected/function_return_row_is_selectable.out
+++ b/test/expected/function_return_row_is_selectable.out
@@ -57,6 +57,9 @@ begin;
              "queryType": {                         +
                  "fields": [                        +
                      {                              +
+                         "name": "accountByPk"      +
+                     },                             +
+                     {                              +
                          "name": "accountCollection"+
                      },                             +
                      {                              +

--- a/test/expected/function_return_view_has_pkey.out
+++ b/test/expected/function_return_view_has_pkey.out
@@ -103,6 +103,9 @@ begin;
              "queryType": {                         +
                  "fields": [                        +
                      {                              +
+                         "name": "accountByPk"      +
+                     },                             +
+                     {                              +
                          "name": "accountCollection"+
                      },                             +
                      {                              +

--- a/test/expected/permissions_table_level.out
+++ b/test/expected/permissions_table_level.out
@@ -22,6 +22,9 @@ begin;
          "__type": {                            +
              "fields": [                        +
                  {                              +
+                     "name": "accountByPk"      +
+                 },                             +
+                 {                              +
                      "name": "accountCollection"+
                  },                             +
                  {                              +
@@ -97,6 +100,9 @@ begin;
          "__type": {                            +
              "fields": [                        +
                  {                              +
+                     "name": "accountByPk"      +
+                 },                             +
+                 {                              +
                      "name": "accountCollection"+
                  },                             +
                  {                              +
@@ -139,6 +145,9 @@ begin;
          "__type": {                            +
              "fields": [                        +
                  {                              +
+                     "name": "accountByPk"      +
+                 },                             +
+                 {                              +
                      "name": "accountCollection"+
                  },                             +
                  {                              +
@@ -180,6 +189,9 @@ begin;
      "data": {                                  +
          "__type": {                            +
              "fields": [                        +
+                 {                              +
+                     "name": "accountByPk"      +
+                 },                             +
                  {                              +
                      "name": "accountCollection"+
                  },                             +

--- a/test/expected/primary_key_queries.out
+++ b/test/expected/primary_key_queries.out
@@ -1,0 +1,315 @@
+begin;
+    -- Set up test tables with different primary key configurations
+    
+    -- Table with single column integer primary key
+    create table person(
+        id int primary key,
+        name text,
+        email text
+    );
+    insert into public.person(id, name, email)
+    values
+        (1, 'Alice', 'alice@example.com'),
+        (2, 'Bob', 'bob@example.com'),
+        (3, 'Charlie', null);
+    -- Table with multi-column primary key
+    create table item(
+        item_id int,
+        product_id int,
+        quantity int,
+        price numeric(10,2),
+        primary key(item_id, product_id)
+    );
+    insert into item(item_id, product_id, quantity, price)
+    values
+        (1, 101, 2, 10.99),
+        (1, 102, 1, 24.99),
+        (2, 101, 3, 10.99),
+        (3, 103, 5, 5.99);
+    -- Table with text primary key (instead of UUID)
+    create table document(
+        id text primary key,
+        title text,
+        content text
+    );
+    insert into document(id, title, content)
+    values
+        ('doc-1', 'Document 1', 'Content 1'),
+        ('doc-2', 'Document 2', 'Content 2');
+    savepoint a;
+    -- Test 1: Query a person by primary key (single integer column)
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              personByPk(id: 1) {
+                id
+                name
+                email
+              }
+            }
+        $$)
+    );
+               jsonb_pretty               
+------------------------------------------
+ {                                       +
+     "data": {                           +
+         "personByPk": {                 +
+             "id": 1,                    +
+             "name": "Alice",            +
+             "email": "alice@example.com"+
+         }                               +
+     }                                   +
+ }
+(1 row)
+
+    -- Test 2: Query a person by primary key with relationship
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              personByPk(id: 2) {
+                id
+                name
+                email
+                nodeId
+              }
+            }
+        $$)
+    );
+                       jsonb_pretty                       
+----------------------------------------------------------
+ {                                                       +
+     "data": {                                           +
+         "personByPk": {                                 +
+             "id": 2,                                    +
+             "name": "Bob",                              +
+             "email": "bob@example.com",                 +
+             "nodeId": "WyJwdWJsaWMiLCAicGVyc29uIiwgMl0="+
+         }                                               +
+     }                                                   +
+ }
+(1 row)
+
+    -- Test 3: Query a non-existent person by primary key
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              personByPk(id: 999) {
+                id
+                name
+              }
+            }
+        $$)
+    );
+        jsonb_pretty        
+----------------------------
+ {                         +
+     "data": {             +
+         "personByPk": null+
+     }                     +
+ }
+(1 row)
+
+    -- Test 4: Query with multi-column primary key
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              itemByPk(itemId: 1, productId: 102) {
+                itemId
+                productId
+                quantity
+                price
+              }
+            }
+        $$)
+    );
+         jsonb_pretty          
+-------------------------------
+ {                            +
+     "data": {                +
+         "itemByPk": {        +
+             "price": "24.99",+
+             "itemId": 1,     +
+             "quantity": 1,   +
+             "productId": 102 +
+         }                    +
+     }                        +
+ }
+(1 row)
+
+    -- Test 5: Query with multi-column primary key, one column value is incorrect
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              itemByPk(itemId: 1, productId: 999) {
+                itemId
+                productId
+                quantity
+                price
+              }
+            }
+        $$)
+    );
+       jsonb_pretty       
+--------------------------
+ {                       +
+     "data": {           +
+         "itemByPk": null+
+     }                   +
+ }
+(1 row)
+
+    -- Test 6: Query with text primary key
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              documentByPk(id: "doc-1") {
+                id
+                title
+                content
+              }
+            }
+        $$)
+    );
+            jsonb_pretty            
+------------------------------------
+ {                                 +
+     "data": {                     +
+         "documentByPk": {         +
+             "id": "doc-1",        +
+             "title": "Document 1",+
+             "content": "Content 1"+
+         }                         +
+     }                             +
+ }
+(1 row)
+
+    -- Test 7: Using variables with primary key queries
+    select jsonb_pretty(
+        graphql.resolve($$
+            query GetPerson($personId: Int!) {
+              personByPk(id: $personId) {
+                id
+                name
+                email
+              }
+            }
+        $$, '{"personId": 3}')
+    );
+          jsonb_pretty          
+--------------------------------
+ {                             +
+     "data": {                 +
+         "personByPk": {       +
+             "id": 3,          +
+             "name": "Charlie",+
+             "email": null     +
+         }                     +
+     }                         +
+ }
+(1 row)
+
+    -- Test 8: Using variables with multi-column primary key queries
+    select jsonb_pretty(
+        graphql.resolve($$
+            query GetItem($itemId: Int!, $productId: Int!) {
+              itemByPk(itemId: $itemId, productId: $productId) {
+                itemId
+                productId
+                quantity
+                price
+              }
+            }
+        $$, '{"itemId": 2, "productId": 101}')
+    );
+         jsonb_pretty          
+-------------------------------
+ {                            +
+     "data": {                +
+         "itemByPk": {        +
+             "price": "10.99",+
+             "itemId": 2,     +
+             "quantity": 3,   +
+             "productId": 101 +
+         }                    +
+     }                        +
+ }
+(1 row)
+
+    -- Test 9: Error case - missing required primary key column
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              itemByPk(itemId: 1) {
+                itemId
+                productId
+              }
+            }
+        $$)
+    );
+                           jsonb_pretty                            
+-------------------------------------------------------------------
+ {                                                                +
+     "data": null,                                                +
+     "errors": [                                                  +
+         {                                                        +
+             "message": "All primary key columns must be provided"+
+         }                                                        +
+     ]                                                            +
+ }
+(1 row)
+
+    -- Test 10: Using fragments with primary key queries
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              personByPk(id: 1) {
+                ...PersonFields
+              }
+            }
+            
+            fragment PersonFields on Person {
+              id
+              name
+              email
+            }
+        $$)
+    );
+               jsonb_pretty               
+------------------------------------------
+ {                                       +
+     "data": {                           +
+         "personByPk": {                 +
+             "id": 1,                    +
+             "name": "Alice",            +
+             "email": "alice@example.com"+
+         }                               +
+     }                                   +
+ }
+(1 row)
+
+    -- Test 11: Query with null values in results
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              personByPk(id: 3) {
+                id
+                name
+                email
+              }
+            }
+        $$)
+    );
+          jsonb_pretty          
+--------------------------------
+ {                             +
+     "data": {                 +
+         "personByPk": {       +
+             "id": 3,          +
+             "name": "Charlie",+
+             "email": null     +
+         }                     +
+     }                         +
+ }
+(1 row)
+
+rollback; 

--- a/test/expected/views_integration.out
+++ b/test/expected/views_integration.out
@@ -32,7 +32,13 @@ begin;
          "__type": {                            +
              "fields": [                        +
                  {                              +
+                     "name": "accountByPk"      +
+                 },                             +
+                 {                              +
                      "name": "accountCollection"+
+                 },                             +
+                 {                              +
+                     "name": "blogByPk"         +
                  },                             +
                  {                              +
                      "name": "blogCollection"   +
@@ -70,13 +76,22 @@ begin;
          "__type": {                            +
              "fields": [                        +
                  {                              +
+                     "name": "accountByPk"      +
+                 },                             +
+                 {                              +
                      "name": "accountCollection"+
+                 },                             +
+                 {                              +
+                     "name": "blogByPk"         +
                  },                             +
                  {                              +
                      "name": "blogCollection"   +
                  },                             +
                  {                              +
                      "name": "node"             +
+                 },                             +
+                 {                              +
+                     "name": "personByPk"       +
                  },                             +
                  {                              +
                      "name": "personCollection" +

--- a/test/sql/primary_key_queries.sql
+++ b/test/sql/primary_key_queries.sql
@@ -1,0 +1,196 @@
+begin;
+    -- Set up test tables with different primary key configurations
+    
+    -- Table with single column integer primary key
+    create table person(
+        id int primary key,
+        name text,
+        email text
+    );
+
+    insert into public.person(id, name, email)
+    values
+        (1, 'Alice', 'alice@example.com'),
+        (2, 'Bob', 'bob@example.com'),
+        (3, 'Charlie', null);
+
+    -- Table with multi-column primary key
+    create table item(
+        item_id int,
+        product_id int,
+        quantity int,
+        price numeric(10,2),
+        primary key(item_id, product_id)
+    );
+
+    insert into item(item_id, product_id, quantity, price)
+    values
+        (1, 101, 2, 10.99),
+        (1, 102, 1, 24.99),
+        (2, 101, 3, 10.99),
+        (3, 103, 5, 5.99);
+
+    -- Table with text primary key (instead of UUID)
+    create table document(
+        id text primary key,
+        title text,
+        content text
+    );
+
+    insert into document(id, title, content)
+    values
+        ('doc-1', 'Document 1', 'Content 1'),
+        ('doc-2', 'Document 2', 'Content 2');
+
+    savepoint a;
+
+    -- Test 1: Query a person by primary key (single integer column)
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              personByPk(id: 1) {
+                id
+                name
+                email
+              }
+            }
+        $$)
+    );
+
+    -- Test 2: Query a person by primary key with relationship
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              personByPk(id: 2) {
+                id
+                name
+                email
+                nodeId
+              }
+            }
+        $$)
+    );
+
+    -- Test 3: Query a non-existent person by primary key
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              personByPk(id: 999) {
+                id
+                name
+              }
+            }
+        $$)
+    );
+
+    -- Test 4: Query with multi-column primary key
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              itemByPk(itemId: 1, productId: 102) {
+                itemId
+                productId
+                quantity
+                price
+              }
+            }
+        $$)
+    );
+
+    -- Test 5: Query with multi-column primary key, one column value is incorrect
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              itemByPk(itemId: 1, productId: 999) {
+                itemId
+                productId
+                quantity
+                price
+              }
+            }
+        $$)
+    );
+
+    -- Test 6: Query with text primary key
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              documentByPk(id: "doc-1") {
+                id
+                title
+                content
+              }
+            }
+        $$)
+    );
+
+    -- Test 7: Using variables with primary key queries
+    select jsonb_pretty(
+        graphql.resolve($$
+            query GetPerson($personId: Int!) {
+              personByPk(id: $personId) {
+                id
+                name
+                email
+              }
+            }
+        $$, '{"personId": 3}')
+    );
+
+    -- Test 8: Using variables with multi-column primary key queries
+    select jsonb_pretty(
+        graphql.resolve($$
+            query GetItem($itemId: Int!, $productId: Int!) {
+              itemByPk(itemId: $itemId, productId: $productId) {
+                itemId
+                productId
+                quantity
+                price
+              }
+            }
+        $$, '{"itemId": 2, "productId": 101}')
+    );
+
+    -- Test 9: Error case - missing required primary key column
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              itemByPk(itemId: 1) {
+                itemId
+                productId
+              }
+            }
+        $$)
+    );
+
+    -- Test 10: Using fragments with primary key queries
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              personByPk(id: 1) {
+                ...PersonFields
+              }
+            }
+            
+            fragment PersonFields on Person {
+              id
+              name
+              email
+            }
+        $$)
+    );
+
+    -- Test 11: Query with null values in results
+    select jsonb_pretty(
+        graphql.resolve($$
+            {
+              personByPk(id: 3) {
+                id
+                name
+                email
+              }
+            }
+        $$)
+    );
+
+rollback; 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Users can now use [table_name]ByPk(key) queries to get a single record using the primary key

## What is the current behavior?

No first-party support for single record queries by primary key.

See #554 .

## What is the new behavior?

Adds a [table_name]ByPk(pk: pk_type) method to all tables that define a primary key
