### PR TITLE
chore: bump version to 1.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "pg_graphql"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "base64 0.13.1",
  "bimap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_graphql"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2024"
 
 [lib]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -131,4 +131,8 @@
 - feature: Add support for single record queries by primary key
 - **breaking**: GraphQL introspection is now disabled by default. Opt in per schema with `comment on schema <name> is e'@graphql({"introspection": true})'`. After upgrading to this version, tools that rely on introspection (GraphiQL, codegen, Apollo DevTools, Relay compiler) will see either `Unknown field "__schema" on type Query` errors or types will be filtered out on disabled schemas. Non-introspection queries and mutations are unaffected. See [Introspection](configuration.md#introspection) for details.
 
+## 1.6.1
+
+- bugfix: Remove double NON_NULL wrapping on byPk argument types
+
 ## master


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bumping up the version to 1.6.1 to include the bug fix and minor doc fixes
