### PR TITLE
fix: expose function return tables outside search path

### DIFF
--- a/sql/load_sql_context.sql
+++ b/sql/load_sql_context.sql
@@ -29,6 +29,37 @@ schemas_(oid, name) as (
         -- filter to current schemas only
         join search_path_oids cur_schemas(oid)
             on pn.oid = cur_schemas.oid
+),
+
+function_referenced_type_oids(type_oid) as (
+    select distinct
+        unnest(array_append(pp.proargtypes::oid[], pp.prorettype))::oid
+    from
+        pg_catalog.pg_proc pp
+        join search_path_oids spo
+            on pp.pronamespace = spo.schema_oid
+),
+
+function_referenced_tables(oid) as (
+    select distinct
+        pc.oid
+    from
+        function_referenced_type_oids fto
+        join pg_type pt
+            on pt.oid = fto.type_oid
+        join pg_type base_pt
+            on base_pt.oid = coalesce(nullif(pt.typelem, 0::oid), pt.oid)
+        join pg_class pc
+            on base_pt.typrelid = pc.oid
+        join schemas_with_privilege swp
+            on pc.relnamespace = swp.oid
+    where
+        pc.relkind in (
+            'r', -- table
+            'v', -- view
+            'm', -- mat view
+            'f'  -- foreign table
+        )
 )
 
 select
@@ -241,7 +272,7 @@ select
                             'relkind', pc.relkind::text,
                             'reltype', pc.reltype::bigint,
                             'is_rls_enabled', pc.relrowsecurity,
-                            'schema', schemas_.name,
+                            'schema', table_schema.name,
                             'schema_oid', pc.relnamespace::bigint,
                             'comment', pg_catalog.obj_description(pc.oid, 'pg_class'),
                             'directives', (
@@ -315,7 +346,7 @@ select
                                             -- char, bpchar, varchar, char[], bpchar[], carchar[]
                                             -- the -4 removes the byte for the null terminated str
                                             'max_characters', nullif(pa.atttypmod, -1) - 4,
-                                            'schema_oid', schemas_.oid::bigint,
+                                            'schema_oid', table_schema.oid::bigint,
                                             'is_not_null', pa.attnotnull,
                                             'attribute_num', pa.attnum,
                                             'has_default', pd.adbin is not null, -- pg_get_expr(pd.adbin, pd.adrelid) shows expression
@@ -393,14 +424,18 @@ select
                     )
             from
                 pg_class pc
-                join schemas_
-                    on pc.relnamespace = schemas_.oid
+                join schemas_with_privilege table_schema
+                    on pc.relnamespace = table_schema.oid
             where
                 pc.relkind in (
                     'r', -- table
                     'v', -- view
                     'm', -- mat view
                     'f'  -- foreign table
+                )
+                and (
+                    pc.relnamespace in (select oid from schemas_)
+                    or pc.oid in (select oid from function_referenced_tables)
                 )
             ),
             jsonb_build_object()

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -86,6 +86,10 @@ impl __Schema {
             .unwrap_or(false)
     }
 
