### PR TITLE
chore: use pgrx version 0.19.2 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         package_name:
           - pg-graphql
         pgrx_version:
-          - 0.16.1
+          - 0.19.2
         postgres: [14, 15, 16, 17, 18]
         box:
           - { runner: ubuntu-latest, arch: amd64 }


### PR DESCRIPTION
In a [previous commit](https://github.com/supabase/pg_graphql/commit/f88274c17dc4562dcf0ea033f5d9e5670bf79d97) updating the pgrx version in the release workflow was missed, this PR updates that.