### PR TITLE
docs: fix typo instrospection -> introspection in configuration.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -317,7 +317,7 @@ field, and introspection is disabled, only the introspection fields return an er
     }
     ```
 
-If there are two schemas with introspection enabled only on one schema, there is no error on the instrospection fields but entities from the introspection disabled schema are filtered out:
+If there are two schemas with introspection enabled only on one schema, there is no error on the introspection fields but entities from the introspection disabled schema are filtered out:
 
 === "Query"
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes typo: `instrospection` → `introspection` in the Mixed Field Queries section of `docs/configuration.md`

## Additional context

Follow-up to #631