### PR TITLE
fix(release): release action did not package successfully

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,9 +85,8 @@ jobs:
           cargo install cargo-pgrx --version ${{ matrix.pgrx_version }} --locked
           cargo pgrx init --pg${{ matrix.postgres }}=/usr/lib/postgresql/${{ matrix.postgres }}/bin/pg_config
 
-          # selects the pgVer from pg_config on path
-          # https://github.com/tcdi/pgrx/issues/288
-          cargo pgrx package --no-default-features --features pg${{ matrix.postgres }}
+          # Explicitly specify pg_config to avoid version detection conflicts
+          cargo pgrx package --pg-config /usr/lib/postgresql/${{ matrix.postgres }}/bin/pg_config --no-default-features --features pg${{ matrix.postgres }}
 
           # Create installable package
           mkdir archive


### PR DESCRIPTION
The release action failed to package the extension (e.g. see [this run](https://github.com/supabase/pg_graphql/actions/runs/20162979243/job/57879568072)). This PR fixes the failure by explicitly mentioning the path to the pg_config file to be used which prevents pgrx from implicitly enabling the installed postgres version's pg_config..