+    fn table_is_on_search_path(&self, table: &Table) -> bool {
+        self.context.schemas.contains_key(&table.schema_oid)
+    }
+
     fn graphql_column_field_name(&self, column: &Column) -> String {
         if let Some(override_name) = &column.directives.name {
             return override_name.clone();
@@ -1257,6 +1261,7 @@ impl ___Type for QueryType {
             .context
             .tables
             .values()
+            .filter(|table| self.schema.table_is_on_search_path(table))
             .filter(|table| self.schema.graphql_table_select_types_are_valid(table))
         {
             {
@@ -1524,7 +1529,13 @@ impl ___Type for MutationType {
         let mut f = Vec::new();
 
         // TODO, filter to types in type map in case any were filtered out
-        for table in self.schema.context.tables.values() {
+        for table in self
+            .schema
+            .context
+            .tables
+            .values()
+            .filter(|table| self.schema.table_is_on_search_path(table))
+        {
             let table_base_type_name = self.schema.graphql_table_base_type_name(table);
 
             if self.schema.graphql_table_insert_types_are_valid(table) {
@@ -4296,7 +4307,9 @@ impl __Schema {
                 schema: Arc::clone(&schema_rc),
             }));
 
-            if self.graphql_table_insert_types_are_valid(table) {
+            let table_is_on_search_path = self.table_is_on_search_path(table);
+
+            if table_is_on_search_path && self.graphql_table_insert_types_are_valid(table) {
                 types_.push(__Type::InsertInput(InsertInputType {
                     table: Arc::clone(table),
                     schema: Arc::clone(&schema_rc),
@@ -4307,7 +4320,7 @@ impl __Schema {
                 }));
             }
 
-            if self.graphql_table_update_types_are_valid(table) {
+            if table_is_on_search_path && self.graphql_table_update_types_are_valid(table) {
                 types_.push(__Type::UpdateInput(UpdateInputType {
                     table: Arc::clone(table),
                     schema: Arc::clone(&schema_rc),
@@ -4318,7 +4331,7 @@ impl __Schema {
                 }));
             }
 
-            if self.graphql_table_delete_types_are_valid(table) {
+            if table_is_on_search_path && self.graphql_table_delete_types_are_valid(table) {
                 types_.push(__Type::DeleteResponse(DeleteResponseType {
                     table: Arc::clone(table),
                     schema: Arc::clone(&schema_rc),
@@ -4326,7 +4339,7 @@ impl __Schema {
             }
 
             // Add Aggregate types if the table is selectable
-            if self.graphql_table_select_types_are_valid(table) {
+            if table_is_on_search_path && self.graphql_table_select_types_are_valid(table) {
                 // Only add aggregate types if the directive is enabled
                 if let Some(aggregate_directive) = table.directives.aggregate.as_ref()
                     && aggregate_directive.enabled

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -362,10 +362,7 @@ where
                     },
                 }
             }
-            let any_field_succeeded = res_data
-                .as_object()
-                .map(|o| !o.is_empty())
-                .unwrap_or(false);
+            let any_field_succeeded = res_data.as_object().map(|o| !o.is_empty()).unwrap_or(false);
             GraphQLResponse {
                 data: if res_errors.is_empty() || any_field_succeeded {
                     Omit::Present(res_data)

--- a/test/expected/function_calls_unsupported.out
+++ b/test/expected/function_calls_unsupported.out
@@ -185,37 +185,8 @@ begin;
  }
 (1 row)
 
-    -- function returning type not on search path
-    create schema dev;
-    create table dev.book(
-        id int primary key
-    );
-    insert into dev.book values (1);
-    create function "returnsBook"()
-        returns dev.book
-        stable
-        language sql
-    as $$
-        select db from dev.book db limit 1;
-    $$;
-    select jsonb_pretty(graphql.resolve($$
-        query {
-            returnsBook
-        }
-    $$));
-                             jsonb_pretty                             
-----------------------------------------------------------------------
- {                                                                   +
-     "data": null,                                                   +
-     "errors": [                                                     +
-         {                                                           +
-             "message": "Unknown field \"returnsBook\" on type Query"+
-         }                                                           +
-     ]                                                               +
- }
-(1 row)
-
     -- function accepting type not on search path
+    create schema dev;
     create type dev.invisible as enum ('ONLY');
     create function "badInputArg"(val dev.invisible)
         returns int

--- a/test/expected/issue_455.out
+++ b/test/expected/issue_455.out
@@ -1,0 +1,56 @@
+begin;
+    create schema a1;
+    grant usage on schema a1 to public;
+    create table a1.foo(
+        id int primary key
+    );
+    grant select on table a1.foo to public;
+    insert into a1.foo values (1);
+    create function a1.the_foo()
+        returns a1.foo
+        stable
+        language sql
+    as $$
+        select f from a1.foo f where f.id = 1;
+    $$;
+    grant execute on function a1.the_foo() to public;
+    create schema a2;
+    grant usage on schema a2 to public;
+    create function a2.get_the_foo()
+        returns a1.foo
+        stable
+        language sql
+    as $$
+        select * from a1.the_foo();
+    $$;
+    grant execute on function a2.get_the_foo() to public;
+    set local search_path to a2;
+    select graphql.resolve($$
+        query {
+            get_the_foo {
+                id
+            }
+        }
+    $$) = '{"data": {"get_the_foo": {"id": 1}}}'::jsonb as function_returned_table;
+ function_returned_table
+-------------------------
+ t
+(1 row)
+
+    select graphql.resolve($$
+        query {
+            fooCollection {
+                edges {
+                    node {
+                        id
+                    }
+                }
+            }
+        }
+    $$) -> 'errors' -> 0 ->> 'message' = 'Unknown field "fooCollection" on type Query' as collection_not_exposed;
+ collection_not_exposed
+------------------------
+ t
+(1 row)
+
+rollback;

--- a/test/sql/function_calls_unsupported.sql
+++ b/test/sql/function_calls_unsupported.sql
@@ -108,28 +108,8 @@ begin;
         }
     $$));
 
-    -- function returning type not on search path
-    create schema dev;
-    create table dev.book(
-        id int primary key
-    );
-    insert into dev.book values (1);
-
-    create function "returnsBook"()
-        returns dev.book
-        stable
-        language sql
-    as $$
-        select db from dev.book db limit 1;
-    $$;
-
-    select jsonb_pretty(graphql.resolve($$
-        query {
-            returnsBook
-        }
-    $$));
-
     -- function accepting type not on search path
+    create schema dev;
     create type dev.invisible as enum ('ONLY');
 
     create function "badInputArg"(val dev.invisible)

--- a/test/sql/issue_455.sql
+++ b/test/sql/issue_455.sql
@@ -1,0 +1,54 @@
+begin;
+
+    create schema a1;
+    grant usage on schema a1 to public;
+    create table a1.foo(
+        id int primary key
+    );
+    grant select on table a1.foo to public;
+    insert into a1.foo values (1);
+
+    create function a1.the_foo()
+        returns a1.foo
+        stable
+        language sql
+    as $$
+        select f from a1.foo f where f.id = 1;
+    $$;
+    grant execute on function a1.the_foo() to public;
+
+    create schema a2;
+    grant usage on schema a2 to public;
+
+    create function a2.get_the_foo()
+        returns a1.foo
+        stable
+        language sql
+    as $$
+        select * from a1.the_foo();
+    $$;
+    grant execute on function a2.get_the_foo() to public;
+
+    set local search_path to a2;
+
+    select graphql.resolve($$
+        query {
+            get_the_foo {
+                id
+            }
+        }
+    $$) = '{"data": {"get_the_foo": {"id": 1}}}'::jsonb as function_returned_table;
+
+    select graphql.resolve($$
+        query {
+            fooCollection {
+                edges {
+                    node {
+                        id
+                    }
+                }
+            }
+        }
+    $$) -> 'errors' -> 0 ->> 'message' = 'Unknown field "fooCollection" on type Query' as collection_not_exposed;
+
+rollback;


### PR DESCRIPTION
## What changed

- Includes tables/views referenced by functions on the active `search_path` in the loaded SQL context, even when the referenced table lives in another schema with USAGE privilege.
- Keeps non-search-path referenced tables out of root collection and mutation fields while still allowing typed function return values.
- Adds regression coverage for a function in `a2` returning a table row type from `a1`.

Fixes #455

## Verification

- `cargo fmt --check`
- `git diff --cached --check`

`cargo check` could not complete in this local environment because pgrx requires `$PGRX_HOME` and it is not initialized here.