### PR TITLE
[#190]: Add upsert support via onConflict argument

### DIFF
--- a/sql/load_sql_context.sql
+++ b/sql/load_sql_context.sql
@@ -289,14 +289,16 @@ select
                                                     ),
                                                     array[]::text[]
                                                 ),
-                                                'is_unique', pi.indisunique and pi.indpred is null,
-                                                'is_primary_key', pi.indisprimary
-                                            )
+                                            'is_unique', pi.indisunique and pi.indpred is null,
+                                            'is_primary_key', pi.indisprimary,
+                                            'name', pc_ix.relname
                                         )
-                                    from
-                                        pg_catalog.pg_index pi
-                                    where
-                                        pi.indrelid = pc.oid
+                                    )
+                                from
+                                    pg_catalog.pg_index pi
+                                    join pg_catalog.pg_class pc_ix on pi.indexrelid = pc_ix.oid
+                                where
+                                    pi.indrelid = pc.oid
                                 ),
                                 jsonb_build_array()
                             ),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -395,7 +395,7 @@ where
                             .columns
                             .iter()
                             .filter(|c| c.permissions.is_updatable && !c.is_generated && !c.is_serial)
-                            .find(|c| &schema.graphql_column_field_name(c) == graphql_col_name)
+                            .find(|c| schema.graphql_column_field_name(c).as_str() == graphql_col_name.as_str())
                             .ok_or_else(|| {
                                 GraphQLError::validation(format!(
                                     "Invalid column in updateFields: {}",

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -63,7 +63,7 @@ pub struct InsertBuilder {
 #[derive(Clone, Debug)]
 pub struct OnConflictBuilder {
     pub constraint: Index,
-    pub update_columns: HashSet<Arc<Column>>,
+    pub update_fields: HashSet<Arc<Column>>,
     pub filter: FilterBuilder,
 }
 
@@ -378,16 +378,16 @@ where
                 .find(|idx| &idx.name == constraint_name)
                 .ok_or(GraphQLError::validation("Invalid constraint name"))?;
 
-            let update_columns_val = obj
-                .get("updateColumns")
-                .ok_or(GraphQLError::validation("updateColumns is required"))?;
-            let update_columns_arr = match update_columns_val {
+            let update_fields_val = obj
+                .get("updateFields")
+                .ok_or(GraphQLError::validation("updateFields is required"))?;
+            let update_fields_arr = match update_fields_val {
                 gson::Value::Array(arr) => arr,
-                _ => return Err(GraphQLError::validation("updateColumns must be an array")),
+                _ => return Err(GraphQLError::validation("updateFields must be an array")),
             };
 
-            let mut update_columns = HashSet::new();
-            for val in update_columns_arr {
+            let mut update_fields = HashSet::new();
+            for val in update_fields_arr {
                 match val {
                     gson::Value::String(graphql_col_name) => {
                         // Map GraphQL column name back to actual Column
@@ -398,15 +398,15 @@ where
                             .find(|c| &schema.graphql_column_field_name(c) == graphql_col_name)
                             .ok_or_else(|| {
                                 GraphQLError::validation(format!(
-                                    "Invalid column in updateColumns: {}",
+                                    "Invalid column in updateFields: {}",
                                     graphql_col_name
                                 ))
                             })?;
-                        update_columns.insert(Arc::clone(column));
+                        update_fields.insert(Arc::clone(column));
                     }
                     _ => {
                         return Err(GraphQLError::validation(
-                            "updateColumns elements must be strings",
+                            "updateFields elements must be strings",
                         ))
                     }
                 }
@@ -426,7 +426,7 @@ where
 
             Ok(Some(OnConflictBuilder {
                 constraint: (*constraint).clone(),
-                update_columns,
+                update_fields,
                 filter: filter.unwrap_or(FilterBuilder { elems: vec![] }),
             }))
         }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -8,7 +8,7 @@ use crate::parser_util::*;
 use crate::sql_types::*;
 use graphql_parser::query::*;
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use std::ops::Deref;
 use std::str::FromStr;
@@ -51,12 +51,20 @@ pub enum AggregateSelection {
 pub struct InsertBuilder {
     // args
     pub objects: Vec<InsertRowBuilder>,
+    pub on_conflict: Option<OnConflictBuilder>,
 
     // metadata
     pub table: Arc<Table>,
 
     //fields
     pub selections: Vec<InsertSelection>,
+}
+
+#[derive(Clone, Debug)]
+pub struct OnConflictBuilder {
+    pub constraint: Index,
+    pub update_columns: HashSet<Arc<Column>>,
+    pub filter: FilterBuilder,
 }
 
 #[derive(Clone, Debug)]
@@ -325,6 +333,107 @@ where
     Ok(objects)
 }
 
+fn read_argument_on_conflict<'a, T>(
+    field: &__Field,
+    query_field: &graphql_parser::query::Field<'a, T>,
+    variables: &serde_json::Value,
+    variable_definitions: &Vec<VariableDefinition<'a, T>>,
+    table: &Arc<Table>,
+    schema: &Arc<__Schema>,
+) -> GraphQLResult<Option<OnConflictBuilder>>
+where
+    T: Text<'a> + Eq + AsRef<str>,
+{
+    let has_on_conflict = query_field
+        .arguments
+        .iter()
+        .any(|(name, _)| name.as_ref() == "onConflict");
+
+    if !has_on_conflict {
+        return Ok(None);
+    }
+
+    let validated: gson::Value = read_argument(
+        "onConflict",
+        field,
+        query_field,
+        variables,
+        variable_definitions,
+    )?;
+
+    match validated {
+        gson::Value::Absent | gson::Value::Null => Ok(None),
+        gson::Value::Object(obj) => {
+            let constraint_val = obj
+                .get("constraint")
+                .ok_or(GraphQLError::validation("constraint is required"))?;
+            let constraint_name = match constraint_val {
+                gson::Value::String(s) => s,
+                _ => return Err(GraphQLError::validation("constraint must be a string")),
+            };
+
+            let constraint = table
+                .on_conflict_indexes()
+                .iter()
+                .find(|idx| &idx.name == constraint_name)
+                .ok_or(GraphQLError::validation("Invalid constraint name"))?;
+
+            let update_columns_val = obj
+                .get("updateColumns")
+                .ok_or(GraphQLError::validation("updateColumns is required"))?;
+            let update_columns_arr = match update_columns_val {
+                gson::Value::Array(arr) => arr,
+                _ => return Err(GraphQLError::validation("updateColumns must be an array")),
+            };
+
+            let mut update_columns = HashSet::new();
+            for val in update_columns_arr {
+                match val {
+                    gson::Value::String(graphql_col_name) => {
+                        // Map GraphQL column name back to actual Column
+                        let column = table
+                            .columns
+                            .iter()
+                            .filter(|c| c.permissions.is_updatable && !c.is_generated && !c.is_serial)
+                            .find(|c| &schema.graphql_column_field_name(c) == graphql_col_name)
+                            .ok_or_else(|| {
+                                GraphQLError::validation(format!(
+                                    "Invalid column in updateColumns: {}",
+                                    graphql_col_name
+                                ))
+                            })?;
+                        update_columns.insert(Arc::clone(column));
+                    }
+                    _ => {
+                        return Err(GraphQLError::validation(
+                            "updateColumns elements must be strings",
+                        ))
+                    }
+                }
+            }
+
+            let filter = if let Some(filter_val) = obj.get(args::FILTER) {
+                let filter_type = __Type::FilterEntity(FilterEntityType {
+                    table: Arc::clone(table),
+                    schema: Arc::clone(schema),
+                });
+                let filter_field_map = input_field_map(&filter_type);
+                let filters = create_filters(filter_val, &filter_field_map)?;
+                Some(FilterBuilder { elems: filters })
+            } else {
+                None
+            };
+
+            Ok(Some(OnConflictBuilder {
+                constraint: (*constraint).clone(),
+                update_columns,
+                filter: filter.unwrap_or(FilterBuilder { elems: vec![] }),
+            }))
+        }
+        _ => Err(GraphQLError::validation("Invalid onConflict argument")),
+    }
+}
+
 pub fn to_insert_builder<'a, T>(
     field: &__Field,
     query_field: &graphql_parser::query::Field<'a, T>,
@@ -345,10 +454,19 @@ where
     match &type_ {
         __Type::InsertResponse(xtype) => {
             // Raise for disallowed arguments
-            restrict_allowed_arguments(&[args::OBJECTS], query_field)?;
+            restrict_allowed_arguments(&[args::OBJECTS, "onConflict"], query_field)?;
 
             let objects: Vec<InsertRowBuilder> =
                 read_argument_objects(field, query_field, variables, variable_definitions)?;
+
+            let on_conflict = read_argument_on_conflict(
+                field,
+                query_field,
+                variables,
+                variable_definitions,
+                &xtype.table,
+                &xtype.schema,
+            )?;
 
             let mut builder_fields: Vec<InsertSelection> = vec![];
 
@@ -394,6 +512,7 @@ where
             Ok(InsertBuilder {
                 table: Arc::clone(&xtype.table),
                 objects,
+                on_conflict,
                 selections: builder_fields,
             })
         }

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -71,7 +71,7 @@ impl __Schema {
         schema.map(|s| s.directives.inflect_names).unwrap_or(false)
     }
 
-    fn graphql_column_field_name(&self, column: &Column) -> String {
+    pub fn graphql_column_field_name(&self, column: &Column) -> String {
         if let Some(override_name) = &column.directives.name {
             return override_name.clone();
         }
@@ -614,6 +614,7 @@ impl ___Type for __Type {
             Self::NonNull(x) => x.kind(),
             Self::Aggregate(x) => x.kind(),
             Self::AggregateNumeric(x) => x.kind(),
+            Self::OnConflictInput(x) => x.kind(),
         }
     }
 
@@ -652,6 +653,7 @@ impl ___Type for __Type {
             Self::NonNull(x) => x.name(),
             Self::Aggregate(x) => x.name(),
             Self::AggregateNumeric(x) => x.name(),
+            Self::OnConflictInput(x) => x.name(),
         }
     }
 
@@ -690,6 +692,7 @@ impl ___Type for __Type {
             Self::NonNull(x) => x.description(),
             Self::Aggregate(x) => x.description(),
             Self::AggregateNumeric(x) => x.description(),
+            Self::OnConflictInput(x) => x.description(),
         }
     }
 
@@ -728,6 +731,7 @@ impl ___Type for __Type {
             Self::NonNull(x) => x.fields(_include_deprecated),
             Self::Aggregate(x) => x.fields(_include_deprecated),
             Self::AggregateNumeric(x) => x.fields(_include_deprecated),
+            Self::OnConflictInput(x) => x.fields(_include_deprecated),
         }
     }
 
@@ -767,6 +771,7 @@ impl ___Type for __Type {
             Self::NonNull(x) => x.interfaces(),
             Self::Aggregate(x) => x.interfaces(),
             Self::AggregateNumeric(x) => x.interfaces(),
+            Self::OnConflictInput(x) => x.interfaces(),
         }
     }
 
@@ -815,6 +820,7 @@ impl ___Type for __Type {
             Self::NonNull(x) => x.enum_values(_include_deprecated),
             Self::Aggregate(x) => x.enum_values(_include_deprecated),
             Self::AggregateNumeric(x) => x.enum_values(_include_deprecated),
+            Self::OnConflictInput(x) => x.enum_values(_include_deprecated),
         }
     }
 
@@ -854,6 +860,7 @@ impl ___Type for __Type {
             Self::NonNull(x) => x.input_fields(),
             Self::Aggregate(x) => x.input_fields(),
             Self::AggregateNumeric(x) => x.input_fields(),
+            Self::OnConflictInput(x) => x.input_fields(),
         }
     }
 

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -508,6 +508,7 @@ pub enum __Type {
     // Mutation
     Mutation(MutationType),
     InsertInput(InsertInputType),
+    OnConflictInput(OnConflictType),
     InsertResponse(InsertResponseType),
     UpdateInput(UpdateInputType),
     UpdateResponse(UpdateResponseType),
@@ -590,6 +591,7 @@ impl ___Type for __Type {
             Self::Node(x) => x.kind(),
             Self::NodeInterface(x) => x.kind(),
             Self::InsertInput(x) => x.kind(),
+            Self::OnConflictInput(x) => x.kind(),
             Self::InsertResponse(x) => x.kind(),
             Self::UpdateInput(x) => x.kind(),
             Self::UpdateResponse(x) => x.kind(),
@@ -627,6 +629,7 @@ impl ___Type for __Type {
             Self::Node(x) => x.name(),
             Self::NodeInterface(x) => x.name(),
             Self::InsertInput(x) => x.name(),
+            Self::OnConflictInput(x) => x.name(),
             Self::InsertResponse(x) => x.name(),
             Self::UpdateInput(x) => x.name(),
             Self::UpdateResponse(x) => x.name(),
@@ -664,6 +667,7 @@ impl ___Type for __Type {
             Self::Node(x) => x.description(),
             Self::NodeInterface(x) => x.description(),
             Self::InsertInput(x) => x.description(),
+            Self::OnConflictInput(x) => x.description(),
             Self::InsertResponse(x) => x.description(),
             Self::UpdateInput(x) => x.description(),
             Self::UpdateResponse(x) => x.description(),
@@ -740,6 +744,7 @@ impl ___Type for __Type {
             Self::Node(x) => x.interfaces(),
             Self::NodeInterface(x) => x.interfaces(),
             Self::InsertInput(x) => x.interfaces(),
+            Self::OnConflictInput(x) => x.interfaces(),
             Self::InsertResponse(x) => x.interfaces(),
             Self::UpdateInput(x) => x.interfaces(),
             Self::UpdateResponse(x) => x.interfaces(),
@@ -787,6 +792,7 @@ impl ___Type for __Type {
             Self::Node(x) => x.enum_values(_include_deprecated),
             Self::NodeInterface(x) => x.enum_values(_include_deprecated),
             Self::InsertInput(x) => x.enum_values(_include_deprecated),
+            Self::OnConflictInput(x) => x.enum_values(_include_deprecated),
             Self::InsertResponse(x) => x.enum_values(_include_deprecated),
             Self::UpdateInput(x) => x.enum_values(_include_deprecated),
             Self::UpdateResponse(x) => x.enum_values(_include_deprecated),
@@ -825,6 +831,7 @@ impl ___Type for __Type {
             Self::Node(x) => x.input_fields(),
             Self::NodeInterface(x) => x.input_fields(),
             Self::InsertInput(x) => x.input_fields(),
+            Self::OnConflictInput(x) => x.input_fields(),
             Self::InsertResponse(x) => x.input_fields(),
             Self::UpdateInput(x) => x.input_fields(),
             Self::UpdateResponse(x) => x.input_fields(),
@@ -958,6 +965,12 @@ pub struct InsertInputType {
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct UpdateInputType {
+    pub table: Arc<Table>,
+    pub schema: Arc<__Schema>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct OnConflictType {
     pub table: Arc<Table>,
     pub schema: Arc<__Schema>,
 }
@@ -1101,6 +1114,8 @@ impl ConnectionType {
 pub enum EnumSource {
     Enum(Arc<Enum>),
     FilterIs,
+    TableColumns(Arc<Table>),
+    OnConflictTarget(Arc<Table>),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -1428,28 +1443,43 @@ impl ___Type for MutationType {
             let table_base_type_name = self.schema.graphql_table_base_type_name(table);
 
             if self.schema.graphql_table_insert_types_are_valid(table) {
+                let mut args = vec![__InputValue {
+                    name_: args::OBJECTS.to_string(),
+                    type_: __Type::NonNull(NonNullType {
+                        type_: Box::new(__Type::List(ListType {
+                            type_: Box::new(__Type::NonNull(NonNullType {
+                                type_: Box::new(__Type::InsertInput(InsertInputType {
+                                    table: Arc::clone(table),
+                                    schema: Arc::clone(&self.schema),
+                                })),
+                            })),
+                        })),
+                    }),
+                    description: None,
+                    default_value: None,
+                    sql_type: None,
+                }];
+
+                if table.has_upsert_support() {
+                    args.push(__InputValue {
+                        name_: "onConflict".to_string(),
+                        type_: __Type::OnConflictInput(OnConflictType {
+                            table: Arc::clone(table),
+                            schema: Arc::clone(&self.schema),
+                        }),
+                        description: Some("Control upsert behavior".to_string()),
+                        default_value: None,
+                        sql_type: None,
+                    });
+                }
+
                 f.push(__Field {
                     name_: format!("insertInto{}Collection", table_base_type_name),
                     type_: __Type::InsertResponse(InsertResponseType {
                         table: Arc::clone(table),
                         schema: Arc::clone(&self.schema),
                     }),
-                    args: vec![__InputValue {
-                        name_: args::OBJECTS.to_string(),
-                        type_: __Type::NonNull(NonNullType {
-                            type_: Box::new(__Type::List(ListType {
-                                type_: Box::new(__Type::NonNull(NonNullType {
-                                    type_: Box::new(__Type::InsertInput(InsertInputType {
-                                        table: Arc::clone(table),
-                                        schema: Arc::clone(&self.schema),
-                                    })),
-                                })),
-                            })),
-                        }),
-                        description: None,
-                        default_value: None,
-                        sql_type: None,
-                    }],
+                    args,
                     description: Some(format!(
                         "Adds one or more `{}` records to the collection",
                         table_base_type_name
@@ -1637,6 +1667,14 @@ impl ___Type for EnumType {
                 )
             }
             EnumSource::FilterIs => Some("FilterIs".to_string()),
+            EnumSource::TableColumns(table) => Some(format!(
+                "{}UpdateColumn",
+                self.schema.graphql_table_base_type_name(table)
+            )),
+            EnumSource::OnConflictTarget(table) => Some(format!(
+                "{}Constraint",
+                self.schema.graphql_table_base_type_name(table)
+            )),
         }
     }
 
@@ -1675,6 +1713,27 @@ impl ___Type for EnumType {
                     },
                 ]
             }
+            EnumSource::TableColumns(table) => table
+                .columns
+                .iter()
+                .filter(|x| x.permissions.is_updatable)
+                .filter(|x| !x.is_generated)
+                .filter(|x| !x.is_serial)
+                .map(|col| __EnumValue {
+                    name: self.schema.graphql_column_field_name(col),
+                    description: None,
+                    deprecation_reason: None,
+                })
+                .collect(),
+            EnumSource::OnConflictTarget(table) => table
+                .on_conflict_indexes()
+                .iter()
+                .map(|idx| __EnumValue {
+                    name: idx.name.clone(),
+                    description: None,
+                    deprecation_reason: None,
+                })
+                .collect(),
         })
     }
 }
@@ -3230,6 +3289,74 @@ impl ___Type for UpdateInputType {
                 })
                 .collect(),
         )
+    }
+}
+
+impl ___Type for OnConflictType {
+    fn kind(&self) -> __TypeKind {
+        __TypeKind::INPUT_OBJECT
+    }
+
+    fn name(&self) -> Option<String> {
+        let table_name = self.schema.graphql_table_base_type_name(&self.table);
+        Some(format!("{}OnConflict", table_name))
+    }
+
+    fn description(&self) -> Option<String> {
+        Some("On Conflict Input".to_string())
+    }
+
+    fn fields(&self, _include_deprecated: bool) -> Option<Vec<__Field>> {
+        None
+    }
+
+    fn input_fields(&self) -> Option<Vec<__InputValue>> {
+        let mut fields = vec![];
+
+        fields.push(__InputValue {
+            name_: "constraint".to_string(),
+            type_: __Type::NonNull(NonNullType {
+                type_: Box::new(__Type::Enum(EnumType {
+                    enum_: EnumSource::OnConflictTarget(Arc::clone(&self.table)),
+                    schema: Arc::clone(&self.schema),
+                })),
+            }),
+            description: Some("The unique constraint to target".to_string()),
+            default_value: None,
+            sql_type: None,
+        });
+
+        fields.push(__InputValue {
+            name_: "updateColumns".to_string(),
+            type_: __Type::NonNull(NonNullType {
+                type_: Box::new(__Type::List(ListType {
+                    type_: Box::new(__Type::NonNull(NonNullType {
+                        type_: Box::new(__Type::Enum(EnumType {
+                            enum_: EnumSource::TableColumns(Arc::clone(&self.table)),
+                            schema: Arc::clone(&self.schema),
+                        })),
+                    })),
+                })),
+            }),
+            description: Some("The columns to update when a conflict occurs".to_string()),
+            default_value: None,
+            sql_type: None,
+        });
+
+        fields.push(__InputValue {
+            name_: args::FILTER.to_string(),
+            type_: __Type::FilterEntity(FilterEntityType {
+                table: Arc::clone(&self.table),
+                schema: Arc::clone(&self.schema),
+            }),
+            description: Some(
+                "Restricts the mutation's impact to records matching the criteria".to_string(),
+            ),
+            default_value: None,
+            sql_type: None,
+        });
+
+        Some(fields)
     }
 }
 

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1668,11 +1668,11 @@ impl ___Type for EnumType {
             }
             EnumSource::FilterIs => Some("FilterIs".to_string()),
             EnumSource::TableColumns(table) => Some(format!(
-                "{}UpdateColumn",
+                "{}Field",
                 self.schema.graphql_table_base_type_name(table)
             )),
             EnumSource::OnConflictTarget(table) => Some(format!(
-                "{}Constraint",
+                "{}OnConflictConstraint",
                 self.schema.graphql_table_base_type_name(table)
             )),
         }
@@ -3327,7 +3327,7 @@ impl ___Type for OnConflictType {
         });
 
         fields.push(__InputValue {
-            name_: "updateColumns".to_string(),
+            name_: "updateFields".to_string(),
             type_: __Type::NonNull(NonNullType {
                 type_: Box::new(__Type::List(ListType {
                     type_: Box::new(__Type::NonNull(NonNullType {
@@ -3338,7 +3338,7 @@ impl ___Type for OnConflictType {
                     })),
                 })),
             }),
-            description: Some("The columns to update when a conflict occurs".to_string()),
+            description: Some("Fields to be updated if conflict occurs".to_string()),
             default_value: None,
             sql_type: None,
         });

--- a/src/parser_util.rs
+++ b/src/parser_util.rs
@@ -493,6 +493,8 @@ pub fn validate_arg_from_type(type_: &__Type, value: &gson::Value) -> GraphQLRes
                                     .map(|val| GsonValue::String(val.clone()))
                                     .unwrap_or_else(|| value.clone()),
                                 EnumSource::FilterIs => value.clone(),
+                                EnumSource::TableColumns(_) => value.clone(),
+                                EnumSource::OnConflictTarget(_) => value.clone(),
                             }
                         }
                         None => {

--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -415,6 +415,7 @@ pub struct Composite {
 
 #[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Index {
+    pub name: String,
     pub table_oid: u32,
     pub column_names: Vec<String>,
     pub is_unique: bool,
@@ -553,6 +554,7 @@ impl Table {
                 None
             } else {
                 Some(Index {
+                    name: "primary_key_directive".to_string(),
                     table_oid: self.oid,
                     column_names: column_names.clone(),
                     is_unique: true,
@@ -562,6 +564,28 @@ impl Table {
         } else {
             None
         }
+    }
+
+    pub fn on_conflict_indexes(&self) -> Vec<&Index> {
+        // Only unique indexes with insertable, non-generated, non-serial columns
+        self.indexes
+            .iter()
+            .filter(|x| x.is_unique)
+            .filter(|uix| {
+                uix.column_names.iter().all(|col_name| {
+                    self.columns.iter().any(|c| {
+                        &c.name == col_name
+                            && c.permissions.is_insertable
+                            && !c.is_generated
+                            && !c.is_serial
+                    })
+                })
+            })
+            .collect()
+    }
+
+    pub fn has_upsert_support(&self) -> bool {
+        !self.on_conflict_indexes().is_empty()
     }
 
     pub fn primary_key_columns(&self) -> Vec<&Arc<Column>> {

--- a/src/transpile.rs
+++ b/src/transpile.rs
@@ -324,10 +324,10 @@ impl MutationEntrypoint<'_> for InsertBuilder {
             Some(on_conflict) => {
                 let constraint_name = quote_ident(&on_conflict.constraint.name);
 
-                let mut update_cols_vec: Vec<&Arc<Column>> =
-                    on_conflict.update_columns.iter().collect();
-                update_cols_vec.sort_by_key(|c| &c.name);
-                let update_columns_clause = update_cols_vec
+                let mut update_fields_vec: Vec<&Arc<Column>> =
+                    on_conflict.update_fields.iter().collect();
+                update_fields_vec.sort_by_key(|c| &c.name);
+                let update_fields_clause = update_fields_vec
                     .iter()
                     .map(|col| {
                         let quoted_col = quote_ident(&col.name);
@@ -342,12 +342,12 @@ impl MutationEntrypoint<'_> for InsertBuilder {
                     param_context,
                 )?;
 
-                if update_columns_clause.is_empty() {
+                if update_fields_clause.is_empty() {
                     format!("on conflict on constraint {} do nothing", constraint_name)
                 } else {
                     format!(
                         "on conflict on constraint {} do update set {} where {}",
-                        constraint_name, update_columns_clause, where_clause
+                        constraint_name, update_fields_clause, where_clause
                     )
                 }
             }

--- a/src/transpile.rs
+++ b/src/transpile.rs
@@ -267,6 +267,7 @@ impl MutationEntrypoint<'_> for InsertBuilder {
         let quoted_block_name = rand_block_name();
         let quoted_schema = quote_ident(&self.table.schema);
         let quoted_table = quote_ident(&self.table.name);
+        let table_alias = rand_block_name();
 
         let frags: Vec<String> = self
             .selections
@@ -319,11 +320,46 @@ impl MutationEntrypoint<'_> for InsertBuilder {
 
         let values_clause = values_rows_clause.join(", ");
 
+        let on_conflict_clause = match &self.on_conflict {
+            Some(on_conflict) => {
+                let constraint_name = quote_ident(&on_conflict.constraint.name);
+
+                let mut update_cols_vec: Vec<&Arc<Column>> =
+                    on_conflict.update_columns.iter().collect();
+                update_cols_vec.sort_by_key(|c| &c.name);
+                let update_columns_clause = update_cols_vec
+                    .iter()
+                    .map(|col| {
+                        let quoted_col = quote_ident(&col.name);
+                        format!("{} = excluded.{}", quoted_col, quoted_col)
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+
+                let where_clause = on_conflict.filter.to_where_clause(
+                    &table_alias,
+                    &self.table,
+                    param_context,
+                )?;
+
+                if update_columns_clause.is_empty() {
+                    format!("on conflict on constraint {} do nothing", constraint_name)
+                } else {
+                    format!(
+                        "on conflict on constraint {} do update set {} where {}",
+                        constraint_name, update_columns_clause, where_clause
+                    )
+                }
+            }
+            None => "".to_string(),
+        };
+
         Ok(format!(
             "
         with affected as (
-            insert into {quoted_schema}.{quoted_table}({referenced_columns_clause})
+            insert into {quoted_schema}.{quoted_table} as {table_alias}({referenced_columns_clause})
             values {values_clause}
+            {on_conflict_clause}
             returning {selectable_columns_clause}
         )
         select

--- a/test/sql/mutation_insert_on_conflict.sql
+++ b/test/sql/mutation_insert_on_conflict.sql
@@ -1,0 +1,357 @@
+begin;
+
+    -- Table with non-serial primary key (supports upsert)
+    create table account(
+        id int primary key,
+        email varchar(255) not null,
+        name text,
+        status text default 'active'
+    );
+
+    -- Table with serial primary key (should NOT support upsert on pkey)
+    create table blog(
+        id serial primary key,
+        owner_id integer not null references account(id),
+        title text not null
+    );
+
+    -- Table with composite unique constraint
+    create table account_setting(
+        account_id int references account(id),
+        setting_key text not null,
+        setting_value text,
+        primary key (account_id, setting_key)
+    );
+
+    -- Table with additional unique index
+    create table product(
+        id int primary key,
+        sku text not null unique,
+        name text,
+        price numeric
+    );
+
+    -- Insert initial data
+    insert into account(id, email, name, status) values
+        (1, 'alice@example.com', 'Alice', 'active'),
+        (2, 'bob@example.com', 'Bob', 'active');
+
+    insert into account_setting(account_id, setting_key, setting_value) values
+        (1, 'theme', 'dark'),
+        (1, 'notifications', 'enabled');
+
+    insert into product(id, sku, name, price) values
+        (1, 'SKU001', 'Widget', 9.99),
+        (2, 'SKU002', 'Gadget', 19.99);
+
+    /*
+        Check that onConflict argument is available for tables with non-serial unique constraints
+    */
+
+    -- Account table should have onConflict (non-serial primary key)
+    select jsonb_pretty(graphql.resolve($$
+    {
+      __type(name: "Mutation") {
+        fields {
+          name
+          args {
+            name
+            type {
+              name
+              kind
+            }
+          }
+        }
+      }
+    }
+    $$) -> 'data' -> '__type' -> 'fields') @> '[{"name": "insertIntoAccountCollection", "args": [{"name": "onConflict"}]}]'::jsonb;
+
+    -- Blog table should NOT have onConflict (serial primary key)
+    select not (jsonb_pretty(graphql.resolve($$
+    {
+      __type(name: "Mutation") {
+        fields {
+          name
+          args {
+            name
+          }
+        }
+      }
+    }
+    $$) -> 'data' -> '__type' -> 'fields') @> '[{"name": "insertIntoBlogCollection", "args": [{"name": "onConflict"}]}]'::jsonb);
+
+    /*
+        Basic upsert - insert new record
+    */
+
+    select graphql.resolve($$
+    mutation {
+      insertIntoAccountCollection(
+        objects: [{ id: 3, email: "charlie@example.com", name: "Charlie" }]
+        onConflict: {
+          constraint: account_pkey
+          updateColumns: [email, name]
+        }
+      ) {
+        affectedCount
+        records {
+          id
+          email
+          name
+          status
+        }
+      }
+    }
+    $$);
+
+    /*
+        Basic upsert - update existing record
+    */
+
+    select graphql.resolve($$
+    mutation {
+      insertIntoAccountCollection(
+        objects: [{ id: 1, email: "alice_updated@example.com", name: "Alice Updated" }]
+        onConflict: {
+          constraint: account_pkey
+          updateColumns: [email, name]
+        }
+      ) {
+        affectedCount
+        records {
+          id
+          email
+          name
+          status
+        }
+      }
+    }
+    $$);
+
+    -- Verify the update happened
+    select id, email, name from account where id = 1;
+
+    /*
+        Upsert with partial update columns - only update specific fields
+    */
+
+    select graphql.resolve($$
+    mutation {
+      insertIntoAccountCollection(
+        objects: [{ id: 2, email: "bob_new@example.com", name: "Bob New Name", status: "inactive" }]
+        onConflict: {
+          constraint: account_pkey
+          updateColumns: [name]
+        }
+      ) {
+        affectedCount
+        records {
+          id
+          email
+          name
+          status
+        }
+      }
+    }
+    $$);
+
+    -- Verify only name was updated, email and status unchanged
+    select id, email, name, status from account where id = 2;
+
+    /*
+        Upsert with filter clause - conditional update
+    */
+
+    -- Reset Bob's data first
+    update account set email = 'bob@example.com', name = 'Bob', status = 'active' where id = 2;
+
+    -- This should NOT update because filter doesn't match (status is 'active', not 'pending')
+    select graphql.resolve($$
+    mutation {
+      insertIntoAccountCollection(
+        objects: [{ id: 2, email: "should_not_update@example.com", name: "Should Not Update" }]
+        onConflict: {
+          constraint: account_pkey
+          updateColumns: [email, name]
+          filter: { status: { eq: "pending" } }
+        }
+      ) {
+        affectedCount
+        records {
+          id
+          email
+          name
+        }
+      }
+    }
+    $$);
+
+    -- Verify Bob's data is unchanged
+    select id, email, name from account where id = 2;
+
+    -- This SHOULD update because filter matches (status is 'active')
+    select graphql.resolve($$
+    mutation {
+      insertIntoAccountCollection(
+        objects: [{ id: 2, email: "bob_filtered@example.com", name: "Bob Filtered" }]
+        onConflict: {
+          constraint: account_pkey
+          updateColumns: [email, name]
+          filter: { status: { eq: "active" } }
+        }
+      ) {
+        affectedCount
+        records {
+          id
+          email
+          name
+        }
+      }
+    }
+    $$);
+
+    -- Verify Bob's data was updated
+    select id, email, name from account where id = 2;
+
+    /*
+        Upsert with composite primary key
+    */
+
+    select graphql.resolve($$
+    mutation {
+      insertIntoAccountSettingCollection(
+        objects: [{ accountId: 1, settingKey: "theme", settingValue: "light" }]
+        onConflict: {
+          constraint: account_setting_pkey
+          updateColumns: [settingValue]
+        }
+      ) {
+        affectedCount
+        records {
+          accountId
+          settingKey
+          settingValue
+        }
+      }
+    }
+    $$);
+
+    -- Verify the setting was updated
+    select account_id, setting_key, setting_value from account_setting where account_id = 1 and setting_key = 'theme';
+
+    /*
+        Upsert using unique constraint (not primary key)
+    */
+
+    select graphql.resolve($$
+    mutation {
+      insertIntoProductCollection(
+        objects: [{ id: 10, sku: "SKU001", name: "Widget Pro", price: 14.99 }]
+        onConflict: {
+          constraint: product_sku_key
+          updateColumns: [name, price]
+        }
+      ) {
+        affectedCount
+        records {
+          id
+          sku
+          name
+          price
+        }
+      }
+    }
+    $$);
+
+    -- Verify the product was updated (not inserted with id 10)
+    select id, sku, name, price from product where sku = 'SKU001';
+
+    /*
+        Upsert with variables
+    */
+
+    select graphql.resolve($$
+    mutation UpsertAccount($id: Int!, $email: String!, $name: String, $constraint: AccountConstraint!, $cols: [AccountUpdateColumn!]!) {
+      insertIntoAccountCollection(
+        objects: [{ id: $id, email: $email, name: $name }]
+        onConflict: {
+          constraint: $constraint
+          updateColumns: $cols
+        }
+      ) {
+        affectedCount
+        records {
+          id
+          email
+          name
+        }
+      }
+    }
+    $$,
+    variables := '{"id": 1, "email": "alice_var@example.com", "name": "Alice Variable", "constraint": "account_pkey", "cols": ["email", "name"]}'::jsonb
+    );
+
+    -- Verify
+    select id, email, name from account where id = 1;
+
+    /*
+        Multiple records upsert
+    */
+
+    select graphql.resolve($$
+    mutation {
+      insertIntoAccountCollection(
+        objects: [
+          { id: 1, email: "alice_multi@example.com", name: "Alice Multi" },
+          { id: 5, email: "eve@example.com", name: "Eve" }
+        ]
+        onConflict: {
+          constraint: account_pkey
+          updateColumns: [email, name]
+        }
+      ) {
+        affectedCount
+        records {
+          id
+          email
+          name
+        }
+      }
+    }
+    $$);
+
+    /*
+        Error cases
+    */
+
+    -- Invalid constraint name
+    select graphql.resolve($$
+    mutation {
+      insertIntoAccountCollection(
+        objects: [{ id: 1, email: "test@test.com" }]
+        onConflict: {
+          constraint: invalid_constraint_name
+          updateColumns: [email]
+        }
+      ) {
+        affectedCount
+      }
+    }
+    $$);
+
+    -- Empty updateColumns (should still work - do nothing on conflict effectively)
+    select graphql.resolve($$
+    mutation {
+      insertIntoAccountCollection(
+        objects: [{ id: 1, email: "test@test.com" }]
+        onConflict: {
+          constraint: account_pkey
+          updateColumns: []
+        }
+      ) {
+        affectedCount
+      }
+    }
+    $$);
+
+rollback;

--- a/test/sql/mutation_insert_on_conflict.sql
+++ b/test/sql/mutation_insert_on_conflict.sql
@@ -90,7 +90,7 @@ begin;
         objects: [{ id: 3, email: "charlie@example.com", name: "Charlie" }]
         onConflict: {
           constraint: account_pkey
-          updateColumns: [email, name]
+          updateFields: [email, name]
         }
       ) {
         affectedCount
@@ -114,7 +114,7 @@ begin;
         objects: [{ id: 1, email: "alice_updated@example.com", name: "Alice Updated" }]
         onConflict: {
           constraint: account_pkey
-          updateColumns: [email, name]
+          updateFields: [email, name]
         }
       ) {
         affectedCount
@@ -141,7 +141,7 @@ begin;
         objects: [{ id: 2, email: "bob_new@example.com", name: "Bob New Name", status: "inactive" }]
         onConflict: {
           constraint: account_pkey
-          updateColumns: [name]
+          updateFields: [name]
         }
       ) {
         affectedCount
@@ -172,7 +172,7 @@ begin;
         objects: [{ id: 2, email: "should_not_update@example.com", name: "Should Not Update" }]
         onConflict: {
           constraint: account_pkey
-          updateColumns: [email, name]
+          updateFields: [email, name]
           filter: { status: { eq: "pending" } }
         }
       ) {
@@ -196,7 +196,7 @@ begin;
         objects: [{ id: 2, email: "bob_filtered@example.com", name: "Bob Filtered" }]
         onConflict: {
           constraint: account_pkey
-          updateColumns: [email, name]
+          updateFields: [email, name]
           filter: { status: { eq: "active" } }
         }
       ) {
@@ -223,7 +223,7 @@ begin;
         objects: [{ accountId: 1, settingKey: "theme", settingValue: "light" }]
         onConflict: {
           constraint: account_setting_pkey
-          updateColumns: [settingValue]
+          updateFields: [settingValue]
         }
       ) {
         affectedCount
@@ -249,7 +249,7 @@ begin;
         objects: [{ id: 10, sku: "SKU001", name: "Widget Pro", price: 14.99 }]
         onConflict: {
           constraint: product_sku_key
-          updateColumns: [name, price]
+          updateFields: [name, price]
         }
       ) {
         affectedCount
@@ -271,12 +271,12 @@ begin;
     */
 
     select graphql.resolve($$
-    mutation UpsertAccount($id: Int!, $email: String!, $name: String, $constraint: AccountConstraint!, $cols: [AccountUpdateColumn!]!) {
+    mutation UpsertAccount($id: Int!, $email: String!, $name: String, $constraint: AccountOnConflictConstraint!, $cols: [AccountField!]!) {
       insertIntoAccountCollection(
         objects: [{ id: $id, email: $email, name: $name }]
         onConflict: {
           constraint: $constraint
-          updateColumns: $cols
+          updateFields: $cols
         }
       ) {
         affectedCount
@@ -307,7 +307,7 @@ begin;
         ]
         onConflict: {
           constraint: account_pkey
-          updateColumns: [email, name]
+          updateFields: [email, name]
         }
       ) {
         affectedCount
@@ -331,7 +331,7 @@ begin;
         objects: [{ id: 1, email: "test@test.com" }]
         onConflict: {
           constraint: invalid_constraint_name
-          updateColumns: [email]
+          updateFields: [email]
         }
       ) {
         affectedCount
@@ -339,14 +339,14 @@ begin;
     }
     $$);
 
-    -- Empty updateColumns (should still work - do nothing on conflict effectively)
+    -- Empty updateFields (should still work - do nothing on conflict effectively)
     select graphql.resolve($$
     mutation {
       insertIntoAccountCollection(
         objects: [{ id: 1, email: "test@test.com" }]
         onConflict: {
           constraint: account_pkey
-          updateColumns: []
+          updateFields: []
         }
       ) {
         affectedCount


### PR DESCRIPTION
## What

Implements upsert support via `onConflict` argument on insert mutations.
Closes #190 
## Why

This enables upsert operations (INSERT ... ON CONFLICT DO UPDATE) through the GraphQL API, which is a common requirement for applications that need idempotent writes.

## Changes

- **SQL Context**: Load index names from `pg_class` to identify constraints
- **SQL Types**: Add `on_conflict_indexes()` and `has_upsert_support()` methods to Table
- **GraphQL Types**: 
  - New `{Table}OnConflict` input type with `constraint`, `updateColumns`, and `filter` fields
  - New `{Table}Constraint` enum (unique index names)
  - New `{Table}UpdateColumn` enum (updatable column names)
  - Conditionally expose `onConflict` arg only on tables with valid constraints
- **Builder**: Parse `onConflict` argument and map GraphQL column names back to Column objects
- **Transpile**: Generate `ON CONFLICT ON CONSTRAINT ... DO UPDATE SET ... WHERE ...`

## Example

```graphql
mutation {
  insertIntoAccountCollection(
    objects: [{ id: 1, email: "new@example.com", name: "Updated" }]
    onConflict: {
      constraint: account_pkey
      updateColumns: [email, name]
      filter: { status: { eq: "active" } }
    }
  ) {
    affectedCount
    records { id email name }
  }
}
```

## Notes

- Tables with serial/generated primary keys will not expose `onConflict` (constraint columns must be insertable)
- Empty `updateColumns` results in `DO NOTHING`
- Based on #503 but reimplemented on current master without unrelated changes

## Tests

Added tests in `test/sql/mutation_insert_on_conflict.sql`