### PR TITLE
fix: install wget in ci if missing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,10 @@ jobs:
 
       - name: build release artifacts
         run: |
+          # Install wget if missing
+          sudo apt-get update
+          sudo apt-get install -y wget
+
           # Add postgres package repo
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc &>/dev/null


### PR DESCRIPTION
wget is missing on ubuntu 22.04 arm runner due to which [release action is failing](https://github.com/supabase/pg_graphql/actions/runs/17422353113/job/49463022263). This PR installs wget if it is missing.